### PR TITLE
New SMTP_ONLY environment variable to disable all courier daemons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ run:
 		-v "`pwd`/test":/tmp/test \
 		-e ENABLE_POP3=1 \
 		-h mail.my-domain.com -t $(NAME)
+	docker run -d --name mail_smtponly \
+		-v "`pwd`/postfix":/tmp/postfix \
+		-v "`pwd`/spamassassin":/tmp/spamassassin \
+		-v "`pwd`/test":/tmp/test \
+		-e SMTP_ONLY=1 \
+		-h mail.my-domain.com -t $(NAME)
 	# Wait for containers to fully start
 	sleep 60
 
@@ -47,4 +53,4 @@ clean:
 	# Get default files back
 	git checkout postfix/accounts.cf postfix/virtual
 	# Remove running test containers
-	docker rm -f mail mail_pop3
+	docker rm -f mail mail_pop3 mail_smtponly

--- a/README.md
+++ b/README.md
@@ -88,14 +88,15 @@ Example:
 * ENABLE_POP3
   * *empty* (default) => POP3 service disabled
   * 1 => Enables POP3 service
+* SMTP_ONLY
+  * *empty* (default) => courier daemons might start
+  * *1 => do not launch any courier daemons (imap, pop3)
 * SA_TAG
   * *2.0* (default) => add spam info headers if at, or above that level
 * SA_TAG2
   * *6.31* (default) => add 'spam detected' headers at that level
 * SA_KILL
   * *6.31* (default) => triggers spam evasive actions)
-* SMTP_ONLY
-  * do not launch any courier daemons (imap, pop3)
 
 Please read [how the container starts](https://github.com/tomav/docker-mailserver/blob/master/start-mailserver.sh) to understand what's expected.  
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Example:
   * *6.31* (default) => add 'spam detected' headers at that level
 * SA_KILL
   * *6.31* (default) => triggers spam evasive actions)
+* SMTP_ONLY
+  * do not launch any courier daemons (imap, pop3)
 
 Please read [how the container starts](https://github.com/tomav/docker-mailserver/blob/master/start-mailserver.sh) to understand what's expected.  
 

--- a/start-mailserver.sh
+++ b/start-mailserver.sh
@@ -229,11 +229,15 @@ echo "Starting daemons"
 cron
 /etc/init.d/rsyslog start
 /etc/init.d/saslauthd start
+
+if [ "$SMTP_ONLY" != 1 ]; then
+
 /etc/init.d/courier-authdaemon start
 /etc/init.d/courier-imap start
 /etc/init.d/courier-imap-ssl start
 
-if [ "$ENABLE_POP3" = 1 ]; then
+fi
+if [ "$ENABLE_POP3" = 1 -a "$SMTP_ONLY" != 1 ]; then
   echo "Starting POP3 services"
   /etc/init.d/courier-pop start
   /etc/init.d/courier-pop-ssl start

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -47,9 +47,25 @@
   [ "$status" -eq 0 ]
 }
 
+@test "checking process: courierpop3d (disabled using SMTP_ONLY)" {
+  run docker exec mail_smtponly /bin/bash -c "ps aux --forest | grep -v grep | grep '/usr/lib/courier/courier/courierpop3d'"
+  [ "$status" -eq 1 ]
+}
+
+
 #
 # imap
 #
+
+@test "checking process: courier imaplogin (enabled in default configuration)" {
+  run docker exec mail /bin/bash -c "ps aux --forest | grep -v grep | grep '/usr/lib/courier/courier/imaplogin'"
+  [ "$status" -eq 0 ]
+}
+
+@test "checking process: courier imaplogin (disabled using SMTP_ONLY)" {
+  run docker exec mail_smtponly /bin/bash -c "ps aux --forest | grep -v grep | grep '/usr/lib/courier/courier/imaplogin'"
+  [ "$status" -eq 1 ]
+}
 
 @test "checking imap: server is ready with STARTTLS" {
   run docker exec mail /bin/bash -c "nc -w 1 0.0.0.0 143 | grep '* OK' | grep 'STARTTLS' | grep 'Courier-IMAP ready'"


### PR DESCRIPTION
Hi Thomas.

This is kind of an initial exploratory pull request to figure out whether you would be interested in more future pull requests for an SMTP_ONLY option for your the docker-mailserver. I quite like the high integration of all these daemons and would preferably work collaboratively one Dockerfile. However, my use case does not require any courier daemons and therefore, I would prefer them not running at all. 

I hope I have done my homework right and you will accept this clean merging patch. As requested I provided some additional tests.

Cheers,
Marko
