### PR TITLE
Fix update in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -118,7 +118,7 @@ case $1 in
         ;;
       update)
         shift
-        _docker_image updatemailuser
+        _docker_image updatemailuser $@
         ;;
       del)
         shift


### PR DESCRIPTION
The updatemailuser needs parameters. Without this, the command can not work and fails with:

```
Usage: updatemailuser <user@domain.tld> [password]
no username specified

```