### PR TITLE
Avoid fixing permissions; add regexp alias file, add AWS SES outgoing email support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Thomas VIAL
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -q --fix-missing && \
 	apt-get -y upgrade && \
 	apt-get -y install --no-install-recommends \
-	postfix dovecot-core dovecot-imapd dovecot-pop3d dovecot-sieve dovecot-managesieved gamin amavisd-new spamassassin razor pyzor \
+	postfix dovecot-core dovecot-imapd dovecot-pop3d dovecot-sieve dovecot-managesieved gamin amavisd-new spamassassin razor pyzor libsasl2-modules \
 	clamav clamav-daemon libnet-dns-perl libmail-spf-perl bzip2 file gzip p7zip unzip arj rsyslog \
     opendkim opendkim-tools opendmarc curl fail2ban ed iptables && \
 	curl -sk http://neuro.debian.net/lists/trusty.de-m.libre > /etc/apt/sources.list.d/neurodebian.sources.list && \

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ fixtures:
 	docker exec mail /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-alias-external.txt"
 	docker exec mail /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-alias-local.txt"
 	docker exec mail /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user.txt"
+	docker exec mail /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-regexp-alias-external.txt"
+	docker exec mail /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-regexp-alias-local.txt"
 	docker exec mail /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/sieve-spam-folder.txt"
 	docker exec mail /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/non-existing-user.txt"
 	# Wait for mails to be analyzed

--- a/README.md
+++ b/README.md
@@ -1,32 +1,4 @@
-# docker-mailserver [![Build Status](https://travis-ci.org/tve/docker-mailserver.svg?branch=master)](https://travis-ci.org/tve/docker-mailserver)
-
-This is a fork of https://github.com/tomav/docker-mailserver with some additional features
-described below.
-
-### Sending outbound mail via Amazon SES
-
-Instead of letting postfix deliver mail directly it is possible to forward outgoing email
-through Amazon SES (Simple Email Service). To enable this feature, define the following two
-environment variables in the `docker-compose.yml` with the appropriate values for your AWS SES
-subscription (the values for `AWS_SES_USERPASS` are the "SMTP username" and "SMTP password"
-provided when yuo create SMTP credentials for SES):
-```
-    environment:
-    - AWS_SES_HOST=email-smtp.us-east-1.amazonaws.com
-    - AWS_SES_USERPASS=AKIAXXXXXXXXXXXXXXXX:kqXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-```
-
-### Configuring regexp aliases
-
-Additional regexp aliases can be configured by placing them into `config/postfix-regexp.cf`.
-The regexp aliases get evaluated after the virtual aliases (`postfix-cirtual.cf`). For example,
-the following `config/postfix-regexp.cf` causes all email to test users to be delivered
-to `qa@example.com`:
-```
-/^test[0-9][0-9]*@example.com/ qa@example.com
-```
-
-## Overview
+# docker-mailserver [![Build Status](https://travis-ci.org/tomav/docker-mailserver.svg?branch=master)](https://travis-ci.org/tomav/docker-mailserver)
 
 A fullstack but simple mail server (smtp, imap, antispam, antivirus...).
 Only configuration files, no SQL database. Keep it simple and versioned.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,31 @@
