### PR TITLE
Fail2ban fix for restarting container

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -840,6 +840,10 @@ function _start_daemons_saslauthd() {
 function _start_daemons_fail2ban() {
 	notify 'task' 'Starting fail2ban'
 	touch /var/log/auth.log
+	# Delete fail2ban.sock that probably was left here after container restart
+  	if [ -e /var/run/fail2ban/fail2ban.sock ]; then
+    	  rm /var/run/fail2ban/fail2ban.sock
+  	fi
 	/etc/init.d/fail2ban start
 }
 


### PR DESCRIPTION
Fail2ban doesn't seems to shutdown cleanly and leaves fail2ban.sock file that prevent it from starting after a container restart. That simple check should do the trick.