### PR TITLE
Sieve filters can now be installed at user setup.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q --fix-missing && \
 RUN sed -i -e 's/include_try \/usr\/share\/dovecot\/protocols\.d/include_try \/etc\/dovecot\/protocols\.d/g' /etc/dovecot/dovecot.conf
 RUN sed -i -e 's/#mail_plugins = \$mail_plugins/mail_plugins = \$mail_plugins sieve/g' /etc/dovecot/conf.d/15-lda.conf
 ADD target/dovecot/auth-passwdfile.inc /etc/dovecot/conf.d/
-ADD target/dovecot/10-*.conf /etc/dovecot/conf.d/
+ADD target/dovecot/??-*.conf /etc/dovecot/conf.d/
 
 # Enables Spamassassin and CRON updates
 RUN sed -i -r 's/^(CRON|ENABLED)=0/\1=1/g' /etc/default/spamassassin


### PR DESCRIPTION
Changed Dockerfile to include a missing configuration file for dovecot (mailboxes).
Changed info message when no postfix-main.cf are provided for overriding postfix config (was referencing the older file name).
Moved Postfix setup after DKIM/DMARC/SSL setup, near the override postfix setup.
This one in particular is only aesthetic if you look at the order messages are outputted at startup:

> user 'user2' for domain 'otherdomain.tld' with password '********'
> Postfix configurations
> No DKIM key provided. Check the documentation to find how to get your keys.
> Loaded 'config/postfix-main.cf'

I thought that `Postfix configurations` should appear before the `loading of postfix-main.cf` instead of being interleaved by DKIM, SSL etc.
 