### PR TITLE
Disable cleartext authentication on SMTP

### DIFF
--- a/postfix/master.cf
+++ b/postfix/master.cf
@@ -11,6 +11,8 @@
 # ==========================================================================
 
 smtp      inet  n       -       n       -       -       smtpd
+  -o smtpd_tls_security_level=none
+  -o smtpd_sasl_auth_enable=no
 submission inet n       -       n       -       -       smtpd
   -o syslog_name=postfix/submission
   -o smtpd_tls_security_level=encrypt


### PR DESCRIPTION
At the moment cleartext authentication via unencrypted SMTP is enabled.
Disable it.