### PR TITLE
fixed log rotate 

### DIFF
--- a/start-mailserver.sh
+++ b/start-mailserver.sh
@@ -158,7 +158,7 @@ case $DMS_SSL in
       sed -i -r 's/TLS_CERTFILE=\/etc\/courier\/pop3d.pem/TLS_CERTFILE=\/etc\/postfix\/ssl\/'$(hostname)'-full.pem/g' /etc/courier/pop3d-ssl
 
       echo "SSL configured with CA signed/custom certificates"
-      
+
     fi
     ;;
 
@@ -224,6 +224,8 @@ sed -i "/^findtime *=/c\findtime = 10800"   /etc/fail2ban/jail.conf
 # avoid warning on startup
 echo "ignoreregex =" >> /etc/fail2ban/filter.d/postfix-sasl.conf
 
+# continue to write the log information in the newly created file after rotating the old log file
+sed -i -r "/^#?compress/c\compress\ncopytruncate" /etc/logrotate.conf
 
 echo "Starting daemons"
 cron


### PR DESCRIPTION
syslog and mail (postfix?) daemon were not continue to write the logs in the newly created file after rotating the old log file. so after a while fail2ban daemon was watching the new (but empty) file and did not work anymore.

see `ls -l /var/log` and `lsof | grep /var/log` for example.

adding "copytruncate" in the configuration file is probably a common solution.

by the way: i also switched on the file compress feature (.gz) for rotated files.