### PR TITLE
Add ENABLE_FAIL2BAN environment variable to enable fail2ban service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,12 @@ run:
 		-v "`pwd`/test":/tmp/test \
 		-e SMTP_ONLY=1 \
 		-h mail.my-domain.com -t $(NAME)
+	docker run -d --name mail_fail2ban \
+		-v "`pwd`/postfix":/tmp/postfix \
+		-v "`pwd`/spamassassin":/tmp/spamassassin \
+		-v "`pwd`/test":/tmp/test \
+		-e ENABLE_FAIL2BAN=1 \
+		-h mail.my-domain.com -t $(NAME)
 	# Wait for containers to fully start
 	sleep 60
 
@@ -55,4 +61,4 @@ clean:
 	# Get default files back
 	git checkout postfix/accounts.cf postfix/main.cf postfix/virtual
 	# Remove running test containers
-	docker rm -f mail mail_pop3 mail_smtponly
+	docker rm -f mail mail_pop3 mail_smtponly mail_fail2ban

--- a/README.md
+++ b/README.md
@@ -96,10 +96,13 @@ Example:
 * SA_TAG2
   * *6.31* (default) => add 'spam detected' headers at that level
 * SA_KILL
-  * *6.31* (default) => triggers spam evasive actions)
+  * *6.31* (default) => triggers spam evasive actions
 * SASL_PASSWORD
   * *empty* (default) => No sasl_passwd will be created
   * *string* => A /etc/postfix/sasl_passwd will be created with that content and postmap will be run on it
+* ENABLE_FAIL2BAN
+  * *empty* (default) => fail2ban service disabled
+  * 1 => Enables fail2ban service
 
 Please read [how the container starts](https://github.com/tomav/docker-mailserver/blob/master/start-mailserver.sh) to understand what's expected.  
 

--- a/start-mailserver.sh
+++ b/start-mailserver.sh
@@ -269,7 +269,11 @@ fi
 /etc/init.d/opendkim start
 /etc/init.d/opendmarc start
 /etc/init.d/postfix start
-/etc/init.d/fail2ban start
+
+if [ "$ENABLE_FAIL2BAN" = 1 ]; then
+  echo "Starting fail2ban service"
+  /etc/init.d/fail2ban start
+fi
 
 echo "Listing SASL users"
 sasldblistusers2

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -32,8 +32,13 @@
   [ "$status" -eq 0 ]
 }
 
-@test "checking process: fail2ban" {
+@test "checking process: fail2ban (disabled in default configuration)" {
   run docker exec mail /bin/bash -c "ps aux --forest | grep -v grep | grep '/usr/bin/python /usr/bin/fail2ban-server'"
+  [ "$status" -eq 1 ]
+}
+
+@test "checking process: fail2ban (fail2ban server enabled)" {
+  run docker exec mail_fail2ban /bin/bash -c "ps aux --forest | grep -v grep | grep '/usr/bin/python /usr/bin/fail2ban-server'"
   [ "$status" -eq 0 ]
 }
 
@@ -311,26 +316,26 @@
 #
 
 @test "checking fail2ban: localhost is not banned" {
-  run docker exec mail /bin/sh -c "fail2ban-client status sasl | grep 'IP list:\s*127.0.0.1'"
+  run docker exec mail_fail2ban /bin/sh -c "fail2ban-client status sasl | grep 'IP list:.*127.0.0.1'"
   [ "$status" -eq 1 ]
 }
 
 @test "checking fail2ban: ban ip on multiple failed login" {
-  docker exec mail fail2ban-client status sasl
-  docker exec mail fail2ban-client set sasl delignoreip 127.0.0.1/8
-  docker exec mail /bin/sh -c 'nc -w 1 0.0.0.0 25 < /tmp/test/auth/smtp-auth-login-wrong.txt'
-  docker exec mail /bin/sh -c 'nc -w 1 0.0.0.0 25 < /tmp/test/auth/smtp-auth-login-wrong.txt'
-  docker exec mail /bin/sh -c 'nc -w 1 0.0.0.0 25 < /tmp/test/auth/smtp-auth-login-wrong.txt'
+  docker exec mail_fail2ban fail2ban-client status sasl
+  docker exec mail_fail2ban fail2ban-client set sasl delignoreip 127.0.0.1/8
+  docker exec mail_fail2ban /bin/sh -c 'nc -w 1 0.0.0.0 25 < /tmp/test/auth/smtp-auth-login-wrong.txt'
+  docker exec mail_fail2ban /bin/sh -c 'nc -w 1 0.0.0.0 25 < /tmp/test/auth/smtp-auth-login-wrong.txt'
+  docker exec mail_fail2ban /bin/sh -c 'nc -w 1 0.0.0.0 25 < /tmp/test/auth/smtp-auth-login-wrong.txt'
   sleep 5
-  run docker exec mail /bin/sh -c "fail2ban-client status sasl | grep 'IP list:\s*127.0.0.1'"
+  run docker exec mail_fail2ban /bin/sh -c "fail2ban-client status sasl | grep 'IP list:.*127.0.0.1'"
   [ "$status" -eq 0 ]
 }
 
 @test "checking fail2ban: unban ip works" {
-  docker exec mail fail2ban-client set sasl addignoreip 127.0.0.1/8
-  docker exec mail fail2ban-client set sasl unbanip 127.0.0.1
+  docker exec mail_fail2ban fail2ban-client set sasl addignoreip 127.0.0.1/8
+  docker exec mail_fail2ban fail2ban-client set sasl unbanip 127.0.0.1
   sleep 5
-  run docker exec mail /bin/sh -c "fail2ban-client status sasl | grep 'IP list:\s*127.0.0.1'"
+  run docker exec mail_fail2ban /bin/sh -c "fail2ban-client status sasl | grep 'IP list:.*127.0.0.1'"
   [ "$status" -eq 1 ]
 }
 


### PR DESCRIPTION
Implement #112
Fail2ban is not enabled by default, now.

* Changed/updated Makefile and integration tests
* Changed some grep expressions in the fail2ban tests