### PR TITLE
BREAKING CHANGES:

### DIFF
--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   mail:
-    image: tvial/docker-mailserver:v2
+    image: tvial/docker-mailserver:v2.1
     hostname: mail
     domainname: domain.com
     container_name: mail
@@ -13,12 +13,19 @@ services:
     - "993:993"
     volumes:
     - maildata:/var/mail
+    - mailstate:/var/mail-state
     - ./config/:/tmp/docker-mailserver/
     environment:
+    - ENABLE_SPAMASSASSIN=1
+    - ENABLE_CLAMAV=1
     - ENABLE_FAIL2BAN=1
+    - ONE_DIR=1
+    - DMS_DEBUG=0
     cap_add:
     - NET_ADMIN
 
 volumes:
   maildata:
+    driver: local
+  mailstate:
     driver: local


### PR DESCRIPTION
* Removed DISABLE_AMAVIS
* Renamed DISABLE_* to ENABLE_* with 0 as default value. (this must be explicit)
* Added missing tests for ENABLE_*
* Improved readme and docker-compose example

Should fix #256 and #386

This will be released as `tvial/docker-mailserver:2.1`