### PR TITLE
Fix Problem with Saslauthd and Postfix master.cf

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -442,6 +442,11 @@ log_level: 10
 EOF
 	fi
 
+		 sed -i \
+		 -e "/^[^#].*smtpd_sasl_type.*/s/^/#/g" \
+		 -e "/^[^#].*smtpd_sasl_path.*/s/^/#/g" \
+		 etc/postfix/master.cf
+
 	sed -i \
 		-e "s|^START=.*|START=yes|g" \
 		-e "s|^MECHANISMS=.*|MECHANISMS="\"$SASLAUTHD_MECHANISMS\""|g" \


### PR DESCRIPTION
The provided default postfix master.cf overwrites the configs for
saslauthd within main.cf. To make saslauthd work, we have to comment or
in this case delete the lines from master.cf to make the given configs
in main.cf work.