### PR TITLE
Removed IFS + Added vmailbox config

### DIFF
--- a/start-mailserver.sh
+++ b/start-mailserver.sh
@@ -58,6 +58,9 @@ if [ -f /tmp/vhost.tmp ]; then
   cat /tmp/vhost.tmp | sort | uniq > /etc/postfix/vhost && rm /tmp/vhost.tmp
 fi
 
+# manual mailbox configuration (reference http://www.postfix.org/VIRTUAL_README.html#virtual_mailbox)
+cat /tmp/postfix/vmailbox >> /etc/postfix/vmailbox
+
 echo "Postfix configurations"
 touch /etc/postfix/vmailbox && postmap /etc/postfix/vmailbox
 touch /etc/postfix/virtual && postmap /etc/postfix/virtual

--- a/start-mailserver.sh
+++ b/start-mailserver.sh
@@ -44,7 +44,7 @@ fi
 if [ -f /tmp/postfix/virtual ]; then
   # Copying virtual file
   cp /tmp/postfix/virtual /etc/postfix/virtual
-  while IFS=$' ' read from to
+  while read from to
   do
     # Setting variables for better readability
     domain=$(echo ${from} | cut -d @ -f2)


### PR DESCRIPTION
Here is a fix for issue #121 and I went a bit further and added support for custom vmailbox settings (usefull for issue #57).

Now, you can define a `/tmp/postfix/vmailbox` (from within the container) that specifies extra virtual mail boxes. It is describe here: http://www.postfix.org/VIRTUAL_README.html#virtual_mailbox

Custom vmailbox settings are appended to the end of `/etc/postfix/vmailbox`, so after the generated content from `accounts.cf`.

What it allows is the support of routing all the other mail from a domain to a mail box.

For example:
accounts.cf:
```
user@domain.tld|password
contact@domain.tld|password2
```

vmailbox:
`@domain.tld domain.tld/contact/`

In this example, all the mails **other** than `user@domain.tld` and `contact@domain.tld` will be placed in `contact@domain.tld`'s mailbox. Be aware that the trailing "/" is required !