### PR TITLE
Add restart: always

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Adapt this file with your FQDN. Install [docker-compose](https://docs.docker.com
 
 Your configs must be mounted in `/tmp/docker-mailserver/`. To understand how things work on boot, please have a look to [start-mailserver.sh](https://github.com/tomav/docker-mailserver/blob/master/target/start-mailserver.sh)
 
-`restart: always` ensures that the mail server container (and ELK container when using docker-compose.elk.yml.dist) is automatically restarted by docker in cases like a docker service or host restart or unintentional container exit.
+`restart: always` ensures that the mail server container (and ELK container when using the mail server together with ELK stack) is automatically restarted by Docker in cases like a Docker service or host restart or container exit.
 
 ```yaml	
 version: '2'

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Adapt this file with your FQDN. Install [docker-compose](https://docs.docker.com
 
 Your configs must be mounted in `/tmp/docker-mailserver/`. To understand how things work on boot, please have a look to [start-mailserver.sh](https://github.com/tomav/docker-mailserver/blob/master/target/start-mailserver.sh)
 
+`restart: always` ensures that the mail server container (and ELK container when using docker-compose.elk.yml.dist) is automatically restarted by docker in cases like a docker service or host restart or unintentional container exit.
+
 ```yaml	
 version: '2'
 

--- a/docker-compose.elk.yml.dist
+++ b/docker-compose.elk.yml.dist
@@ -21,6 +21,7 @@ services:
     - ENABLE_ELK_FORWARDER=1
     cap_add:
     - NET_ADMIN
+    restart: always
   elk:
      build: elk
      ports:
@@ -28,6 +29,7 @@ services:
      - "9200:9200"
      - "5044:5044"
      - "5000:5000"
+     restart: always
 
 volumes:
   maildata:

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -23,6 +23,7 @@ services:
     - DMS_DEBUG=0
     cap_add:
     - NET_ADMIN
+    restart: always
 
 volumes:
   maildata:


### PR DESCRIPTION
This PR adds restart: always to the containers in docker-compose.yml for 
auto-restarting them in the event of docker service or host restart.