### PR TITLE
Adjust coding style in "bin" scripts

### DIFF
--- a/target/bin/addmailuser
+++ b/target/bin/addmailuser
@@ -3,27 +3,27 @@
 DATABASE=/tmp/docker-mailserver/postfix-accounts.cf
 
 function usage {
- echo 'Usage: addmailuser <user@domain.tld> [password]'
- exit 1
+  echo 'Usage: addmailuser <user@domain.tld> [password]'
+  exit 1
 }
 
 if [ ! -z "$1" ]; then
- USER=$1
- if [ ! -z "$(grep $USER -i $DATABASE)" ]; then
-  echo "User already exists"
-  exit 1
- fi
- if [ ! -z "$2" ]; then
-  PASS="$2"
- else
-  read -s -p "Enter Password: " PASS
-  if [ -z "$PASS" ]; then 
-   echo "Password can't be empty"
-   exit 1
+  USER=$1
+  if [ ! -z "$(grep $USER -i $DATABASE)" ]; then
+    echo "User already exists"
+    exit 1
   fi
- fi
- ENTRY=$(echo "$USER|$(doveadm pw -s SHA512-CRYPT -u "$USER" -p "$PASS")")
- echo "$ENTRY" >> $DATABASE
+  if [ ! -z "$2" ]; then
+    PASS="$2"
+  else
+    read -s -p "Enter Password: " PASS
+    if [ -z "$PASS" ]; then
+      echo "Password can't be empty"
+      exit 1
+    fi
+  fi
+  ENTRY=$(echo "$USER|$(doveadm pw -s SHA512-CRYPT -u "$USER" -p "$PASS")")
+  echo "$ENTRY" >> $DATABASE
 else
- usage
+  usage
 fi

--- a/target/bin/delmailuser
+++ b/target/bin/delmailuser
@@ -3,14 +3,14 @@
 DATABASE=/tmp/docker-mailserver/postfix-accounts.cf
 
 function usage {
- echo "Usage: delmailuser <user@domain.tld>"
- exit 1
+  echo "Usage: delmailuser <user@domain.tld>"
+  exit 1
 }
 
 if [ ! -z "$1" ]; then
- USER=$1
- ENTRIES=$(grep "$USER" -vi $DATABASE)
- echo "$ENTRIES" > $DATABASE
+  USER=$1
+  ENTRIES=$(grep "$USER" -vi $DATABASE)
+  echo "$ENTRIES" > $DATABASE
 else
- usage
+  usage
 fi

--- a/target/bin/generate-dkim-config
+++ b/target/bin/generate-dkim-config
@@ -5,60 +5,59 @@ touch /tmp/vhost.tmp
 # Getting domains from mail accounts
 while IFS=$'|' read login pass
 do
-	domain=$(echo ${login} | cut -d @ -f2)
-	echo ${domain} >> /tmp/vhost.tmp
+  domain=$(echo ${login} | cut -d @ -f2)
+  echo ${domain} >> /tmp/vhost.tmp
 done < /tmp/docker-mailserver/postfix-accounts.cf
 
 # Getting domains from mail aliases
 while read from to
 do
-	# Setting variables for better readability
-	uname=$(echo ${from} | cut -d @ -f1)
-	domain=$(echo ${from} | cut -d @ -f2)
-	# if they are equal it means the line looks like: "user1     other@domain.tld"
-	test "$uname" != "$domain" && echo ${domain} >> /tmp/vhost.tmp
+  # Setting variables for better readability
+  uname=$(echo ${from} | cut -d @ -f1)
+  domain=$(echo ${from} | cut -d @ -f2)
+  # if they are equal it means the line looks like: "user1     other@domain.tld"
+  test "$uname" != "$domain" && echo ${domain} >> /tmp/vhost.tmp
 done < /tmp/docker-mailserver/postfix-virtual.cf
 
 # Keeping unique entries
 if [ -f /tmp/vhost.tmp ]; then
-	cat /tmp/vhost.tmp | sort | uniq > /tmp/vhost && rm /tmp/vhost.tmp
+  cat /tmp/vhost.tmp | sort | uniq > /tmp/vhost && rm /tmp/vhost.tmp
 fi
 
 grep -vE '^(\s*$|#)' /tmp/vhost | while read domainname; do
