### PR TITLE
Dockerfile optimization to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,14 @@ FROM ubuntu:14.04
 MAINTAINER Thomas VIAL
 
 # Packages
-RUN apt-get update -q --fix-missing
-RUN apt-get -y upgrade
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install vim postfix sasl2-bin courier-imap courier-imap-ssl \
-    courier-pop courier-pop-ssl courier-authdaemon supervisor gamin amavisd-new spamassassin clamav clamav-daemon libnet-dns-perl libmail-spf-perl \
-    pyzor razor arj bzip2 cabextract cpio file gzip nomarch p7zip pax unzip zip zoo rsyslog mailutils netcat \
-    opendkim opendkim-tools opendmarc curl fail2ban
-RUN apt-get autoclean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -q --fix-missing &&\
+    apt-get -y upgrade &&\
+    DEBIAN_FRONTEND=noninteractive apt-get -y install vim postfix sasl2-bin courier-imap courier-imap-ssl \
+    	courier-pop courier-pop-ssl courier-authdaemon supervisor gamin amavisd-new spamassassin clamav clamav-daemon libnet-dns-perl libmail-spf-perl \
+    	pyzor razor arj bzip2 cabextract cpio file gzip nomarch p7zip pax unzip zip zoo rsyslog mailutils netcat \
+    	opendkim opendkim-tools opendmarc curl fail2ban &&\
+    apt-get autoclean &&\
+    rm -rf /var/lib/apt/lists/*
 
 # Configures Saslauthd
 RUN rm -rf /var/run/saslauthd && ln -s /var/spool/postfix/var/run/saslauthd /var/run/saslauthd


### PR DESCRIPTION
I noticed the Dockerfile wasn't well written: files have to be removed in the same layer (for example  same RUN) it was added to save on image size.

I therefor merged the apt-get lines.

The result is an image size down to 489.7 MB instead of 559.7 MB (-12,5%). It's not much but it's still something ;-)