### PR TITLE
Merge "volumes" option in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,13 @@ Adapt this file with your FQDN.
         hostname: mail
         domainname: domain.com
         container_name: mail
-        volumes:
-        - maildata:/var/mail
         ports:
         - "25:25"
         - "143:143"
         - "587:587"
         - "993:993"
         volumes:
+        - maildata:/var/mail
         - ./config/:/tmp/docker-mailserver/
 
     volumes:

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -6,14 +6,13 @@ services:
     hostname: mail
     domainname: domain.com
     container_name: mail
-    volumes:
-    - maildata:/var/mail
     ports:
     - "25:25"
     - "143:143"
     - "587:587"
     - "993:993"
     volumes:
+    - maildata:/var/mail
     - ./config/:/tmp/docker-mailserver/
     environment:
     - ENABLE_FAIL2BAN=1


### PR DESCRIPTION
By having two separate `volumes` options, only the last one is used, so they should be merged into one to make sure the `maildata` container is used.