-	mkdir -p /tmp/docker-mailserver/opendkim/keys/$domainname
+  mkdir -p /tmp/docker-mailserver/opendkim/keys/$domainname
 
-	if [ ! -f "/tmp/docker-mailserver/opendkim/keys/$domainname/mail.private" ]; then
-		echo "Creating DKIM private key /tmp/docker-mailserver/opendkim/keys/$domainname/mail.private"
-		opendkim-genkey --subdomains --domain=$domainname --selector=mail -D /tmp/docker-mailserver/opendkim/keys/$domainname
-	fi
+  if [ ! -f "/tmp/docker-mailserver/opendkim/keys/$domainname/mail.private" ]; then
+    echo "Creating DKIM private key /tmp/docker-mailserver/opendkim/keys/$domainname/mail.private"
+    opendkim-genkey --subdomains --domain=$domainname --selector=mail -D /tmp/docker-mailserver/opendkim/keys/$domainname
+  fi
 
-	# Write to KeyTable if necessary
-	keytableentry="mail._domainkey.$domainname $domainname:mail:/etc/opendkim/keys/$domainname/mail.private"
-	if [ ! -f "/tmp/docker-mailserver/opendkim/KeyTable" ]; then
-		echo "Creating DKIM KeyTable"
-		echo $keytableentry > /tmp/docker-mailserver/opendkim/KeyTable
-	else
-		if ! grep -q "$keytableentry" "/tmp/docker-mailserver/opendkim/KeyTable" ; then
-	    	echo $keytableentry >> /tmp/docker-mailserver/opendkim/KeyTable
-		fi
-	fi
+  # Write to KeyTable if necessary
+  keytableentry="mail._domainkey.$domainname $domainname:mail:/etc/opendkim/keys/$domainname/mail.private"
+  if [ ! -f "/tmp/docker-mailserver/opendkim/KeyTable" ]; then
+    echo "Creating DKIM KeyTable"
+    echo $keytableentry > /tmp/docker-mailserver/opendkim/KeyTable
+  else
+    if ! grep -q "$keytableentry" "/tmp/docker-mailserver/opendkim/KeyTable" ; then
+        echo $keytableentry >> /tmp/docker-mailserver/opendkim/KeyTable
+    fi
+  fi
 
-	# Write to SigningTable if necessary
-	signingtableentry="*@$domainname mail._domainkey.$domainname"
-	if [ ! -f "/tmp/docker-mailserver/opendkim/SigningTable" ]; then
-		echo "Creating DKIM SigningTable"
-		echo "*@$domainname mail._domainkey.$domainname" > /tmp/docker-mailserver/opendkim/SigningTable
-	else
-		if ! grep -q "$signingtableentry" "/tmp/docker-mailserver/opendkim/SigningTable" ; then
-	    	echo $signingtableentry >> /tmp/docker-mailserver/opendkim/SigningTable
-		fi
-	fi
+  # Write to SigningTable if necessary
+  signingtableentry="*@$domainname mail._domainkey.$domainname"
+  if [ ! -f "/tmp/docker-mailserver/opendkim/SigningTable" ]; then
+    echo "Creating DKIM SigningTable"
+    echo "*@$domainname mail._domainkey.$domainname" > /tmp/docker-mailserver/opendkim/SigningTable
+  else
+    if ! grep -q "$signingtableentry" "/tmp/docker-mailserver/opendkim/SigningTable" ; then
+      echo $signingtableentry >> /tmp/docker-mailserver/opendkim/SigningTable
+    fi
+  fi
 done
 
 # Creates TrustedHosts if missing
 if [ ! -f "/tmp/docker-mailserver/opendkim/TrustedHosts" ]; then
-	echo "Creating DKIM TrustedHosts";
-	echo "127.0.0.1" > /tmp/docker-mailserver/opendkim/TrustedHosts
-	echo "localhost" >> /tmp/docker-mailserver/opendkim/TrustedHosts
+  echo "Creating DKIM TrustedHosts";
+  echo "127.0.0.1" > /tmp/docker-mailserver/opendkim/TrustedHosts
+  echo "localhost" >> /tmp/docker-mailserver/opendkim/TrustedHosts
 fi
-


### PR DESCRIPTION
The main shell script (start-mailserver.sh) uses two spaces for
indentation. All other shell scripts should use this coding
style.