### PR TITLE
Fix permission issues on wrong dkim path

### DIFF
--- a/target/bin/generate-dkim-config
+++ b/target/bin/generate-dkim-config
@@ -33,10 +33,10 @@ grep -vE '^(\s*$|#)' /tmp/vhost | while read domainname; do
 	fi
 
 	# Write to KeyTable if necessary
-	keytableentry="mail._domainkey.$domainname $domainname:mail:/tmp/docker-mailserver/opendkim/keys/$domainname/mail.private"
+	keytableentry="mail._domainkey.$domainname $domainname:mail:/etc/opendkim/keys/$domainname/mail.private"
 	if [ ! -f "/tmp/docker-mailserver/opendkim/KeyTable" ]; then
 		echo "Creating DKIM KeyTable"
-	 	echo "mail._domainkey.$domainname $domainname:mail:/tmp/docker-mailserver/opendkim/keys/$domainname/mail.private" > /tmp/docker-mailserver/opendkim/KeyTable
+		echo $keytableentry > /tmp/docker-mailserver/opendkim/KeyTable
 	else
 		if ! grep -q "$keytableentry" "/tmp/docker-mailserver/opendkim/KeyTable" ; then
 	    	echo $keytableentry >> /tmp/docker-mailserver/opendkim/KeyTable


### PR DESCRIPTION
Hi, I used your v2 branch and wasn't able to send mails due
```
Apr 30 11:01:11 mail opendkim[521]: mail._domainkey.zauberstuhl.de: key data is not secure: /tmp can be read or written by other users
Apr 30 11:01:11 mail opendkim[521]: 176E2C07: error loading key 'mail._domainkey.zauberstuhl.de'
```

I followed your tutorial and ran `generate-dkim-config` from the console. Maybe I missed a step but in the KeyTable file there is the path to the temporary file configured after creation.

~~You can avoid this kind of issue by simply running `sed` after the copy step. Even if I missed something that fix could avoid problems in future.~~

great work btw.. Cheers!