-# docker-mailserver [![Build Status](https://travis-ci.org/tomav/docker-mailserver.svg?branch=master)](https://travis-ci.org/tomav/docker-mailserver)
+# docker-mailserver [![Build Status](https://travis-ci.org/tve/docker-mailserver.svg?branch=master)](https://travis-ci.org/tve/docker-mailserver)
+
+This is a fork of https://github.com/tomav/docker-mailserver with some additional features:
+
+### Sending outbound mail via Amazon SES
+
+Instead of letting postfix deliver mail directly it is possible to forward outgoing email
+through Amazon SES (Simple Email Service). To enable this feature, define the following two
+environment variables in the `docker-compose.yml` with the appropriate values for your AWS SES
+subscription (the values for `AWS_SES_USERPASS` are the "SMTP username" and "SMTP password"
+provided when yuo create SMTP credentials for SES):
+```
+    environment:
+    - AWS_SES_HOST=email-smtp.us-east-1.amazonaws.com
+    - AWS_SES_USERPASS=AKIAXXXXXXXXXXXXXXXX:kqXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+### Configuring regexp aliases
+
+Additional regexp aliases can be configured by placing them into `config/postfix-regexp.cf`.
+The regexp aliases get evaluated after the virtual aliases (`postfix-cirtual.cf`). For example,
+the following `config/postfix-regexp.cf` causes all email to test users to be delivered
+to `qa@example.com`:
+```
+/^test[0-9][0-9]*@example.com/ qa@example.com
+```
+
+## Overview
 
 A fullstack but simple mail server (smtp, imap, antispam, antivirus...).
 Only configuration files, no SQL database. Keep it simple and versioned.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # docker-mailserver [![Build Status](https://travis-ci.org/tve/docker-mailserver.svg?branch=master)](https://travis-ci.org/tve/docker-mailserver)
 
-This is a fork of https://github.com/tomav/docker-mailserver with some additional features:
+This is a fork of https://github.com/tomav/docker-mailserver with some additional features
+described below.
 
 ### Sending outbound mail via Amazon SES
 

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -247,7 +247,7 @@ else
 fi
 
 # Fix permissions, but skip this if 3 levels deep the user id is already set
-if [ `find /var/mail -maxdepth 3 \! -user 5000 | grep -c .` != 0 ]; then
+if [ `find /var/mail -maxdepth 3 -a \( \! -user 5000 -o \! -group 5000 \) | grep -c .` != 0 ]; then
   echo "Fixing /var/mail permissions"
   chown -R 5000:5000 /var/mail
 else

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -231,7 +231,8 @@ if [ ! -z "$AWS_SES_HOST" -a ! -z "$AWS_SES_USERPASS" ]; then
     "smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd" \
     "smtp_use_tls = yes" \
     "smtp_tls_security_level = encrypt" \
-    "smtp_tls_note_starttls_offer = yes"
+    "smtp_tls_note_starttls_offer = yes" \
+    "smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt"
 fi
 
 # Install SASL passwords

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -82,7 +82,10 @@ if [ -f /tmp/docker-mailserver/postfix-regexp.cf ]; then
   # Copying regexp alias file
   echo "Adding regexp alias file postfix-regexp.cf"
   cp /tmp/docker-mailserver/postfix-regexp.cf /etc/postfix/regexp
-  sed -i -e "/^virtual_alias_maps/a| regexp:/etc/postfix/regexp|" /etc/postfix/main.cf
+  sed -i -e '/^virtual_alias_maps/{
+    s/ regexp:.*//
+    s/$/ regexp:\/etc\/postfix\/regexp/
+    }' /etc/postfix/main.cf
 fi
 
 # DKIM

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -82,7 +82,7 @@ if [ -f /tmp/docker-mailserver/postfix-regexp.cf ]; then
   # Copying regexp alias file
   echo "Adding regexp alias file postfix-regexp.cf"
   cp /tmp/docker-mailserver/postfix-regexp.cf /etc/postfix/regexp
-  sed -i -e "/^virtual_alias_maps/a|/etc/postfix/regexp|" /tmp/docker-mailserver/target/postfix/main.cf
+  sed -i -e "/^virtual_alias_maps/a|/etc/postfix/regexp|" /etc/postfix/main.cf
 fi
 
 # DKIM

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -222,8 +222,13 @@ else
   echo "==> Warning: 'SASL_PASSWD' is not provided. /etc/postfix/sasl_passwd not created."
 fi
 
-echo "Fixing permissions"
-chown -R 5000:5000 /var/mail
+# Fix permissions, but skip this if 3 levels deep the user id is already set
+if [ `find /var/mail -maxdepth 3 \! -user 5000 | grep -c .` != 0 ]; then
+  echo "Fixing /var/mail permissions"
+  chown -R 5000:5000 /var/mail
+else
+  echo "Permissions in /var/mail look OK"
+fi
 
 echo "Creating /etc/mailname"
 echo $(hostname -d) > /etc/mailname

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -211,8 +211,28 @@ else
   echo "No extra postfix settings loaded because optional '/tmp/docker-mailserver/postfix-main.cf' not provided."
 fi
 
+# Support general SASL password
+rm -f /etc/postfix/sasl_passwd
 if [ ! -z "$SASL_PASSWD" ]; then
-  echo "$SASL_PASSWD" > /etc/postfix/sasl_passwd
+  echo "$SASL_PASSWD" >> /etc/postfix/sasl_passwd
+fi
+
+# Support outgoing email relay via Amazon SES
+if [ ! -z "$AWS_SES_HOST" -a ! -z "$AWS_SES_USERPASS" ]; then
+  echo "Setting up outgoing email via AWS SES host $AWS_SES_HOST"
+  echo "[$AWS_SES_HOST]:25 $AWS_SES_USERPASS" >>/etc/postfix/sasl_passwd
+  postconf -e \
+    "relayhost = [$AWS_SES_HOST]:25" \
+    "smtp_sasl_auth_enable = yes" \
+    "smtp_sasl_security_options = noanonymous" \
+    "smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd" \
+    "smtp_use_tls = yes" \
+    "smtp_tls_security_level = encrypt" \
+    "smtp_tls_note_starttls_offer = yes"
+fi
+
+# Install SASL passwords
+if [ -f /etc/postfix/sasl_passwd ]; then
   postmap hash:/etc/postfix/sasl_passwd
   rm /etc/postfix/sasl_passwd
   chown root:root /etc/postfix/sasl_passwd.db

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -78,6 +78,12 @@ if [ -f /tmp/docker-mailserver/postfix-virtual.cf ]; then
 else
   echo "==> Warning: 'config/postfix-virtual.cf' is not provided. No mail alias/forward created."
 fi
+if [ -f /tmp/docker-mailserver/postfix-regexp.cf ]; then
+  # Copying regexp alias file
+  echo "Adding regexp alias file postfix-regexp.cf"
+  cp /tmp/docker-mailserver/postfix-regexp.cf /etc/postfix/regexp
+  sed -i -e "/^virtual_alias_maps/a|/etc/postfix/regexp|" /tmp/docker-mailserver/target/postfix/main.cf
+fi
 
 # DKIM
 # Check if keys are already available

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -82,7 +82,7 @@ if [ -f /tmp/docker-mailserver/postfix-regexp.cf ]; then
   # Copying regexp alias file
   echo "Adding regexp alias file postfix-regexp.cf"
   cp /tmp/docker-mailserver/postfix-regexp.cf /etc/postfix/regexp
-  sed -i -e "/^virtual_alias_maps/a|/etc/postfix/regexp|" /etc/postfix/main.cf
+  sed -i -e "/^virtual_alias_maps/a| regexp:/etc/postfix/regexp|" /etc/postfix/main.cf
 fi
 
 # DKIM

--- a/test/config/postfix-regexp.cf
+++ b/test/config/postfix-regexp.cf
@@ -1,0 +1,2 @@
+/^test[0-9][0-9]*@localhost.localdomain/ user1@localhost.localdomain
+/^bounce.*@.*/ external1@otherdomain.tld

--- a/test/email-templates/existing-regexp-alias-external.txt
+++ b/test/email-templates/existing-regexp-alias-external.txt
@@ -1,0 +1,12 @@
+HELO mail.external.tld
+MAIL FROM: user@external.tld
+RCPT TO: bounce-always@localhost.localdomain
+DATA
+From: Docker Mail Server <dockermailserver@external.tld>
+To: Existing Local User <bounce-always@localhost.localdomain>
+Date: Sat, 22 May 2010 07:43:25 -0400
+Subject: Test Message
+This is a test mail.
+
+.
+QUIT

--- a/test/email-templates/existing-regexp-alias-local.txt
+++ b/test/email-templates/existing-regexp-alias-local.txt
@@ -1,0 +1,12 @@
+HELO mail.external.tld
+MAIL FROM: user@external.tld
+RCPT TO: test123@localhost.localdomain
+DATA
+From: Docker Mail Server <dockermailserver@external.tld>
+To: Existing Local User <test123@localhost.localdomain>
+Date: Sat, 22 May 2010 07:43:25 -0400
+Subject: Test Message
+This is a test mail.
+
+.
+QUIT

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -131,7 +131,7 @@
 @test "checking smtp: delivers mail to existing account" {
   run docker exec mail /bin/sh -c "grep 'status=sent (delivered via dovecot service)' /var/log/mail/mail.log | wc -l"
   [ "$status" -eq 0 ]
-  [ "$output" -eq 3 ]
+  [ "$output" -eq 4 ]
 }
 
 @test "checking smtp: delivers mail to existing alias" {
@@ -161,7 +161,7 @@
 @test "checking smtp: redirects mail to external aliases" {
   run docker exec mail /bin/sh -c "grep -- '-> <external1@otherdomain.tld>' /var/log/mail/mail.log | wc -l"
   [ "$status" -eq 0 ]
-  [ "$output" = 1 ]
+  [ "$output" = 2 ]
 }
 
 @test "checking smtp: rejects spam" {

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -140,10 +140,16 @@
   [ "$output" = 1 ]
 }
 
-@test "checking smtp: user1 should have received 2 mails" {
+@test "checking smtp: delivers mail to regexp alias" {
+  run docker exec mail /bin/sh -c "grep 'to=<user1@localhost.localdomain>, orig_to=<test123@localhost.localdomain>' /var/log/mail/mail.log | grep 'status=sent' | wc -l"
+  [ "$status" -eq 0 ]
+  [ "$output" = 1 ]
+}
+
+@test "checking smtp: user1 should have received 3 mails" {
   run docker exec mail /bin/sh -c "ls -A /var/mail/localhost.localdomain/user1/new | wc -l"
   [ "$status" -eq 0 ]
-  [ "$output" = 2 ]
+  [ "$output" = 3 ]
 }
 
 @test "checking smtp: rejects mail to unknown user" {
@@ -152,7 +158,7 @@
   [ "$output" = 1 ]
 }
 
-@test "checking smtp: redirects mail to external alias" {
+@test "checking smtp: redirects mail to external aliases" {
   run docker exec mail /bin/sh -c "grep -- '-> <external1@otherdomain.tld>' /var/log/mail/mail.log | wc -l"
   [ "$status" -eq 0 ]
   [ "$output" = 1 ]


### PR DESCRIPTION
This PR is not intended to be merged as-is, please indicate whether you want all/some/none of it and I can cherry-pick accordingly. It has:
- avoid fixing permissions if they're OK #190
- support regexp alias file
- support outgoing email via AWS SES

I added docs to the README, but I would move that to the wiki.