### PR TITLE
Fixes #451 - add incoming mail SPF policy checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM ubuntu:14.04
 MAINTAINER Thomas VIAL
 
+# Ensure that package operations will not produce warnings
+ENV DEBIAN_FRONTEND noninteractive
+
 # Packages
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -q --fix-missing && \
+RUN apt-get update -q --fix-missing && \
   apt-get -y upgrade && \
   apt-get -y install --no-install-recommends \
     amavisd-new \
@@ -34,6 +37,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q --fix-missing && \
     p7zip \
     postfix \
     postfix-ldap \
+    postfix-policyd-spf-python \
     pyzor \
     razor \
     rsyslog \
@@ -140,5 +144,3 @@ CMD /usr/local/bin/start-mailserver.sh
 
 
 ADD target/filebeat.yml.tmpl /etc/filebeat/filebeat.yml.tmpl
-
-

--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -42,7 +42,7 @@ smtpd_helo_required = yes
 smtpd_delay_reject = yes
 smtpd_helo_restrictions = permit_mynetworks, reject_invalid_helo_hostname, permit
 smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
-smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unauth_destination,
+smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unauth_destination, check_policy_service unix:private/policyd-spf,
     reject_unauth_pipelining, reject_invalid_helo_hostname, reject_non_fqdn_helo_hostname, reject_unknown_recipient_domain,
     reject_rbl_client zen.spamhaus.org, reject_rbl_client bl.spamcop.net
 smtpd_client_restrictions = permit_mynetworks, permit_sasl_authenticated, reject_unauth_destination, reject_unauth_pipelining
@@ -73,3 +73,6 @@ dkim_milter = inet:localhost:8891
 dmarc_milter = inet:localhost:8893
 smtpd_milters = $dkim_milter,$dmarc_milter
 non_smtpd_milters = $dkim_milter
+
+# SPF policy settings
+policyd-spf_time_limit = 3600

--- a/target/postfix/master.cf
+++ b/target/postfix/master.cf
@@ -63,6 +63,11 @@ mailman   unix  -       n       n       -       -       pipe
   flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
   ${nexthop} ${user}
 
+#
+# SPF configuration
+#
+policyd-spf  unix  -       n       n       -       0       spawn
+    user=policyd-spf argv=/usr/bin/policyd-spf
 
 #
 # Amavis configuration

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -147,7 +147,7 @@ load 'test_helper/bats-assert/load'
 
 @test "checking postgrey: there should be a log entry about a new greylisted e-mail user@external.tld in /var/log/mail/mail.log" {
   #editing the postfix config in order to ensure that postgrey handles the test e-mail. The other spam checks at smtpd_recipient_restrictionswould interfere with it.
-  run docker exec mail_with_postgrey /bin/sh -c "sed -ie 's/permit_sasl_authenticated.*reject_unauth_destination,$//g' /etc/postfix/main.cf"
+  run docker exec mail_with_postgrey /bin/sh -c "sed -ie 's/permit_sasl_authenticated.*policyd-spf,$//g' /etc/postfix/main.cf"
   run docker exec mail_with_postgrey /bin/sh -c "sed -ie 's/reject_unauth_pipelining.*reject_unknown_recipient_domain,$//g' /etc/postfix/main.cf"
   run docker exec mail_with_postgrey /bin/sh -c "sed -ie 's/reject_rbl_client.*inet:127\.0\.0\.1:10023$//g' /etc/postfix/main.cf"
   run docker exec mail_with_postgrey /bin/sh -c "sed -ie 's/smtpd_recipient_restrictions = /smtpd_recipient_restrictions = check_policy_service inet:127.0.0.1:10023/g' /etc/postfix/main.cf"


### PR DESCRIPTION
This adds support support for checking incoming SPF records using `postfix-policyd-spf-python`.

I have also moved the `DEBIAN_FRONTEND` to use the `ENV` command so that it works for all apt-get runs, eliminating apt-get runs complaining about the lack of `TERM`.

Test where executed via `make` and successful.