### PR TITLE
Remove unnecessary spamd process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,8 @@ RUN sed -i -e 's/#mail_plugins = \$mail_plugins/mail_plugins = \$mail_plugins si
 COPY target/dovecot/auth-passwdfile.inc /etc/dovecot/conf.d/
 COPY target/dovecot/??-*.conf /etc/dovecot/conf.d/
 
-# Enables Spamassassin and CRON updates
-RUN sed -i -r 's/^(CRON|ENABLED)=0/\1=1/g' /etc/default/spamassassin
+# Enables Spamassassin CRON updates
+RUN sed -i -r 's/^(CRON)=0/\1=1/g' /etc/default/spamassassin
 
 # Enables Amavis
 RUN sed -i -r 's/#(@|   \\%)bypass/\1bypass/g' /etc/amavis/conf.d/15-content_filter_mode

--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,6 @@ run:
 		-e DISABLE_AMAVIS=1 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 20
-	docker run -d --name mail_disabled_spamassassin \
-		-v "`pwd`/test/config":/tmp/docker-mailserver \
-		-v "`pwd`/test":/tmp/docker-mailserver-test \
-		-e DISABLE_SPAMASSASSIN=1 \
-		-h mail.my-domain.com -t $(NAME)
-	sleep 20
 	docker run -d --name mail_disabled_clamav \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
@@ -111,4 +105,4 @@ tests:
 
 clean:
 	# Remove running test containers
-	docker rm -f mail mail_pop3 mail_smtponly mail_fail2ban mail_fetchmail fail-auth-mailer mail_disabled_amavis mail_disabled_spamassassin mail_disabled_clamav mail_manual_ssl
+	docker rm -f mail mail_pop3 mail_smtponly mail_fail2ban mail_fetchmail fail-auth-mailer mail_disabled_amavis mail_disabled_clamav mail_manual_ssl

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -392,9 +392,6 @@ if [ "$ENABLE_FETCHMAIL" = 1 ]; then
 fi
 
 # Start services related to SMTP
-if ! [ "$DISABLE_SPAMASSASSIN" = 1 ]; then
-  /etc/init.d/spamassassin start
-fi
 if ! [ "$DISABLE_CLAMAV" = 1 ]; then
   /etc/init.d/clamav-daemon start
 fi

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -52,11 +52,6 @@
   [ "$status" -eq 1 ]
 }
 
-@test "checking process: spamassassin (spamassassin disabled by DISABLE_SPAMASSASSIN)" {
-  run docker exec mail_disabled_spamassassin /bin/bash -c "ps aux --forest | grep -v grep | grep ''/usr/sbin/spamd'"
-  [ "$status" -eq 1 ]
-}
-
 @test "checking process: clamav (clamav disabled by DISABLE_CLAMAV)" {
   run docker exec mail_disabled_clamav /bin/bash -c "ps aux --forest | grep -v grep | grep '/usr/sbin/clamd'"
   [ "$status" -eq 1 ]


### PR DESCRIPTION
This PR removes `spamd` process from container because of reasons described in #311.