### PR TITLE
#503

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -538,13 +538,12 @@ function _setup_dovecot_local_user() {
 
 function _setup_ldap() {
 	notify 'task' 'Setting up Ldap'
-	declare -A _check_arr
 
 	# cp config files if in place
 	for i in 'users' 'groups' 'aliases'; do
-	    fpath="/tmp/docker-mailserver/postfix-ldap-${i}.cf"
+	    fpath="/tmp/docker-mailserver/ldap-${i}.cf"
 	    if [ -f $fpath ]; then
-		cp ${fpath} /etc/postfix/ldap-${i}.cf || _check_arr["cp_$fpath"]='1'
+		cp ${fpath} /etc/postfix/ldap-${i}.cf 
 	    fi
 	done
 

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -981,7 +981,7 @@ function _fix_var_mail_permissions() {
 }
 
 function _fix_var_amavis_permissions() {
-	if [ "$ONE_DIR" -eq 0 ]; then
+	if [[ "$ONE_DIR" -eq 0 ]]; then
 		amavis_state_dir=/var/lib/amavis
 	else
 		amavis_state_dir=/var/mail-state/lib-amavis

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -315,10 +315,10 @@ function display_startup_daemon() {
 	return $res
 }
 
-function overwrite_config() {
-    notify "task" "Starting do do overwrites"
+function override_config() {
+    notify "task" "Starting do do overrides"
 
-    declare -A config_overwrites
+    declare -A config_overrides
 
     _env_variable_prefix=$1
     [ -z ${_env_variable_prefix} ] && return 1
@@ -340,19 +340,19 @@ function overwrite_config() {
 	# get value
 	value=$(echo $env_variable | cut -d "=" -f2-)
 
-	config_overwrites[$key]=$value
+	config_overrides[$key]=$value
     done
 
     for f in "${_config_files[@]}"
     do
 	if [ ! -f "${f}" ];then
-	    echo "Can not find ${f}. Skipping overwrite" 
+	    echo "Can not find ${f}. Skipping override" 
 	else
-	    for key in ${!config_overwrites[@]} 
+	    for key in ${!config_overrides[@]} 
 	    do
 		[ -z $key ] && echo -e "\t no key provided" && return 1
 		
-		sed -i -e "s|^${key}[[:space:]]\+.*|${key} = "${config_overwrites[$key]}'|g' \
+		sed -i -e "s|^${key}[[:space:]]\+.*|${key} = "${config_overrides[$key]}'|g' \
 		    ${f}
 	    done
 	fi
@@ -548,7 +548,7 @@ function _setup_ldap() {
 	    fi
 	done
 
-	overwrite_config "LDAP_" "/etc/postfix/ldap-users.cf /etc/postfix/ldap-groups.cf /etc/postfix/ldap-aliases.cf /etc/dovecot/dovecot-ldap.conf.ext"
+	override_config "LDAP_" "/etc/postfix/ldap-users.cf /etc/postfix/ldap-groups.cf /etc/postfix/ldap-aliases.cf /etc/dovecot/dovecot-ldap.conf.ext"
 					  
 	# Add  domainname to vhost.
 	echo $DOMAINNAME >> /tmp/vhost.tmp

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -316,7 +316,8 @@ function display_startup_daemon() {
 }
 
 function overwrite_config() {
-    echo -e "Starting do do overwrites"
+    notify "task" "Starting do do overwrites"
+
     declare -A config_overwrites
 
     _env_variable_prefix=$1

--- a/test/config/ldap-aliases.cf
+++ b/test/config/ldap-aliases.cf
@@ -1,0 +1,9 @@
+# Testconfig for ldap integration
+bind             = yes
+bind_dn          = cn=admin,dc=domain,dc=com
+bind_pw          = admin
+query_filter     = (&(mailAlias=%s)(mailEnabled=TRUE))
+result_attribute = mail
+search_base      = ou=people,dc=domain,dc=com
+server_host      = mail.domain.com
+version          = 3

--- a/test/config/ldap-groups.cf
+++ b/test/config/ldap-groups.cf
@@ -1,0 +1,9 @@
+# Testconfig for ldap integration
+bind                     = yes
+bind_dn                  = cn=admin,dc=domain,dc=com
+bind_pw                  = admin
+query_filter             = (&(mailGroupMember=%s)(mailEnabled=TRUE))
+result_attribute         = mail
+search_base              = ou=people,dc=domain,dc=com
+server_host              = mail.domain.com
+version                  = 3

--- a/test/config/ldap-users.cf
+++ b/test/config/ldap-users.cf
@@ -1,0 +1,9 @@
+# Testconfig for ldap integration
+bind             = yes
+bind_dn          = cn=admin,dc=domain,dc=com
+bind_pw          = admin
+query_filter     = (&(mail=%s)(mailEnabled=TRUE))
+result_attribute = mail
+search_base      = ou=people,dc=domain,dc=com
+server_host      = mail.domain.com
+version          = 3

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -960,6 +960,38 @@ load 'test_helper/bats-assert/load'
   assert_output "some.user@localhost.localdomain"
 }
 
+@test "checking postfix: ldap custom config files copied" {
+ run docker exec mail_with_ldap /bin/sh -c "grep "# Testconfig for ldap integration" /etc/postfix/ldap-users.cf" 
+ assert_success
+ run docker exec mail_with_ldap /bin/sh -c "grep "# Testconfig for ldap integration" /etc/postfix/ldap-groups.cf" 
+ assert_success
+ run docker exec mail_with_ldap /bin/sh -c "grep "# Testconfig for ldap integration" /etc/postfix/ldap-aliases.cf" 
+ assert_success
+}
+
+@test "checking postfix: ldap config overwrites success" {
+ run docker exec mail_with_ldap /bin/sh -c "grep 'server_host = ldap' /etc/postfix/ldap-users.cf" 
+ assert_success
+ run docker exec mail_with_ldap /bin/sh -c "grep 'search_base = ou=people,dc=localhost,dc=localdomain' /etc/postfix/ldap-users.cf" 
+ assert_success
+ run docker exec mail_with_ldap /bin/sh -c "grep 'bind_dn = cn=admin,dc=localhost,dc=localdomain' /etc/postfix/ldap-users.cf" 
+ assert_success
+
+ run docker exec mail_with_ldap /bin/sh -c "grep 'server_host = ldap' /etc/postfix/ldap-groups.cf" 
+ assert_success
+ run docker exec mail_with_ldap /bin/sh -c "grep 'search_base = ou=people,dc=localhost,dc=localdomain' /etc/postfix/ldap-groups.cf" 
+ assert_success
+ run docker exec mail_with_ldap /bin/sh -c "grep 'bind_dn = cn=admin,dc=localhost,dc=localdomain' /etc/postfix/ldap-groups.cf" 
+ assert_success
+
+ run docker exec mail_with_ldap /bin/sh -c "grep 'server_host = ldap' /etc/postfix/ldap-aliases.cf" 
+ assert_success
+ run docker exec mail_with_ldap /bin/sh -c "grep 'search_base = ou=people,dc=localhost,dc=localdomain' /etc/postfix/ldap-aliases.cf" 
+ assert_success
+ run docker exec mail_with_ldap /bin/sh -c "grep 'bind_dn = cn=admin,dc=localhost,dc=localdomain' /etc/postfix/ldap-aliases.cf" 
+ assert_success
+}
+
 # dovecot
 @test "checking dovecot: ldap imap connection and authentication works" {
   run docker exec mail_with_ldap /bin/sh -c "nc -w 1 0.0.0.0 143 < /tmp/docker-mailserver-test/auth/imap-ldap-auth.txt"
@@ -984,6 +1016,7 @@ load 'test_helper/bats-assert/load'
   run docker exec mail_with_ldap /bin/sh -c "nc -w 5 0.0.0.0 25 < /tmp/docker-mailserver-test/auth/sasl-ldap-smtp-auth.txt | grep 'Authentication successful'"
   assert_success
 }
+
 
 #
 # RIMAP

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -961,11 +961,11 @@ load 'test_helper/bats-assert/load'
 }
 
 @test "checking postfix: ldap custom config files copied" {
- run docker exec mail_with_ldap /bin/sh -c "grep "# Testconfig for ldap integration" /etc/postfix/ldap-users.cf" 
+ run docker exec mail_with_ldap /bin/sh -c "grep '# Testconfig for ldap integration' /etc/postfix/ldap-users.cf" 
  assert_success
- run docker exec mail_with_ldap /bin/sh -c "grep "# Testconfig for ldap integration" /etc/postfix/ldap-groups.cf" 
+ run docker exec mail_with_ldap /bin/sh -c "grep '# Testconfig for ldap integration' /etc/postfix/ldap-groups.cf" 
  assert_success
- run docker exec mail_with_ldap /bin/sh -c "grep "# Testconfig for ldap integration" /etc/postfix/ldap-aliases.cf" 
+ run docker exec mail_with_ldap /bin/sh -c "grep '# Testconfig for ldap integration' /etc/postfix/ldap-aliases.cf" 
  assert_success
 }
 


### PR DESCRIPTION
This PR fixes issue #503.

I also introduced a new method/logic to deal with config substitution "override_configs".

This method parses takes 2 argument: an env var prefix (like LDAP_) and a config file. See start-mailserver.sh for details. I think this could make the provisioning also for other config implementations  much easier. Maybe we could write a section for developers at the end of the README.me to point at stuff like this.