### PR TITLE
V2 CI-tests

### DIFF
--- a/test/config/clear.postfix-accounts.cf
+++ b/test/config/clear.postfix-accounts.cf
@@ -1,0 +1,2 @@
+user1@localhost.localdomain|mypassword
+user2@otherdomain.tld|mypassword

--- a/test/config/postfix-accounts.cf
+++ b/test/config/postfix-accounts.cf
@@ -1,2 +1,2 @@
-user1@localhost.localdomain|mypassword
-user2@otherdomain.tld|mypassword
+user1@localhost.localdomain|{MD5-CRYPT}$1$agWCql3M$ATBimsiJ4EETYnG/yLWwr.
+user2@otherdomain.tld|{MD5-CRYPT}$1$31q82qPz$vprzqppi3chSsK8SgWT8d/

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -52,7 +52,7 @@
 }
 
 @test "checking imap: server is ready with STARTTLS" {
-  run docker exec mail /bin/bash -c "nc -w 1 0.0.0.0 143 | grep '* OK' | grep 'STARTTLS' | grep 'ready'"
+  run docker exec mail /bin/bash -c "nc -w 5 0.0.0.0 143 | grep '* OK' | grep 'STARTTLS' | grep 'ready'"
   [ "$status" -eq 0 ]
 }
 
@@ -182,32 +182,15 @@
 }
 
 @test "checking accounts: user mail folders for user1" {
-  run docker exec mail ls -A /var/mail/localhost.localdomain/user1
+  run docker exec mail /bin/bash -c "ls -A /var/mail/localhost.localdomain/user1 | grep -E '.Drafts|.Sent|.Trash|cur|new|subscriptions|tmp' | wc -l"
   [ "$status" -eq 0 ]
-  [ "${lines[0]}" = ".Drafts" ]
-  [ "${lines[1]}" = ".Sent" ]
-  [ "${lines[2]}" = ".Trash" ]
-  [ "${lines[3]}" = "cur" ]
-  [ "${lines[4]}" = "dovecot-uidlist" ]
-  [ "${lines[5]}" = "dovecot-uidvalidity" ]
-  [ "${lines[6]}" = "dovecot-uidvalidity.5712dae3" ]
-  [ "${lines[7]}" = "dovecot.index.cache" ]
-  [ "${lines[8]}" = "dovecot.index.log" ]
-  [ "${lines[9]}" = "new" ]
-  [ "${lines[10]}" = "subscriptions" ]
-  [ "${lines[11]}" = "tmp" ]
+  [ "$output" -eq 7 ]
 }
 
 @test "checking accounts: user mail folders for user2" {
-  run docker exec mail ls -A /var/mail/otherdomain.tld/user2
+  run docker exec mail /bin/bash -c "ls -A /var/mail/otherdomain.tld/user2 | grep -E '.Drafts|.Sent|.Trash|cur|new|subscriptions|tmp' | wc -l"
   [ "$status" -eq 0 ]
-  [ "${lines[0]}" = ".Drafts" ]
-  [ "${lines[1]}" = ".Sent" ]
-  [ "${lines[2]}" = ".Trash" ]
-  [ "${lines[3]}" = "cur" ]
-  [ "${lines[4]}" = "new" ]
-  [ "${lines[5]}" = "subscriptions" ]
-  [ "${lines[6]}" = "tmp" ]
+  [ "$output" -eq 7 ]
 }
 
 #


### PR DESCRIPTION
Adapted the user account setup for the test environment to the new v2 approach (encrypted passwords).
Modified integration tests to adapt to dovecot.

Need to be worked out:
- user accounts checks: dir layout under dovecot probably include dynamic filenames.
  How can we handle that ?
- fail2ban container cannot ban via iptables if we do not run it with special
  privileges.

Please note @tomav : tests involving the use of "nc -w 1" on dovecot services may need a longer timeout, in particular when testing failures as dovecot do not answer immediately (by design? who know!). It may even depends on my busy host.