### PR TITLE
Fix #443 - RIMAP support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,15 @@ run:
 		-e POSTMASTER_ADDRESS=postmaster@localhost.localdomain \
 		--link ldap_for_mail:ldap \
 		-h mail.my-domain.com -t $(NAME)
+	sleep 15
+	docker run -d --name mail_with_imap \
+		-v "`pwd`/test/config":/tmp/docker-mailserver \
+		-v "`pwd`/test":/tmp/docker-mailserver-test \
+		-e ENABLE_SASLAUTHD=1 \
+		-e SASLAUTHD_MECHANISMS=rimap \
+		-e SASLAUTHD_MECH_OPTIONS=127.0.0.1 \
+		-e POSTMASTER_ADDRESS=postmaster@localhost.localdomain \
+		-h mail.my-domain.com -t $(NAME)
 	# Wait for containers to fully start
 	sleep 15
 
@@ -140,7 +149,8 @@ clean:
 		mail_disabled_clamav_spamassassin \
 		mail_manual_ssl \
 		ldap_for_mail \
-		mail_with_ldap
+		mail_with_ldap \
+		mail_with_imap
 
 	@if [ -f config/postfix-accounts.cf.bak ]; then\
 		rm -f config/postfix-accounts.cf ;\

--- a/test/auth/sasl-imap-smtp-auth.txt
+++ b/test/auth/sasl-imap-smtp-auth.txt
@@ -1,0 +1,5 @@
+EHLO mail
+AUTH LOGIN
+dXNlcjFAbG9jYWxob3N0LmxvY2FsZG9tYWlu
+bXlwYXNzd29yZA==
+QUIT

--- a/test/auth/sasl-imap-smtp-auth.txt
+++ b/test/auth/sasl-imap-smtp-auth.txt
@@ -1,5 +1,0 @@
-EHLO mail
-AUTH LOGIN
-dXNlcjFAbG9jYWxob3N0LmxvY2FsZG9tYWlu
-bXlwYXNzd29yZA==
-QUIT

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -905,6 +905,6 @@
 }
 
 @test "checking saslauthd: rimap smtp authentication" {
-  run docker exec mail_with_imap /bin/sh -c "nc -w 5 0.0.0.0 25 < /tmp/docker-mailserver-test/auth/sasl-imap-smtp-auth.txt | grep 'Authentication successful'"
+  run docker exec mail_with_imap /bin/sh -c "nc -w 5 0.0.0.0 25 < /tmp/docker-mailserver-test/auth/smtp-auth-login.txt | grep 'Authentication successful'"
   [ "$status" -eq 0 ]
 }

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -66,6 +66,11 @@
   [ "$status" -eq 0 ]
 }
 
+@test "checking process: saslauthd (saslauthd server enabled)" {
+  run docker exec mail_with_imap /bin/bash -c "ps aux --forest | grep -v grep | grep '/usr/sbin/saslauthd'"
+  [ "$status" -eq 0 ]
+}
+
 #
 # imap
 #
@@ -879,5 +884,27 @@
 
 @test "checking saslauthd: ldap smtp authentication" {
   run docker exec mail_with_ldap /bin/sh -c "nc -w 5 0.0.0.0 25 < /tmp/docker-mailserver-test/auth/sasl-ldap-smtp-auth.txt | grep 'Authentication successful'"
+  [ "$status" -eq 0 ]
+}
+
+
+#
+# RIMAP
+#
+
+# dovecot
+@test "checking dovecot: ldap rimap connection and authentication works" {
+  run docker exec mail_with_imap /bin/sh -c "nc -w 1 0.0.0.0 143 < /tmp/docker-mailserver-test/auth/imap-auth.txt"
+  [ "$status" -eq 0 ]
+}
+
+# saslauthd
+@test "checking saslauthd: sasl rimap authentication works" {
+  run docker exec mail_with_imap bash -c "testsaslauthd -u user1@localhost.localdomain -p mypassword"
+  [ "$status" -eq 0 ]
+}
+
+@test "checking saslauthd: rimap smtp authentication" {
+  run docker exec mail_with_imap /bin/sh -c "nc -w 5 0.0.0.0 25 < /tmp/docker-mailserver-test/auth/sasl-imap-smtp-auth.txt | grep 'Authentication successful'"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
#443

- Added unit tests to rimap sasl mechanism
- Enabled sasl auth in postfix when rimap mechanism is selected
- Additionally, it seems necessary to start saslauthd with option "-r" ("Combine the realm with the login") in that case