### PR TITLE
Let Travis CI test on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  except:
+    - donttestme 
 language: bash
 sudo: required
 services:


### PR DESCRIPTION
Most developers implement new docker-mailserver features on feature
branches before they create a pull request. This commit enables Travis
CI testing on all branches except 'donttestme'. Developers now can
'pre-test' their features branches without permanentaly hacking
'.travis.yml'. More testing is good!