### PR TITLE
Improve script 'debug-fetchmail'

### DIFF
--- a/target/bin/debug-fetchmail
+++ b/target/bin/debug-fetchmail
@@ -5,6 +5,7 @@
 su -s /bin/sh -c "/usr/bin/fetchmail \
 	--verbose \
 	--daemon 0 \
+	--check \
 	--nosyslog \
 	--nodetach \
 	-f /etc/fetchmailrc" fetchmail <&- 2>&1


### PR DESCRIPTION
The option '--check' checks for new mails without actually fetching
or deleting mail. Without '--check' 'debug-fetchmail' throws errors if
the external mail accout has new mails and the smtp daemon is not
running.