### PR TITLE
Actually use the key.

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -124,20 +124,20 @@ case $SSL_TYPE in
     && [ -e "/etc/letsencrypt/live/$(hostname)/fullchain.pem" ]; then
       KEY=""
       if [ -e "/etc/letsencrypt/live/$(hostname)/privkey.pem" ]; then
-        KEY="/etc/letsencrypt/live/$(hostname)/privkey.pem"
+        KEY="privkey"
       elif [ -e "/etc/letsencrypt/live/$(hostname)/key.pem" ]; then
-        KEY="/etc/letsencrypt/live/$(hostname)/key.pem"
+        KEY="key"
       fi
       if [ -n "$KEY" ]; then
         echo "Adding $(hostname) SSL certificate"
 
         # Postfix configuration
         sed -i -r 's/smtpd_tls_cert_file=\/etc\/ssl\/certs\/ssl-cert-snakeoil.pem/smtpd_tls_cert_file=\/etc\/letsencrypt\/live\/'$(hostname)'\/fullchain.pem/g' /etc/postfix/main.cf
-        sed -i -r 's/smtpd_tls_key_file=\/etc\/ssl\/private\/ssl-cert-snakeoil.key/smtpd_tls_key_file=\/etc\/letsencrypt\/live\/'$(hostname)'\/privkey.pem/g' /etc/postfix/main.cf
+        sed -i -r 's/smtpd_tls_key_file=\/etc\/ssl\/private\/ssl-cert-snakeoil.key/smtpd_tls_key_file=\/etc\/letsencrypt\/live\/'$(hostname)'\/'"$KEY"'\.pem/g' /etc/postfix/main.cf
 
         # Dovecot configuration
         sed -i -e 's/ssl_cert = <\/etc\/dovecot\/dovecot\.pem/ssl_cert = <\/etc\/letsencrypt\/live\/'$(hostname)'\/fullchain\.pem/g' /etc/dovecot/conf.d/10-ssl.conf
-        sed -i -e 's/ssl_key = <\/etc\/dovecot\/private\/dovecot\.pem/ssl_key = <\/etc\/letsencrypt\/live\/'$(hostname)'\/privkey\.pem/g' /etc/dovecot/conf.d/10-ssl.conf
+        sed -i -e 's/ssl_key = <\/etc\/dovecot\/private\/dovecot\.pem/ssl_key = <\/etc\/letsencrypt\/live\/'$(hostname)'\/'"$KEY"'\.pem/g' /etc/dovecot/conf.d/10-ssl.conf
 
         echo "SSL configured with 'letsencrypt' certificates"
 


### PR DESCRIPTION
This code was mistakenly not committed, and is required for the feature to work.

Functional tests all pass, and I have additionally tested the container in my production environment using keys generated by simp_le.