### PR TITLE
Add the option of manually specifying paths to SSL certificates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,13 @@ run:
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e DISABLE_CLAMAV=1 \
 		-h mail.my-domain.com -t $(NAME)
+	docker run -d --name mail_manual_ssl \
+		-v "`pwd`/test/config":/tmp/docker-mailserver \
+		-v "`pwd`/test":/tmp/docker-mailserver-test \
+		-e SSL_TYPE=manual \
+		-e SSL_CERT_PATH=/tmp/docker-mailserver/letsencrypt/mail.my-domain.com/fullchain.pem \
+		-e SSL_KEY_PATH=/tmp/docker-mailserver/letsencrypt/mail.my-domain.com/privkey.pem \
+		-h mail.my-domain.com -t $(NAME)
 	# Wait for containers to fully start
 	sleep 20
 
@@ -104,4 +111,4 @@ tests:
 
 clean:
 	# Remove running test containers
-	docker rm -f mail mail_pop3 mail_smtponly mail_fail2ban mail_fetchmail fail-auth-mailer mail_disabled_amavis mail_disabled_spamassassin mail_disabled_clamav
+	docker rm -f mail mail_pop3 mail_smtponly mail_fail2ban mail_fetchmail fail-auth-mailer mail_disabled_amavis mail_disabled_spamassassin mail_disabled_clamav mail_manual_ssl

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Before you open an issue, please have a look this `README`, the [Wiki](https://g
 ## Usage
 
 #### Get latest image
- 
+
     docker pull tvial/docker-mailserver:latest
 
 #### Create a `docker-compose.yml`
@@ -70,7 +70,7 @@ Don't forget to adapt MAIL_USER and MAIL_PASS to your needs
       -ti tvial/docker-mailserver:latest \
       /bin/sh -c 'echo "$MAIL_USER|$(doveadm pw -s SHA512-CRYPT -u $MAIL_USER -p $MAIL_PASS)"' >> config/postfix-accounts.cf
 
-#### Generate DKIM keys 
+#### Generate DKIM keys
 
     docker run --rm \
       -v "$(pwd)/config":/tmp/docker-mailserver \
@@ -143,6 +143,7 @@ Otherwise, `iptables` won't be able to ban IPs.
   - **empty** => SSL disabled
   - letsencrypt => Enables Let's Encrypt certificates
   - custom => Enables custom certificates
+  - manual => Let's you manually specify locations of your SSL certificates for non-standard cases
   - self-signed => Enables self-signed certificates
 
 Please read [the SSL page in the wiki](https://github.com/tomav/docker-mailserver/wiki/Configure-SSL) for more information.

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -165,6 +165,30 @@ case $SSL_TYPE in
     fi
     ;;
 
+  "manual" )
+    # Lets you manually specify the location of the SSL Certs to use. This gives you some more control over this whole processes (like using kube-lego to generate certs)
+    if [ -n "$SSL_CERT_PATH" ] \
+    && [ -n "$SSL_KEY_PATH" ]; then
+      echo "Configuring certificates using cert $SSL_CERT_PATH and key $SSL_KEY_PATH"
+      mkdir -p /etc/postfix/ssl
+      cp "$SSL_CERT_PATH" /etc/postfix/ssl/cert
+      cp "$SSL_KEY_PATH" /etc/postfix/ssl/key
+      chmod 600 /etc/postfix/ssl/cert
+      chmod 600 /etc/postfix/ssl/key
+
+      # Postfix configuration
+      sed -i -r 's/smtpd_tls_cert_file=\/etc\/ssl\/certs\/ssl-cert-snakeoil.pem/smtpd_tls_cert_file=\/etc\/postfix\/ssl\/cert/g' /etc/postfix/main.cf
+      sed -i -r 's/smtpd_tls_key_file=\/etc\/ssl\/private\/ssl-cert-snakeoil.key/smtpd_tls_key_file=\/etc\/postfix\/ssl\/key/g' /etc/postfix/main.cf
+
+      # Dovecot configuration
+      sed -i -e 's/ssl_cert = <\/etc\/dovecot\/dovecot\.pem/ssl_cert = <\/etc\/postfix\/ssl\/cert/g' /etc/dovecot/conf.d/10-ssl.conf
+      sed -i -e 's/ssl_key = <\/etc\/dovecot\/private\/dovecot\.pem/ssl_key = <\/etc\/postfix\/ssl\/key/g' /etc/dovecot/conf.d/10-ssl.conf
+
+      echo "SSL configured with 'Manual' certificates"
+
+    fi
+    ;;
+
   "self-signed" )
     # Adding self-signed SSL certificate if provided in 'postfix/ssl' folder
     if [ -e "/tmp/docker-mailserver/ssl/$(hostname)-cert.pem" ] \

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -433,6 +433,33 @@
   [ "$status" -eq 0 ]
 }
 
+@test "checking ssl: manual configuration is correct" {
+  run docker exec mail_manual_ssl /bin/sh -c 'grep -ir "/etc/postfix/ssl/cert" /etc/postfix/main.cf | wc -l'
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+  run docker exec mail_manual_ssl /bin/sh -c 'grep -ir "/etc/postfix/ssl/cert" /etc/dovecot/conf.d/10-ssl.conf | wc -l'
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+  run docker exec mail_manual_ssl /bin/sh -c 'grep -ir "/etc/postfix/ssl/key" /etc/postfix/main.cf | wc -l'
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+  run docker exec mail_manual_ssl /bin/sh -c 'grep -ir "/etc/postfix/ssl/key" /etc/dovecot/conf.d/10-ssl.conf | wc -l'
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
+@test "checking ssl: manual configuration copied files correctly " {
+  run docker exec mail_manual_ssl /bin/sh -c 'cmp -s /etc/postfix/ssl/cert /tmp/docker-mailserver/letsencrypt/mail.my-domain.com/fullchain.pem'
+  [ "$status" -eq 0 ]
+  run docker exec mail_manual_ssl /bin/sh -c 'cmp -s /etc/postfix/ssl/key /tmp/docker-mailserver/letsencrypt/mail.my-domain.com/privkey.pem'
+  [ "$status" -eq 0 ]
+}
+
+@test "checking ssl: manual cert works correctly" {
+  run docker exec mail_manual_ssl /bin/sh -c "timeout 1 openssl s_client -connect 0.0.0.0:587 -starttls smtp -CApath /etc/ssl/certs/ | grep 'Verify return code: 10 (certificate has expired)'"
+  [ "$status" -eq 0 ]
+}
+
 #
 # fail2ban
 #


### PR DESCRIPTION
I needed to directly specify the paths to my SSL certificates to solve getting this running within a Kubernetes cluster where my SSL certificates are managed by kube-lego.

Kubernetes will let me mount the secret volume (which is where the ssl keys are stored) into the container, but the "self signed" and "custom" options really work with that.

This will let you define two additional env variables

SSL_CERT_PATH
SSL_KEY_PATH

Honestly just being able to manually tell what SSL certificates is very handy since obviously not everyone fits in a specific structure. 

Let me know what you think or if there is anything I can improve!