### PR TITLE
add switchable dovecot feature address extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,13 @@ run:
 		-e POSTFIX_DAGENT=lmtp:127.0.0.1:24 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 30
+	docker run -d --name mail_lmtp_address_extension \
+		-v "`pwd`/test/config":/tmp/docker-mailserver \
+		-v "`pwd`/test/config/dovecot-lmtp":/etc/dovecot \
+		-v "`pwd`/test":/tmp/docker-mailserver-test \
+		-e ENABLE_LMTP_ADDRESS_EXTENSION=1 \
+		-h mail.my-domain.com -t $(NAME)
+	sleep 30
 	docker run -d --name mail_with_postgrey \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
@@ -162,6 +169,8 @@ fixtures:
 	docker exec mail_disabled_clamav_spamassassin /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user1.txt"
 	# postfix virtual transport lmtp
 	docker exec mail_lmtp_ip /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user1.txt"
+	# ltmp address extension
+	docker exec mail_lmtp_address_extension /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user1-address-extension.txt"
 
 	docker exec mail_override_hostname /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user1.txt"
 	# Wait for mails to be analyzed
@@ -186,6 +195,7 @@ clean:
 		mail_with_ldap \
 		mail_with_imap \
 		mail_lmtp_ip \
+		mail_lmtp_address_extension \
 		mail_with_postgrey \
 		mail_override_hostname
 

--- a/README.md
+++ b/README.md
@@ -337,3 +337,9 @@ Enabled by ENABLE_POSTFIX_VIRTUAL_TRANSPORT. Specify the final delivery of postf
     - lmtp:<kopano-host>:2003 (use kopano as mailstore)
     - etc.
 
+##### ENABLE_LMTP_ADDRESS_EXTENSION
+
+Enable dovecot to deliver mails to specific (new) inbox folders, if separated like account+folder@domain.com.
+  - **empty** => disabled
+  - 1 => enabled
+

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -22,6 +22,7 @@ DEFAULT_VARS["ENABLE_SASLAUTHD"]="${ENABLE_SASLAUTHD:="0"}"
 DEFAULT_VARS["SMTP_ONLY"]="${SMTP_ONLY:="0"}"
 DEFAULT_VARS["DMS_DEBUG"]="${DMS_DEBUG:="0"}"
 DEFAULT_VARS["OVERRIDE_HOSTNAME"]="${OVERRIDE_HOSTNAME}"
+DEFAULT_VARS["ENABLE_LMTP_ADDRESS_EXTENSION"]="${ENABLE_LMTP_ADDRESS_EXTENSION:="0"}"
 ##########################################################################
 # << DEFAULT VARS
 ##########################################################################
@@ -497,6 +498,11 @@ function _setup_dovecot() {
 		cp /tmp/docker-mailserver/sieve-pipe/* /usr/lib/dovecot/sieve-pipe/
 		chown docker:docker /usr/lib/dovecot/sieve-pipe/*
 		chmod 550 /usr/lib/dovecot/sieve-pipe/*
+	fi
+
+	if [ "$ENABLE_LMTP_ADDRESS_EXTENSION" = 1 ]; then
+		notify 'inf' "Dovecot/lmtp address extension enabled"
+		sed -i -e 's/#lmtp_save_to_detail_mailbox = no/lmtp_save_to_detail_mailbox = yes/g' /etc/dovecot/conf.d/20-lmtp.conf
 	fi
 }
 

--- a/test/email-templates/existing-user1-address-extension.txt
+++ b/test/email-templates/existing-user1-address-extension.txt
@@ -1,0 +1,12 @@
+HELO mail.external.tld
+MAIL FROM: user@external.tld
+RCPT TO: user1+subfolder@localhost.localdomain
+DATA
+From: Docker Mail Server <dockermailserver@external.tld>
+To: Existing Local User <user1+subfolder@localhost.localdomain>
+Date: Sat, 22 May 2010 07:43:25 -0400
+Subject: Test Message
+This is a test mail.
+
+.
+QUIT

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1128,6 +1128,12 @@ load 'test_helper/bats-assert/load'
   assert_output 1
 }
 
+@test "checking postfix-lmtp-address-extension: delivers mail to existing account and inbox subfolder" {
+  run docker exec mail_lmtp_address_extension /bin/sh -c "grep -c 'dovecot: lmtp.*: saved mail to subfolder' var/log/mail/mail.log"
+  assert_success
+  assert_output 1
+}
+
 #
 # PCI compliance
 #


### PR DESCRIPTION
	* currently the container does not support to sort
          incoming mails with an address extension into subfolders
          automatically, since the default for dovecot/lmtp is "no"

	* with this feature enabled, mails to user+subfolder@d.com
          will cause dovecot to automatically create subfolder within
          your inbox

	* the feature is IMO useful in a lot of places, e.g. for
          _dmarc records, where you can automatically sort into
          forensic and aggregated report folders