### PR TITLE
Implement './setup.sh email list'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN curl -s https://letsencrypt.org/certs/lets-encrypt-x1-cross-signed.pem > /et
   curl -s https://letsencrypt.org/certs/lets-encrypt-x2-cross-signed.pem > /etc/ssl/certs/lets-encrypt-x2-cross-signed.pem
 
 # Start-mailserver script
-ADD target/bin/generate-ssl-certificate target/bin/generate-dkim-config target/bin/addmailuser target/bin/delmailuser target/start-mailserver.sh /usr/local/bin/
+ADD target/bin/generate-ssl-certificate target/bin/generate-dkim-config target/bin/addmailuser target/bin/delmailuser target/bin/listmailuser target/start-mailserver.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/*
 
 EXPOSE 25 587 143 993 110 995 4190

--- a/setup.sh
+++ b/setup.sh
@@ -17,7 +17,7 @@ SUBCOMMANDS:
 
     $0 email add <email> <password>
     $0 email del <email>
-    $0 email list (not yet implemented)
+    $0 email list
 
   config:
 
@@ -52,8 +52,9 @@ case $1 in
         _docker delmailuser $@
         ;;
 
-#      list)
-#        ;;
+      list)
+        _docker listmailuser	
+        ;;
 
       *)
         _usage

--- a/target/bin/listmailuser
+++ b/target/bin/listmailuser
@@ -1,0 +1,16 @@
+#! /bin/sh
+
+DATABASE=/tmp/docker-mailserver/postfix-accounts.cf
+
+if [ ! -f "$DATABASE" ]; then
+  echo "The configuration file 'postfix-accounts.cf' doesn't exist. Until now no email addresses have been added."
+  exit 1
+fi
+
+if [ ! -s "$DATABASE" ]; then
+  echo "No email addresses have been added."
+  exit 1
+fi
+
+cat "$DATABASE" | awk -F '|' '{print $1}'
+

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -591,6 +591,12 @@
   [ -z "$output" ]
 }
 
+@test "checking accounts: listmailuser" {
+  run docker exec mail /bin/sh -c "listmailuser | head -n 1"
+  [ "$status" -eq 0 ]
+  [ "$output" = user1@localhost.localdomain ]
+}
+
 @test "checking accounts: no error is generated when deleting a user if /tmp/docker-mailserver/postfix-accounts.cf is missing" {
   run docker run --rm \
     -v "$(pwd)/test/config/without-accounts/":/tmp/docker-mailserver/ \


### PR DESCRIPTION
This commit adds a script nammed 'listmailuser'. './setup.sh' uses this
this script for its subcommand './setup.sh email list'. A test have
been added too.