### PR TITLE
Override hostname for kubernetes et al.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ Otherwise, `iptables` won't be able to ban IPs.
   - **empty** => admin
   - => Specify the password to bind against ldap
 
+##### OVERRIDE_HOSTNAE
+
+  - **empty** => uses the `hostname` command to get the mail server's canonical hostname
+  - => Specify a fully-qualified domainname to serve mail for.  This is used for many of the config features so if you can't set your hostname (e.g. you're in a container platform that doesn't let you) specify it in this environment variable.
+
 ##### POSTMASTER_ADDRESS
 
   - **empty** => postmaster@domain.com

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -417,6 +417,9 @@ SA_TAG2=${SA_TAG2:="6.31"} && sed -i -r 's/^\$sa_tag2_level_deflt (.*);/\$sa_tag
 SA_KILL=${SA_KILL:="6.31"} && sed -i -r 's/^\$sa_kill_level_deflt (.*);/\$sa_kill_level_deflt = '$SA_KILL';/g' /etc/amavis/conf.d/20-debian_defaults
 test -e /tmp/docker-mailserver/spamassassin-rules.cf && cp /tmp/docker-mailserver/spamassassin-rules.cf /etc/spamassassin/
 
+echo "Overriding hostname of amavis"
+sed -i 's/^#\$myhostname = "mail.example.com";/\$myhostname = "'$HOSTNAME'";/' /etc/amavis/conf.d/05-node_id
+
 if [ "$ENABLE_FAIL2BAN" = 1 ]; then
   echo "Fail2ban enabled"
   test -e /tmp/docker-mailserver/fail2ban-jail.cf && cp /tmp/docker-mailserver/fail2ban-jail.cf /etc/fail2ban/jail.local

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -22,11 +22,6 @@ else
   DOMAINNAME=$(echo $OVERRIDE_HOSTNAME | sed s/[^.]*.//)
 fi
 
-echo HOSTNAME $HOSTNAME
-echo DOMAINNAME $DOMAINNAME
-die "debugging"
-
-
 #
 # Default variables
 #


### PR DESCRIPTION
In kubernetes land, it's not possible to set the hostname of a container, it's always set to a variation of the pod name, with random characters in it.

This PR should allow the env var OVERRIDE_HOSTNAME to replace the hostname commands that are used in the script.