### PR TITLE
Increase message size limit to 25MB

### DIFF
--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -63,6 +63,9 @@ virtual_mailbox_domains = /etc/postfix/vhost
 virtual_mailbox_maps = texthash:/etc/postfix/vmailbox
 virtual_alias_maps = texthash:/etc/postfix/virtual
 
+# Increase the default attachment size limit (10MB) to 25MB
+message_size_limit = 26214400
+
 # Additional option for filtering
 content_filter = smtp-amavis:[127.0.0.1]:10024
 


### PR DESCRIPTION
This PR increases the limit Postfix enforces on message attachment size.

As of currently with ```docker-mailserver```, if someone were to send you a message, with an attachment greater than 10240000 bytes (roughly 10MB), Postfix would silently drop it, and return an error to the sender.

Especially in this time of large files, attachments are creeping closer and closer to the default Postfix size limit. This will hopefully alleviate some headaches of dropped mail because of attachments that are too large.

However, where some users may potentially run into some issues regarding mailbox size. I believe the current default mailbox limit of Postfix is roughly 50MB... Two messages with full size attachments (at 25MB each) would fill up a user's mailbox. 
That being said, things weren't much better at the default attachment size either (5 messages would fill up a user's mailbox).

Increasing the size limit of users' mailboxes may be beyond of the scope of this PR, but nonetheless something to consider. I can add that fix if you wish.