### PR TITLE
opendkim folder shadowing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Adapt this file with your FQDN.
         - "993:993"
         volumes:
         - ./config/:/tmp/docker-mailserver/
-        - ./opendkim/:/tmp/docker-mailserver/opendkim/
 
     volumes:
       maildata:

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -15,7 +15,6 @@ services:
     - "993:993"
     volumes:
     - ./config/:/tmp/docker-mailserver/
-    - ./opendkim/:/tmp/docker-mailserver/opendkim/
     environment:
     - ENABLE_FAIL2BAN=1
     cap_add:


### PR DESCRIPTION
./opendkim/ local folder shadows ./config/opendkim
on generation of the keyfiles all files get written to ./config/opendkim leaving ./opendkim empty
thus on startup no config for opendkim is loaded