### PR TITLE
Allow accounts which do not start with a-z (fixes #567)

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -463,7 +463,8 @@ function _setup_dovecot_local_user() {
 
 		# Creating users
 		# 'pass' is encrypted
-		grep "^[a-z]" /tmp/docker-mailserver/postfix-accounts.cf | while IFS=$'|' read login pass
+		# comments and empty lines are ignored
+		grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-accounts.cf | while IFS=$'|' read login pass
 		do
 			# Setting variables for better readability
 			user=$(echo ${login} | cut -d @ -f1)
@@ -805,7 +806,8 @@ function _setup_postfix_override_configuration() {
 
 	if [ -f /tmp/docker-mailserver/postfix-main.cf ]; then
 		while read line; do
-		# line should start with a letter (avoid comments and new lines)
+		# all valid postfix options start with a lower case letter
+		# http://www.postfix.org/postconf.5.html
 		if [[ "$line" =~ ^[a-z] ]]; then
 			postconf -e "$line"
 		fi

--- a/test/config/postfix-main.cf
+++ b/test/config/postfix-main.cf
@@ -1,5 +1,5 @@
 recipient_delimiter = ~
 max_idle = 600s
 # this is a comment
+     # this is also a comment
 readme_directory = /tmp
-


### PR DESCRIPTION
Commit 912cb5676b9538eb1c799b3c229c7e8dc9c94f40 restricts accounts to begin with lower case a-z

The modified regex now ignores empty lines, lines with one or multiple blanks and lines with comments (#) but allows accounts like 123@domain.tld.

Fixes #567 