### PR TITLE
Docker tag fix

### DIFF
--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   mail:
-    image: tvial/docker-mailserver:v2.1
+    image: tvial/docker-mailserver:2.1
     hostname: mail
     domainname: domain.com
     container_name: mail


### PR DESCRIPTION
On Docker Hub, the tag for **v2.1** is labeled **2.1**