### PR TITLE
Revert "Fix for multiple ipv4" (#306 #310)

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -231,7 +231,7 @@ touch /etc/postfix/vmailbox && postmap /etc/postfix/vmailbox
 touch /etc/postfix/virtual && postmap /etc/postfix/virtual
 
 # PERMIT_DOCKER Option
-container_ip=$(ip addr show eth0 | grep 'inet 172\.' | sed 's/[^0-9\.\/]*//g' | cut -d '/' -f 1)
+container_ip=$(ip addr show eth0 | grep 'inet ' | sed 's/[^0-9\.\/]*//g' | cut -d '/' -f 1)
 container_network="$(echo $container_ip | cut -d '.' -f1-2).0.0"
 case $PERMIT_DOCKER in
   "host" )


### PR DESCRIPTION
This reverts commit e5d14fd0bc79c21e89ebc51ce81e9b31cd1f35d0.
172.0.0.0-172.15.255.255 and 172.32.0.0-172.255.255.255 are valid
external IP addresses. Try PERMIT_DOCKER: network instead.