### PR TITLE
[wip] Feature to avoid clear text pwd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,9 @@ ADD postfix/main.cf /etc/postfix/main.cf
 ADD postfix/master.cf /etc/postfix/master.cf
 ADD postfix/sasl/smtpd.conf /etc/postfix/sasl/smtpd.conf
 ADD bin/generate-ssl-certificate /usr/local/bin/generate-ssl-certificate
+ADD bin/generate-user-databases /usr/local/bin/generate-user-databases
 RUN chmod +x /usr/local/bin/generate-ssl-certificate
+RUN chmod +x /usr/local/bin/generate-user-databases
 
 # Get LetsEncrypt signed certificate
 RUN curl https://letsencrypt.org/certs/lets-encrypt-x1-cross-signed.pem > /etc/ssl/certs/lets-encrypt-x1-cross-signed.pem

--- a/bin/generate-user-databases
+++ b/bin/generate-user-databases
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Generate the courier and sasl databases
+if [ -f /tmp/postfix/accounts.cf ]; then
+  # Checking that /tmp/postfix/accounts.cf ends with a newline
+  sed -i -e '$a\' /tmp/postfix/accounts.cf
+
+  # Creating users
+  while IFS=$'|' read login pass
+  do
+    # Setting variables for better readability
+    user=$(echo ${login} | cut -d @ -f1)
+    domain=$(echo ${login} | cut -d @ -f2)
+    # Let's go!
+    echo "user '${user}' for domain '${domain}' with password '********'"
+    /usr/sbin/userdb ${login} set uid=5000 gid=5000 home=/var/mail/${domain}/${user} mail=/var/mail/${domain}/${user}
+    echo "${pass}" | userdbpw -md5 | userdb ${login} set systempw
+    echo "${pass}" | saslpasswd2 -p -c -u ${domain} ${login}
+  done < /tmp/postfix/accounts.cf
+  cp /etc/courier/userdb /tmp/postfix/userdb
+  cp /etc/sasldb2 /tmp/postfix/sasldb2
+  echo "Courier and Sasl databases populated with user accounts"
+fi


### PR DESCRIPTION
@tomav 
This is a possible approach to the problem of having to handle clear text passwords for user accounts. 
My proposal is : 

-  start with an account.cf (and clear text passwords)
-  run _generate-user-databases_ inside the docker: it will export two DBs (for courier and sasl)
-  run the docker mailserver providing userdb and sasldb2 instead of accounts.cf

That way passwords are kept secret even on the host.

The project buils and runs as for my own tests.
Part of the code that handles users in _start-mailserver.sh_ is redundant wrt that of the new script _generate-user-databases_ (probably it would need a better approach).

The docker command that could be used to generate user dbs is like the following:
docker run --rm **-v "$(pwd)"/postfix:/tmp/postfix** -h mail.fobbar.it -t angus/docker-mailserver **generate-user-databases**