### PR TITLE
Minor tweaks to letsencrypt configuration.

### DIFF
--- a/test/tests.bats
+++ b/test/tests.bats
@@ -428,11 +428,6 @@
   [ "$output" -eq 2 ]
 }
 
-@test "checking ssl: letsencrypt combined.pem generated correctly" {
-  run docker exec mail_pop3 ls -1 /etc/letsencrypt/live/mail.my-domain.com/combined.pem
-  [ "$status" -eq 0 ]
-}
-
 @test "checking ssl: letsencrypt cert works correctly" {
   run docker exec mail_pop3 /bin/sh -c "timeout 1 openssl s_client -connect 0.0.0.0:587 -starttls smtp -CApath /etc/ssl/certs/ | grep 'Verify return code: 10 (certificate has expired)'"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
The letsencrypt-auto client creates cert.pem, chain.pem, fullchain.pem, and
privkey.pem in its default settings.  The simp_le client creates cert.pem,
fullchain.pem, and key.pem in its default settings.

A check for either privkey.pem or key.pem was added.

The chain.pem file was only used by the letsencrypt code for the creation of
combined.pem, which is not used by either postfix or dovecot.

The code to create a combined.pem file for letsencrypt was removed, as was the
corresponding test.