### PR TITLE
Include whitelist_clients.local in postgrey setup from config folder

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -539,6 +539,7 @@ function _setup_postgrey() {
 	if [ $TEXT_FOUND -eq 0 ]; then
 		printf "POSTGREY_TEXT=\"$POSTGREY_TEXT\"\n\n" >> /etc/default/postgrey
 	fi
+	cp -f /tmp/docker-mailserver/whitelist_clients.local /etc/postgrey/whitelist_clients.local
 }
 
 

--- a/test/config/whitelist_clients.local
+++ b/test/config/whitelist_clients.local
@@ -1,0 +1,1 @@
+whitelist.tld

--- a/test/nc_templates/postgrey_whitelist.txt
+++ b/test/nc_templates/postgrey_whitelist.txt
@@ -1,0 +1,9 @@
+request=smtpd_access_policy
+protocol_state=RCPT
+protocol_name=ESMTP
+client_address=127.0.0.1
+client_name=whitelist.tld
+helo_name=whitelist.tld
+sender=test@whitelist.tld
+recipient=user1@localhost.localdomain
+

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -169,6 +169,14 @@ load 'test_helper/bats-assert/load'
   assert_output 1
 }
 
+@test "checking postgrey: there should be a log entry about the whitelisted and passed e-mail user@whitelist.tld in /var/log/mail/mail.log" {
+  run docker exec mail_with_postgrey /bin/sh -c "nc 0.0.0.0 10023 < /tmp/docker-mailserver-test/nc_templates/postgrey_whitelist.txt"
+  sleep 8
+  run docker exec mail_with_postgrey /bin/sh -c "grep -i 'action=pass, reason=client whitelist' /var/log/mail/mail.log | wc -l"
+  assert_success
+  assert_output 1
+}
+
 #
 # imap
 #


### PR DESCRIPTION
Copies whitelist_clients.local from config dir to /etc/postgrey. 
Test is made by communicating directly with postgrey via nc on port 10023 in order to test for the correct client_name instead of localhost. 

Credit for that solution to this blog post: http://www.brandonchecketts.com/archives/manually-testing-postgrey-through-a-telnet-session 