### PR TITLE
Use "texthash" Postfix lookup format instead of "hash"

### DIFF
--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -7,8 +7,8 @@ readme_directory = no
 
 # Basic configuration
 # myhostname = 
-alias_maps = hash:/etc/aliases
-alias_database = hash:/etc/aliases
+alias_maps = texthash:/etc/aliases
+alias_database = texthash:/etc/aliases
 mydestination = 
 relayhost = 
 mynetworks = 127.0.0.0/8 [::1]/128 [fe80::]/64
@@ -59,8 +59,8 @@ broken_sasl_auth_clients = yes
 # Mail directory
 virtual_transport = lmtp:unix:/var/run/dovecot/lmtp
 virtual_mailbox_domains = /etc/postfix/vhost
-virtual_mailbox_maps = hash:/etc/postfix/vmailbox
-virtual_alias_maps = hash:/etc/postfix/virtual
+virtual_mailbox_maps = texthash:/etc/postfix/vmailbox
+virtual_alias_maps = texthash:/etc/postfix/virtual
 
 # Additional option for filtering
 content_filter = smtp-amavis:[127.0.0.1]:10024

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -123,8 +123,8 @@
   [ "$status" -eq 0 ]
 }
 
-@test "checking sasl: sasl_passwd.db exists" {
-  run docker exec mail [ -f /etc/postfix/sasl_passwd.db ]
+@test "checking sasl: sasl_passwd exists" {
+  run docker exec mail [ -f /etc/postfix/sasl_passwd ]
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
As far as Postfix setup inside Docker container does not require to re-apply configuration on-fly, and reconfiguration is done with container restarts (which actually stops and starts Postfix) we can use [`texthash:` Postfix lookup format](http://www.postfix.org/DATABASE_README.html#types) instead of `hash:`, which allows us don't mess with pre-`postmap` commands.

Also, I changed a bit handling of such lookup files to make them survive container restarts a bit better. Initially, if we create a container with accounts configuration, then remove all accounts and restart container, those accounts will be in lookup files still. I made them stripped before accounts configuration is applied.