### PR TITLE
fixed an issue where sieve complains about ~/.dovecot.sieve is not a directory

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -28,6 +28,7 @@ if [ -f /tmp/docker-mailserver/postfix-accounts.cf ]; then
   sed -i -e 's/#port = 993/port = 993/g' /etc/dovecot/conf.d/10-master.conf
   sed -i -e 's/#port = 995/port = 995/g' /etc/dovecot/conf.d/10-master.conf
   sed -i -e 's/#ssl = yes/ssl = required/g' /etc/dovecot/conf.d/10-ssl.conf
+  sed -i -e 's/sieve = ~\/\.dovecot\.sieve/sieve = ~\/sieve\/\.dovecot\.sieve/g' /etc/dovecot/conf.d/90-sieve.conf
 
   # Creating users
   # 'pass' is encrypted


### PR DESCRIPTION
I am having an issue using ManageSieve where I got the following error message:

```
Jul 28 00:02:27 mail dovecot: imap(xxx@xxx.xxx): Error: stat(/var/mail/xxx.xxx/xxx/.dovecot.sieve/tmp) failed: Not a directory
Jul 28 00:02:35 mail dovecot: message repeated 247 times: [ imap(xxx@xxx.xxx): Error: stat(/var/mail/xxx.xxx/xxx/.dovecot.sieve/tmp) failed: Not a directory]
```

`.dovecot.sieve` seems to be a symbolic link.

I am using RoundCube to configure sieve filter rules.