### PR TITLE
Persist mail state directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,13 @@ run:
 	docker run -d --name mail \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
+		-v "`pwd`/test/onedir":/var/mail-state \
 		-e SA_TAG=1.0 \
 		-e SA_TAG2=2.0 \
 		-e SA_KILL=3.0 \
 		-e SASL_PASSWD=testing \
 		-e ENABLE_MANAGESIEVE=1 \
+		-e ONE_DIR=1 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 20
 	docker run -d --name mail_pop3 \


### PR DESCRIPTION
This PR consolidates all directories with mail state into /var/mail-state, which can then be mounted as a volume. This is to address #191.

This PR is based off the changes in PR 194, please look at the one new commit https://github.com/tomav/docker-mailserver/commit/4ca39f9144f42675257af879c7d49558e5d66f1d for the changes.

If you like this approach, I will add docs to the Wiki. Dunno whether you want this to be in the docker-compose.yaml.dist or not. Also, I changed the tests to use the consolidated directories, but I don't really know how you want to proceed, so this PR is a bit of a WIP 'til I hear back...