### PR TITLE
Improve fetchmail support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN curl -s https://letsencrypt.org/certs/lets-encrypt-x1-cross-signed.pem > /et
   curl -s https://letsencrypt.org/certs/lets-encrypt-x2-cross-signed.pem > /etc/ssl/certs/lets-encrypt-x2-cross-signed.pem
 
 # Start-mailserver script
-ADD target/bin/generate-ssl-certificate target/bin/generate-dkim-config target/bin/addmailuser target/bin/delmailuser target/bin/listmailuser target/start-mailserver.sh /usr/local/bin/
+ADD target/bin/generate-ssl-certificate target/bin/generate-dkim-config target/bin/addmailuser target/bin/delmailuser target/bin/listmailuser target/bin/setup-fetchmail target/bin/debug-fetchmail target/start-mailserver.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/*
 
 EXPOSE 25 587 143 993 110 995 4190

--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,7 @@ SUBCOMMANDS:
 
   debug:
 
-    $0 debug fetchmail (not yet implemented)
+    $0 debug fetchmail
 "
   exit 1
 }
@@ -84,7 +84,7 @@ case $1 in
     shift
     case $1 in
       fetchmail)
-        _docker sh -c "cat /etc/fetchmailrc_general /tmp/docker-mailserver/fetchmail.cf > /etc/fetchmailrc; /etc/init.d/fetchmail debug-run"
+        _docker debug-fetchmail
         ;;
     esac
     ;;

--- a/target/bin/debug-fetchmail
+++ b/target/bin/debug-fetchmail
@@ -1,0 +1,10 @@
+#! /bin/sh
+
+/usr/local/bin/setup-fetchmail
+
+su -s /bin/sh -c "/usr/bin/fetchmail \
+	--verbose \
+	--daemon 0 \
+	--nosyslog \
+	--nodetach \
+	-f /etc/fetchmailrc" fetchmail <&- 2>&1

--- a/target/bin/setup-fetchmail
+++ b/target/bin/setup-fetchmail
@@ -1,0 +1,18 @@
+#! /bin/sh
+
+CONF=/tmp/docker-mailserver/fetchmail.cf
+RC=/etc/fetchmailrc
+
+if [ -f "$RC" ]; then
+	echo "The Fetchmail configuration is file '$RC' is already generated."
+	exit 0
+fi
+
+if [ -f "$CONF" ]; then
+	cat /etc/fetchmailrc_general $CONF > $RC
+else
+	cat /etc/fetchmailrc_general > $RC
+fi
+
+chmod 700 $RC
+chown fetchmail:root $RC

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -361,9 +361,7 @@ fi
 
 # Enable fetchmail daemon
 if [ "$ENABLE_FETCHMAIL" = 1 ]; then
-  if [ -f /tmp/docker-mailserver/fetchmail.cf ]; then
-    cat /etc/fetchmailrc_general /tmp/docker-mailserver/fetchmail.cf > /etc/fetchmailrc
-  fi
+  /usr/local/bin/setup-fetchmail
   echo "Fetchmail enabled"
   /etc/init.d/fetchmail start
 fi


### PR DESCRIPTION
Fetchmail is now configured by a script called 'setup-fetchmail'.
The script 'debug-fetchmail' is used inside the 'setup.sh' script.