### PR TITLE
Add eol to letsencrypt provided files [Issue #110]

### DIFF
--- a/start-mailserver.sh
+++ b/start-mailserver.sh
@@ -120,6 +120,10 @@ fi
 case $DMS_SSL in
   "letsencrypt" )
     # letsencrypt folders and files mounted in /etc/letsencrypt
+      # add eol to all files before concatenation
+      sed -i -e '$a\' /etc/letsencrypt/live/$(hostname)/cert.pem
+      sed -i -e '$a\' /etc/letsencrypt/live/$(hostname)/chain.pem
+      sed -i -e '$a\' /etc/letsencrypt/live/$(hostname)/privkey.pem
 
       # Postfix configuration
       sed -i -r 's/smtpd_tls_cert_file=\/etc\/ssl\/certs\/ssl-cert-snakeoil.pem/smtpd_tls_cert_file=\/etc\/letsencrypt\/live\/'$(hostname)'\/fullchain.pem/g' /etc/postfix/main.cf


### PR DESCRIPTION
Some LE tools like simp_le create the cert files with no end-of-line. This change adds an eol if non exists.

If a file does not exist, sed throws an error on STDERR. It might be a good idea to check for file existence first like in the "self-signed" and "custom" case.

This fixes [Issue #110 ](https://github.com/tomav/docker-mailserver/issues/110).