### PR TITLE
use strong tls and ciphers

### DIFF
--- a/target/dovecot/10-ssl.conf
+++ b/target/dovecot/10-ssl.conf
@@ -46,13 +46,13 @@ ssl_key = </etc/dovecot/private/dovecot.pem
 #ssl_dh_parameters_length = 1024
 
 # SSL protocols to use
-#ssl_protocols = !SSLv2
+ssl_protocols = TLSv1 TLSv1.1 TLSv1.2
 
 # SSL ciphers to use
-#ssl_cipher_list = ALL:!LOW:!SSLv2:!EXP:!aNULL
+ssl_cipher_list = ECDHE+AESGCM ECDHE+AES DHE+AESGCM DHE+AES DES-CBC3-SHA
 
 # Prefer the server's order of ciphers over client's.
-#ssl_prefer_server_ciphers = no
+ssl_prefer_server_ciphers = yes
 
 # SSL crypto device to use, for valid values run "openssl engine"
 #ssl_crypto_device =


### PR DESCRIPTION
Postfix configuration use strong protocols and ciphers, I don't know if there is a good reason for not using them in dovecot.