### PR TITLE
Make the required changes for relay support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Example:
   * *6.31* (default) => add 'spam detected' headers at that level
 * SA_KILL
   * *6.31* (default) => triggers spam evasive actions)
+* SASL_PASSWORD
+  * *empty* (default) => No sasl_passwd will be created
+  * *string* => A /etc/postfix/sasl_passwd will be created with that content and postmap will be run on it
 
 Please read [how the container starts](https://github.com/tomav/docker-mailserver/blob/master/start-mailserver.sh) to understand what's expected.  
 

--- a/postfix/master.cf
+++ b/postfix/master.cf
@@ -72,6 +72,7 @@ smtp-amavis     unix    -       -       -       -       2       smtp
   -o smtp_send_xforward_command=yes
   -o disable_dns_lookups=yes
   -o max_use=20
+  -o smtp_tls_security_level=none
 
 127.0.0.1:10025 inet    n       -       n       -       -       smtpd
   -o content_filter=
@@ -92,3 +93,4 @@ smtp-amavis     unix    -       -       -       -       2       smtp
   -o smtpd_client_connection_count_limit=0
   -o smtpd_client_connection_rate_limit=0
   -o receive_override_options=no_header_body_checks,no_unknown_recipient_checks
+  -o smtp_tls_security_level=none

--- a/postfix/opendkim.conf
+++ b/postfix/opendkim.conf
@@ -4,6 +4,7 @@ UMask                   002
 Syslog                  yes
 SyslogSuccess           Yes
 LogWhy                  Yes
+RemoveOldSignatures	Yes
 
 Canonicalization        relaxed/simple
 

--- a/start-mailserver.sh
+++ b/start-mailserver.sh
@@ -182,6 +182,17 @@ else
   echo "==> Warning: '/tmp/postfix/main.cf' is not provided. No extra postfix settings loaded."
 fi
 
+if [ ! -z "$SASL_PASSWD" ]; then
+  echo "$SASL_PASSWD" > /etc/postfix/sasl_passwd
+  postmap hash:/etc/postfix/sasl_passwd
+  rm /etc/postfix/sasl_passwd
+  chown root:root /etc/postfix/sasl_passwd.db
+  chmod 0600 /etc/postfix/sasl_passwd.db
+  echo "Loaded SASL_PASSWORD"
+else
+  echo "==> Warning: 'SASL_PASSWORD' is not provided. /etc/postfix/sasl_passwd not created."
+fi
+
 echo "Fixing permissions"
 chown -R 5000:5000 /var/mail
 mkdir -p /var/log/clamav && chown -R clamav:root /var/log/clamav

--- a/start-mailserver.sh
+++ b/start-mailserver.sh
@@ -173,6 +173,15 @@ case $DMS_SSL in
 
 esac
 
+if [ -f /tmp/postfix/main.cf ]; then
+  while read line; do
+    postconf -e "$line"
+  done < /tmp/postfix/main.cf
+  echo "Loaded '/tmp/postfix/main.cf'"
+else
+  echo "==> Warning: '/tmp/postfix/main.cf' is not provided. No extra postfix settings loaded."
+fi
+
 echo "Fixing permissions"
 chown -R 5000:5000 /var/mail
 mkdir -p /var/log/clamav && chown -R clamav:root /var/log/clamav


### PR DESCRIPTION
Now you can configure AWS SES as relay for postfix.