### PR TITLE
Hostname override fixes for docker option --net=host in conjunction with OVERRIDE_HOSTNAME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,14 @@ run:
 		-e OVERRIDE_HOSTNAME=mail.my-domain.com \
 		-t $(NAME)
 	sleep 15
+	docker run -d --name mail_override_hostname \
+		-v "`pwd`/test/config":/tmp/docker-mailserver \
+		-v "`pwd`/test":/tmp/docker-mailserver-test \
+		-e PERMIT_DOCKER=network \
+		-e OVERRIDE_HOSTNAME=mail.my-domain.com \
+		-h unknown.domain.tld \
+		-t $(NAME)
+	sleep 15
 	docker run -d --name mail_fail2ban \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
@@ -151,6 +159,8 @@ fixtures:
 	docker exec mail_disabled_clamav_spamassassin /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user.txt"
 	# postfix virtual transport lmtp
 	docker exec mail_lmtp_ip /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user.txt"
+
+	docker exec mail_override_hostname /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user.txt"
 	# Wait for mails to be analyzed
 	sleep 20
 
@@ -173,7 +183,8 @@ clean:
 		mail_with_ldap \
 		mail_with_imap \
 		mail_lmtp_ip \
-		mail_with_postgrey
+		mail_with_postgrey \
+		mail_override_hostname
 
 	@if [ -f config/postfix-accounts.cf.bak ]; then\
 		rm -f config/postfix-accounts.cf ;\

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -104,7 +104,7 @@ function register_functions() {
 
 	_register_setup_function "_setup_mailname"
 	_register_setup_function "_setup_amavis"
-	_register_setup_function "_setup_dmarc"
+	_register_setup_function "_setup_dmarc_hostname"
 	_register_setup_function "_setup_postfix_hostname"
 	_register_setup_function "_setup_dovecot_hostname"
 
@@ -398,7 +398,7 @@ function _setup_amavis() {
 	sed -i 's/^#\$myhostname = "mail.example.com";/\$myhostname = "'$HOSTNAME'";/' /etc/amavis/conf.d/05-node_id
 }
 
-function _setup_dmarc() {
+function _setup_dmarc_hostname() {
 	notify 'task' 'Setting up dmarc'
 
 	notify 'inf' "Applying hostname to /etc/opendmarc.conf"
@@ -407,7 +407,7 @@ function _setup_dmarc() {
 }
 
 function _setup_postfix_hostname() {
-	notify 'task' 'Applying hostname and domainname to postfix/main.cf'
+	notify 'task' 'Applying hostname and domainname to Postfix'
 
 	notify 'inf' "Applying hostname to /etc/postfix/main.cf"
 	postconf -e "myhostname = $HOSTNAME"

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -104,6 +104,9 @@ function register_functions() {
 
 	_register_setup_function "_setup_mailname"
 	_register_setup_function "_setup_amavis"
+	_register_setup_function "_setup_dmarc"
+	_register_setup_function "_setup_postfix_hostname"
+	_register_setup_function "_setup_dovecot_hostname"
 
 	_register_setup_function "_setup_postfix_override_configuration"
 	_register_setup_function "_setup_postfix_sasl_password"
@@ -393,6 +396,29 @@ function _setup_amavis() {
 
 	notify 'inf' "Applying hostname to /etc/amavis/conf.d/05-node_id"
 	sed -i 's/^#\$myhostname = "mail.example.com";/\$myhostname = "'$HOSTNAME'";/' /etc/amavis/conf.d/05-node_id
+}
+
+function _setup_dmarc() {
+	notify 'task' 'Setting up dmarc'
+
+	notify 'inf' "Applying hostname to /etc/opendmarc.conf"
+	sed -i -e 's/^AuthservID.*$/AuthservID          '$HOSTNAME'/g' \
+	       -e 's/^TrustedAuthservIDs.*$/TrustedAuthservIDs  '$HOSTNAME'/g' /etc/opendmarc.conf
+}
+
+function _setup_postfix_hostname() {
+	notify 'task' 'Applying hostname and domainname to postfix/main.cf'
+
+	notify 'inf' "Applying hostname to /etc/postfix/main.cf"
+	postconf -e "myhostname = $HOSTNAME"
+	postconf -e "mydomain = $DOMAINNAME"
+}
+
+function _setup_dovecot_hostname() {
+	notify 'task' 'Applying hostname to Dovecot'
+
+	notify 'inf' "Applying hostname to /etc/postfix/main.cf"
+	sed -e 's/^#hostname =.*$/hostname = '$HOSTNAME'/g' /etc/dovecot/conf.d/15-lda.conf
 }
 
 function _setup_dovecot() {

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -417,8 +417,8 @@ function _setup_postfix_hostname() {
 function _setup_dovecot_hostname() {
 	notify 'task' 'Applying hostname to Dovecot'
 
-	notify 'inf' "Applying hostname to /etc/postfix/main.cf"
-	sed -e 's/^#hostname =.*$/hostname = '$HOSTNAME'/g' /etc/dovecot/conf.d/15-lda.conf
+	notify 'inf' "Applying hostname to /etc/dovecot/conf.d/15-lda.conf"
+	sed -i 's/^#hostname =.*$/hostname = '$HOSTNAME'/g' /etc/dovecot/conf.d/15-lda.conf
 }
 
 function _setup_dovecot() {

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -14,6 +14,44 @@ load 'test_helper/bats-assert/load'
   assert_success
 }
 
+@test "checking configuration: hostname/domainname override: check container hostname is applied correctly" {
+  run docker exec mail_override_hostname /bin/bash -c "hostname | grep unknown.domain.tld"
+  assert_success
+}
+
+@test "checking configuration: hostname/domainname override: check overriden hostname is applied to all configs" {
+  run docker exec mail_override_hostname /bin/bash -c "cat /etc/mailname | grep my-domain.com"
+  assert_success
+  run docker exec mail_override_hostname /bin/bash -c "postconf -n | grep mydomain | grep my-domain.com"
+  assert_success
+  run docker exec mail_override_hostname /bin/bash -c "postconf -n | grep myhostname | grep mail.my-domain.com"
+  assert_success
+  run docker exec mail_override_hostname /bin/bash -c "doveconf | grep hostname | grep mail.my-domain.com"
+  assert_success
+  run docker exec mail_override_hostname /bin/bash -c "cat /etc/opendmarc.conf | grep AuthservID | grep mail.my-domain.com"
+  assert_success
+  run docker exec mail_override_hostname /bin/bash -c "cat /etc/opendmarc.conf | grep TrustedAuthservIDs | grep mail.my-domain.com"
+  assert_success
+  run docker exec mail_override_hostname /bin/bash -c "cat /etc/amavis/conf.d/05-node_id | grep myhostname | grep mail.my-domain.com"
+  assert_success
+}
+
+@test "checking configuration: hostname/domainname override: check hostname in postfix HELO message" {
+  run docker exec mail_override_hostname /bin/bash -c "nc -w 1 0.0.0.0 25 | grep mail.my-domain.com"
+  assert_success
+}
+
+@test "checking configuration: hostname/domainname override: check headers of received mail" {
+  run docker exec mail_override_hostname /bin/sh -c "ls -A /var/mail/localhost.localdomain/user1/new | wc -l | grep 1"
+  assert_success
+  run docker exec mail_override_hostname /bin/sh -c "cat /var/mail/localhost.localdomain/user1/new/* | grep mail.my-domain.com"
+  assert_success
+
+  # test whether the container hostname is not found in received mail
+  run docker exec mail_override_hostname /bin/sh -c "cat /var/mail/localhost.localdomain/user1/new/* | grep unknown.domain.tld"
+  assert_failure
+}
+
 #
 # processes
 #


### PR DESCRIPTION
I have noticed that my emails contain the hostname of my docker host when I use the docker option `--net=host` with the env-var `OVERRIDE_HOSTNAME`. That is because postfix, dovecot and opendmarc user the `hostname` command to retrieve the name of host. Until now the hostname was only overwritten for amavis, but these changes will overwrite it for all mentioned services.