### PR TITLE
Handle missing files more gracefully.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 docker-compose.yml
 .idea
 test/config/empty/
+test/config/without-accounts/
+test/config/without-virtual/
 test/config/postfix-accounts.cf
 test/config/letsencrypt/mail.my-domain.com/combined.pem
 test/onedir

--- a/target/bin/addmailuser
+++ b/target/bin/addmailuser
@@ -9,7 +9,7 @@ function usage {
 
 if [ ! -z "$1" ]; then
  USER=$1
- if [ ! -z "$(grep $USER -i $DATABASE)" ]; then
+ if [ -e "$DATABASE" ] && [ ! -z "$(grep $USER -i $DATABASE)" ]; then
   echo "User already exists"
   exit 1
  fi

--- a/target/bin/delmailuser
+++ b/target/bin/delmailuser
@@ -9,8 +9,10 @@ function usage {
 
 if [ ! -z "$1" ]; then
  USER=$1
- ENTRIES=$(grep "$USER" -vi $DATABASE)
- echo "$ENTRIES" > $DATABASE
+ if [ -f "$DATABASE" ]; then
+  ENTRIES=$(grep "$USER" -vi $DATABASE)
+  echo "$ENTRIES" > $DATABASE
+ fi
 else
  usage
 fi

--- a/target/bin/generate-dkim-config
+++ b/target/bin/generate-dkim-config
@@ -3,25 +3,35 @@
 touch /tmp/vhost.tmp
 
 # Getting domains from mail accounts
-while IFS=$'|' read login pass
-do
-	domain=$(echo ${login} | cut -d @ -f2)
-	echo ${domain} >> /tmp/vhost.tmp
-done < /tmp/docker-mailserver/postfix-accounts.cf
+if [ -f /tmp/docker-mailserver/postfix-accounts.cf ]; then
+	while IFS=$'|' read login pass
+	do
+		domain=$(echo ${login} | cut -d @ -f2)
+		echo ${domain} >> /tmp/vhost.tmp
+	done < /tmp/docker-mailserver/postfix-accounts.cf
+fi
 
 # Getting domains from mail aliases
-while read from to
-do
-	# Setting variables for better readability
-	uname=$(echo ${from} | cut -d @ -f1)
-	domain=$(echo ${from} | cut -d @ -f2)
-	# if they are equal it means the line looks like: "user1     other@domain.tld"
-	test "$uname" != "$domain" && echo ${domain} >> /tmp/vhost.tmp
-done < /tmp/docker-mailserver/postfix-virtual.cf
+if [ -f /tmp/docker-mailserver/postfix-virtual.cf ]; then
+	while read from to
+	do
+		# Setting variables for better readability
+		uname=$(echo ${from} | cut -d @ -f1)
+		domain=$(echo ${from} | cut -d @ -f2)
+		# if they are equal it means the line looks like: "user1     other@domain.tld"
+		test "$uname" != "$domain" && echo ${domain} >> /tmp/vhost.tmp
+	done < /tmp/docker-mailserver/postfix-virtual.cf
+fi
 
 # Keeping unique entries
 if [ -f /tmp/vhost.tmp ]; then
 	cat /tmp/vhost.tmp | sort | uniq > /tmp/vhost && rm /tmp/vhost.tmp
+fi
+
+# Exit if no entries found
+if [ ! -f /tmp/vhost ]; then
+	echo "No entries found, no keys to make"
+	exit 0
 fi
 
 grep -vE '^(\s*$|#)' /tmp/vhost | while read domainname; do
@@ -56,9 +66,8 @@ grep -vE '^(\s*$|#)' /tmp/vhost | while read domainname; do
 done
 
 # Creates TrustedHosts if missing
-if [ ! -f "/tmp/docker-mailserver/opendkim/TrustedHosts" ]; then
+if [ -d "/tmp/docker-mailserver/opendkim" ] && [ ! -f "/tmp/docker-mailserver/opendkim/TrustedHosts" ]; then
 	echo "Creating DKIM TrustedHosts";
 	echo "127.0.0.1" > /tmp/docker-mailserver/opendkim/TrustedHosts
 	echo "localhost" >> /tmp/docker-mailserver/opendkim/TrustedHosts
 fi
-


### PR DESCRIPTION
Several tools expect the presence of certain config files, and fail gracelessly when they are absent.

Both addmailuser and delmailuser assume the existence of the postfix-accounts.cf file, while generate-dkim-config assumes the existence of that file and the postfix-virtual.cf file.