### PR TITLE
Fix mailuser tools

### DIFF
--- a/target/bin/addmailuser
+++ b/target/bin/addmailuser
@@ -1,29 +1,32 @@
-#!/bin/bash
+#! /bin/bash
 
-DATABASE=/tmp/docker-mailserver/postfix-accounts.cf
+DATABASE=${DATABASE:-/tmp/docker-mailserver/postfix-accounts.cf}
 
-function usage {
-  echo 'Usage: addmailuser <user@domain.tld> [password]'
-  exit 1
+USER="$1"
+PASSWD="$2"
+
+usage() {
+	echo "Usage: addmailuser <user@domain> [<password>]"
 }
 
-if [ ! -z "$1" ]; then
-  USER=$1
-  if [ -e "$DATABASE" ] && [ ! -z "$(grep $USER -i $DATABASE)" ]; then
-    echo "User already exists"
-    exit 1
-  fi
-  if [ ! -z "$2" ]; then
-    PASS="$2"
-  else
-    read -s -p "Enter Password: " PASS
-    if [ -z "$PASS" ]; then
-      echo "Password can't be empty"
-      exit 1
-    fi
-  fi
-  ENTRY=$(echo "$USER|$(doveadm pw -s SHA512-CRYPT -u "$USER" -p "$PASS")")
-  echo "$ENTRY" >> $DATABASE
-else
-  usage
+errex() {
+	echo "$@" 1>&2
+	exit 1
+}
+
+escape() {
+	echo "${1//./\\.}"
+}
+
+[ -z "$USER" ] && { usage; errex "no username specified"; }
+
+grep -qi "^$(escape "$USER")|" $DATABASE 2>/dev/null &&
+	errex "User \"$USER\" already exists"
+
+if [ -z "$PASSWD" ]; then
+	read -s -p "Enter Password: " PASSWD
+	echo
+	[ -z "$PASSWD" ] && errex "Password must not be empty"
 fi
+
+echo "$USER|$(doveadm pw -s SHA512-CRYPT -u "$USER" -p "$PASSWD")" >>$DATABASE

--- a/target/bin/delmailuser
+++ b/target/bin/delmailuser
@@ -1,18 +1,24 @@
-#!/bin/bash
+#! /bin/bash
 
-DATABASE=/tmp/docker-mailserver/postfix-accounts.cf
+DATABASE=${DATABASE:-/tmp/docker-mailserver/postfix-accounts.cf}
 
-function usage {
-  echo "Usage: delmailuser <user@domain.tld>"
-   exit 1
+USER="$1"
+
+usage() {
+	echo "Usage: delmailuser <user@domain>"
 }
 
-if [ ! -z "$1" ]; then
-  USER=$1
-  if [ -f "$DATABASE" ]; then
-    ENTRIES=$(grep "$USER" -vi $DATABASE)
-    echo "$ENTRIES" > $DATABASE
-  fi
-else
-  usage
-fi
+errex() {
+	echo "$@" 1>&2
+	exit 1
+}
+
+escape() {
+	echo "${1//./\\.}"
+}
+
+[ -z "$USER" ] && { usage; errex "No user specifed"; }
+[ -s "$DATABASE" ] || exit 0
+
+# XXX $USER must not contain /s and other syntactic characters
+sed -i "/^$(escape "$USER")|/d" $DATABASE

--- a/target/bin/listmailuser
+++ b/target/bin/listmailuser
@@ -1,16 +1,13 @@
-#! /bin/sh
+#! /bin/bash
 
-DATABASE=/tmp/docker-mailserver/postfix-accounts.cf
+DATABASE=${DATABASE:-/tmp/docker-mailserver/postfix-accounts.cf}
 
-if [ ! -f "$DATABASE" ]; then
-  echo "The configuration file 'postfix-accounts.cf' doesn't exist. Until now no email addresses have been added."
-  exit 1
-fi
+errex() {
+	echo "$@" 1>&2
+	exit 1
+}
 
-if [ ! -s "$DATABASE" ]; then
-  echo "No email addresses have been added."
-  exit 1
-fi
+[ -f $DATABASE ] || errex "No postfix-accounts.cf file"
+[ -s $DATABASE ] || errex "Empty postfix-accounts.cf - no users have been added"
 
-cat "$DATABASE" | awk -F '|' '{print $1}'
-
+awk -F '|' '{ print $1; }' $DATABASE

--- a/target/bin/updatemailuser
+++ b/target/bin/updatemailuser
@@ -1,29 +1,27 @@
-#!/bin/bash
+#! /bin/bash
 
-DATABASE=/tmp/docker-mailserver/postfix-accounts.cf
+DATABASE=${DATABASE:-/tmp/docker-mailserver/postfix-accounts.cf}
 
-function usage {
-  echo 'Usage: updatemailuser <user@domain.tld> [password]'
-  exit 1
+USER="$1"
+PASSWD="$2"
+
+usage() {
+	echo "Usage: updatemailuser <user@domain.tld> [password]"
 }
 
-if [ ! -z "$1" ]; then
-  USER=$1
-  if [ -e "$DATABASE" ] && [ -z "$(grep $USER -i $DATABASE)" ]; then
-    echo "User doesn't exist"
-    exit 1
-  fi
-  if [ ! -z "$2" ]; then
-    PASS="$2"
-  else
-    read -s -p "Enter Password: " PASS
-    if [ -z "$PASS" ]; then
-      echo "Password can't be empty"
-      exit 1
-    fi
-  fi
-  ENTRY=$(echo "$USER|$(doveadm pw -s SHA512-CRYPT -u "$USER" -p "$PASS")")
-  sed -i.bak "s%^$USER.*%$ENTRY%g" $DATABASE 
-else
-  usage
-fi
+errex() {
+	echo "$@" 1>&2
+	exit 1
+}
+
+escape() {
+	echo "${1//./\\.}"
+}
+
+[ -z "$USER" ] && { usage; errex "no username specified"; }
+
+grep -qi "^$(escape "$USER")|" $DATABASE 2>/dev/null ||
+	errex "User \"$USER\" does not exist"
+
+delmailuser "$USER"
+addmailuser "$USER" "$PASSWD"

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -565,7 +565,7 @@
 }
 
 @test "checking amavis: VIRUSMAILS_DELETE_DELAY override works as expected" {
-  run docker run -ti --rm -e VIRUSMAILS_DELETE_DELAY=2 `docker inspect --format '{{ .Config.Image }}' mail` /bin/bash -c 'echo $VIRUSMAILS_DELETE_DELAY | grep 2' 
+  run docker run -ti --rm -e VIRUSMAILS_DELETE_DELAY=2 `docker inspect --format '{{ .Config.Image }}' mail` /bin/bash -c 'echo $VIRUSMAILS_DELETE_DELAY | grep 2'
   [ "$status" -eq 0 ]
 }
 
@@ -653,17 +653,37 @@
 @test "checking accounts: user3 should have been added to /tmp/docker-mailserver/postfix-accounts.cf" {
   docker exec mail /bin/sh -c "addmailuser user3@domain.tld mypassword"
 
-  run docker exec mail /bin/sh -c "grep user3@domain.tld -i /tmp/docker-mailserver/postfix-accounts.cf"
+  run docker exec mail /bin/sh -c "grep '^user3@domain\.tld|' -i /tmp/docker-mailserver/postfix-accounts.cf"
   [ "$status" -eq 0 ]
   [ ! -z "$output" ]
 }
 
-@test "checking accounts: user3 should have been removed from /tmp/docker-mailserver/postfix-accounts.cf" {
+@test "checking accounts: auser3 should have been added to /tmp/docker-mailserver/postfix-accounts.cf" {
+  docker exec mail /bin/sh -c "addmailuser auser3@domain.tld mypassword"
+
+  run docker exec mail /bin/sh -c "grep '^auser3@domain\.tld|' -i /tmp/docker-mailserver/postfix-accounts.cf"
+  [ "$status" -eq 0 ]
+  [ ! -z "$output" ]
+}
+
+@test "checking accounts: a.ser3 should have been added to /tmp/docker-mailserver/postfix-accounts.cf" {
+  docker exec mail /bin/sh -c "addmailuser a.ser3@domain.tld mypassword"
+
+  run docker exec mail /bin/sh -c "grep '^a\.ser3@domain\.tld|' -i /tmp/docker-mailserver/postfix-accounts.cf"
+  [ "$status" -eq 0 ]
+  [ ! -z "$output" ]
+}
+
+@test "checking accounts: user3 should have been removed from /tmp/docker-mailserver/postfix-accounts.cf but not auser3" {
   docker exec mail /bin/sh -c "delmailuser user3@domain.tld"
 
-  run docker exec mail /bin/sh -c "grep user3@domain.tld -i /tmp/docker-mailserver/postfix-accounts.cf"
+  run docker exec mail /bin/sh -c "grep '^user3@domain\.tld' -i /tmp/docker-mailserver/postfix-accounts.cf"
   [ "$status" -eq 1 ]
   [ -z "$output" ]
+
+  run docker exec mail /bin/sh -c "grep '^auser3@domain\.tld' -i /tmp/docker-mailserver/postfix-accounts.cf"
+  [ "$status" -eq 0 ]
+  [ ! -z "$output" ]
 }
 
 @test "checking user updating password for user in /tmp/docker-mailserver/postfix-accounts.cf" {
@@ -705,6 +725,7 @@
   run docker run --rm \
     -v "$(pwd)/test/config/without-accounts/":/tmp/docker-mailserver/ \
     `docker inspect --format '{{ .Config.Image }}' mail` /bin/sh -c 'addmailuser user3@domain.tld mypassword'
+  [ "$status" -eq 0 ]
   run docker run --rm \
     -v "$(pwd)/test/config/without-accounts/":/tmp/docker-mailserver/ \
     `docker inspect --format '{{ .Config.Image }}' mail` /bin/sh -c 'grep user3@domain.tld -i /tmp/docker-mailserver/postfix-accounts.cf'

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -687,13 +687,13 @@
 }
 
 @test "checking user updating password for user in /tmp/docker-mailserver/postfix-accounts.cf" {
-  docker exec mail /bin/sh -c "addmailuser user3@domain.tld mypassword"
+  docker exec mail /bin/sh -c "addmailuser user4@domain.tld mypassword"
 
-  initialpass=$(run docker exec mail /bin/sh -c "grep user3@domain.tld -i /tmp/docker-mailserver/postfix-accounts.cf")
+  initialpass=$(run docker exec mail /bin/sh -c "grep '^user4@domain\.tld' -i /tmp/docker-mailserver/postfix-accounts.cf")
   sleep 2
-  docker exec mail /bin/sh -c "updatemailuser user3@domain.tld mynewpassword"
+  docker exec mail /bin/sh -c "updatemailuser user4@domain.tld mynewpassword"
   sleep 2
-  changepass=$(run docker exec mail /bin/sh -c "grep user3@domain.tld -i /tmp/docker-mailserver/postfix-accounts.cf")
+  changepass=$(run docker exec mail /bin/sh -c "grep '^user4@domain\.tld' -i /tmp/docker-mailserver/postfix-accounts.cf")
 
   if [ initialpass != changepass ]; then
     status="0"
@@ -701,7 +701,7 @@
     status="1"
   fi
 
-  docker exec mail /bin/sh -c "delmailuser user3@domain.tld"
+  docker exec mail /bin/sh -c "delmailuser auser3@domain.tld"
 
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
I tried to refactor and improve the mailuser tools (add/del/list and update). Certain user names were not exactly matched by the patterns: e.g. "user@domain" matched also "anotheruser@domain", or "a.user@domain" matched "anuser@domain".

I appreciate your project very much, it is really useful to me! Thank you so much!