### PR TITLE
Fix #526: fatal: no SASL authentication mechanisms

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -90,7 +90,6 @@ function register_functions() {
 
 	if [ "$ENABLE_SASLAUTHD" = 1 ];then
 		_register_setup_function "_setup_saslauthd"
-		_register_setup_function "_setup_postfix_sasl"
 	fi
 
 	if [ "$ENABLE_POSTGREY" = 1 ];then
@@ -107,6 +106,7 @@ function register_functions() {
 	_register_setup_function "_setup_postfix_hostname"
 	_register_setup_function "_setup_dovecot_hostname"
 
+	_register_setup_function "_setup_postfix_sasl"
 	_register_setup_function "_setup_postfix_override_configuration"
 	_register_setup_function "_setup_postfix_sasl_password"
 	_register_setup_function "_setup_security_stack"
@@ -545,11 +545,21 @@ function _setup_postgrey() {
 
 
 function _setup_postfix_sasl() {
+    if [[ ${ENABLE_SASLAUTHD} == 1 ]];then
 	[ ! -f /etc/postfix/sasl/smtpd.conf ] && cat > /etc/postfix/sasl/smtpd.conf << EOF
 pwcheck_method: saslauthd
 mech_list: plain login
 EOF
-	return 0
+    fi
+
+    # cyrus sasl or dovecot sasl
+    if [[ ${ENABLE_SASLAUTHD} == 1 ]] || [[ ${SMTP_ONLY} == 0 ]];then
+	sed -i -e 's|^smtpd_sasl_auth_enable[[:space:]]\+.*|smtpd_sasl_auth_enable = yes|g' /etc/postfix/main.cf
+    else 
+	sed -i -e 's|^smtpd_sasl_auth_enable[[:space:]]\+.*|smtpd_sasl_auth_enable = no|g' /etc/postfix/main.cf
+    fi
+
+    return 0
 }
 
 function _setup_saslauthd() {

--- a/test/email-templates/smtp-only.txt
+++ b/test/email-templates/smtp-only.txt
@@ -1,0 +1,8 @@
+HELO mail.localhost
+MAIL FROM: test@localhost
+RCPT TO: user2@external.tld
+DATA
+This is a test mail.
+
+.
+QUIT

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -338,8 +338,8 @@ load 'test_helper/bats-assert/load'
   assert_success
   run docker exec mail_smtponly /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/smtp-only.txt"
   assert_success
-  run docker exec mail_smtponly /bin/sh -c 'grep -E "to=<user2\@external.tld>.*status\=sent" /var/log/mail/mail.log'
-  assert_success
+  run docker exec mail_smtponly /bin/sh -c 'grep -cE "to=<user2\@external.tld>.*status\=sent" /var/log/mail/mail.log'
+  [ "$status" -ge 0 ]
 }
   
 

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -331,6 +331,19 @@ load 'test_helper/bats-assert/load'
   assert_output 1
 }
 
+@test "checking smtp_only: mail send should work" {
+  run docker exec mail_smtponly /bin/sh -c "postconf -e smtp_host_lookup=no"
+  assert_success
+  run docker exec mail_smtponly /bin/sh -c "/etc/init.d/postfix reload"
+  assert_success
+  run docker exec mail_smtponly /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/smtp-only.txt"
+  assert_success
+  run docker exec mail_smtponly /bin/sh -c 'grep -E "to=<user2\@external.tld>.*status\=sent" /var/log/mail/mail.log'
+  assert_success
+}
+  
+
+
 #
 # accounts
 #


### PR DESCRIPTION
When using the container with SMTP_ONLY = 1,  the postfix process within the container fails
on ehlo because there is no valid sasl authentication mechanism available. This happens because sasl has been enabled within postfix/main.cf per default but sasl is not configured.

To fix this _setup_postfix_sasl does not depend anymore on ENABLE_SASLAUTHD and will check in it's logic, whether to enable or disable sasl explicit within postfix/main.cf.