### PR TITLE
Improve OpenDKIM and OpenDMARC milters integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,7 @@ COPY target/opendkim/default-opendkim /etc/default/opendkim
 # Configure DMARC (opendmarc)
 COPY target/opendmarc/opendmarc.conf /etc/opendmarc.conf
 COPY target/opendmarc/default-opendmarc /etc/default/opendmarc
+COPY target/opendmarc/ignore.hosts /etc/opendmarc/ignore.hosts
 
 # Configure fetchmail
 COPY target/fetchmail/fetchmailrc /etc/fetchmailrc_general

--- a/target/opendkim/default-opendkim
+++ b/target/opendkim/default-opendkim
@@ -9,4 +9,4 @@
 #SOCKET="inet:12345@localhost" # listen on loopback on port 12345
 #SOCKET="inet:12345@192.0.2.1" # listen on 192.0.2.1 on port 12345
 
-SOCKET="inet:12301@localhost"
+SOCKET="inet:8891@localhost"

--- a/target/opendkim/opendkim.conf
+++ b/target/opendkim/opendkim.conf
@@ -4,7 +4,7 @@ UMask                   002
 Syslog                  yes
 SyslogSuccess           Yes
 LogWhy                  Yes
-RemoveOldSignatures	Yes
+RemoveOldSignatures     Yes
 
 Canonicalization        relaxed/simple
 
@@ -19,4 +19,4 @@ SignatureAlgorithm      rsa-sha256
 
 UserID                  opendkim:opendkim
 
-Socket                  inet:12301@localhost
+Socket                  inet:8891@localhost

--- a/target/opendmarc/default-opendmarc
+++ b/target/opendmarc/default-opendmarc
@@ -8,4 +8,5 @@
 #SOCKET="inet:54321" # listen on all interfaces on port 54321
 #SOCKET="inet:12345@localhost" # listen on loopback on port 12345
 #SOCKET="inet:12345@192.0.2.1" # listen on 192.0.2.1 on port 12345
-SOCKET="inet:54321@localhost"
+
+SOCKET="inet:8893@localhost"

--- a/target/opendmarc/ignore.hosts
+++ b/target/opendmarc/ignore.hosts
@@ -1,0 +1,1 @@
+localhost

--- a/target/opendmarc/opendmarc.conf
+++ b/target/opendmarc/opendmarc.conf
@@ -1,8 +1,12 @@
+UserID   opendmarc:opendmarc
+UMask    0002
+PidFile  /var/run/opendmarc.pid
+Syslog   true
 
-PidFile /var/run/opendmarc.pid
-RejectFailures false
-Syslog true
-UMask 0002
-UserID opendmarc:opendmarc
-IgnoreHosts /etc/opendmarc/ignore.hosts
-HistoryFile /var/run/opendmarc/opendmarc.dat
+RejectFailures  false
+
+IgnoreHosts  /etc/opendmarc/ignore.hosts
+HistoryFile  /var/run/opendmarc/opendmarc.dat
+
+AuthservID          HOSTNAME
+TrustedAuthservIDs  HOSTNAME

--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -67,7 +67,9 @@ virtual_alias_maps = hash:/etc/postfix/virtual
 content_filter = smtp-amavis:[127.0.0.1]:10024
 
 # Milters used by DKIM
-milter_protocol = 2
+milter_protocol = 6
 milter_default_action = accept
-smtpd_milters = inet:localhost:12301,inet:localhost:54321
-non_smtpd_milters = inet:localhost:12301,inet:localhost:54321
+dkim_milter = inet:localhost:8891
+dmarc_milter = inet:localhost:8893
+smtpd_milters = $dkim_milter,$dmarc_milter
+non_smtpd_milters = $dkim_milter

--- a/target/postfix/master.cf
+++ b/target/postfix/master.cf
@@ -93,5 +93,5 @@ smtp-amavis     unix    -       -       -       -       2       smtp
   -o smtpd_hard_error_limit=1000
   -o smtpd_client_connection_count_limit=0
   -o smtpd_client_connection_rate_limit=0
-  -o receive_override_options=no_header_body_checks,no_unknown_recipient_checks
+  -o receive_override_options=no_header_body_checks,no_unknown_recipient_checks,no_milters
   -o smtp_tls_security_level=none

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -109,19 +109,6 @@ else
   echo "No DKIM key provided. Check the documentation to find how to get your keys."
 fi
 
-# DMARC
-# if there is no AuthservID create it
-if [ `cat /etc/opendmarc.conf | grep -w AuthservID | wc -l` -eq 0 ]; then
-  echo "AuthservID $(hostname)" >> /etc/opendmarc.conf
-fi
-if [ `cat /etc/opendmarc.conf | grep -w TrustedAuthservIDs | wc -l` -eq 0 ]; then
-  echo "TrustedAuthservIDs $(hostname)" >> /etc/opendmarc.conf
-fi
-if [ ! -f "/etc/opendmarc/ignore.hosts" ]; then
-  mkdir -p /etc/opendmarc/
-  echo "localhost" >> /etc/opendmarc/ignore.hosts
-fi
-
 # SSL Configuration
 case $SSL_TYPE in
   "letsencrypt" )

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -380,22 +380,6 @@
 }
 
 #
-# opendmarc
-#
-
-@test "checking opendkim: server fqdn should be added to /etc/opendmarc.conf as AuthservID" {
-  run docker exec mail grep ^AuthservID /etc/opendmarc.conf
-  [ "$status" -eq 0 ]
-  [ "$output" = "AuthservID mail.my-domain.com" ]
-}
-
-@test "checking opendkim: server fqdn should be added to /etc/opendmarc.conf as TrustedAuthservIDs" {
-  run docker exec mail grep ^TrustedAuthservID /etc/opendmarc.conf
-  [ "$status" -eq 0 ]
-  [ "$output" = "TrustedAuthservIDs mail.my-domain.com" ]
-}
-
-#
 # ssl
 #
 


### PR DESCRIPTION
This PR provides some improvements for current milters integration inside container:

1. Upgrades `milter_protocol` from `2` to `6`. It seems that there is no reason to keep it `2`, because all apps that uses it (OpenDKIM, OpenDMARC) already supports `6` with their current versions.
2. Disables OpenDMARC milter for outgoing mails as far as it does no job. [DMARC relies on SPF and DKIM](https://dmarc.org/wiki/FAQ#How_does_DMARC_work.2C_briefly.2C_and_in_non-technical_terms.3F) and there is nothing to do with outgoing messages for it (opposite to OpenDKIM which must sign messages).
3. Disables duplicate milters checking when we receive mail back from AMaViS on `10025` Postfix port. Miltering before sending mail to AMaViS is enough.
4. Sets OpenDKIM and OpenDMARC to listen on more "traditional" ports `8891` and `8893`. See blockquote description in [this tutorial](http://www.stevejenkins.com/blog/2015/03/installing-opendmarc-rpm-via-yum-with-postfix-or-sendmail-for-rhel-centos-fedora/) to find out why these numbers are meant to be more "traditional".
5. Configures OpenDMARC parameters `AuthservID` and `TrustedAuthservIDs` with `HOSTNAME` value which, accordingly to [documentation](http://www.trusteddomain.org/opendmarc/opendmarc.conf.5.html), will automatically resolve to container hostname. So no need to inject those values in `start-mailserver.sh` script.
6. Relatively to previous one, moves creating of `/etc/opendmarc/ignore.hosts` file to `Dockerfile` instead of `start-mailserver.sh`.