### PR TITLE
Run services with supervisor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,9 @@ RUN apt-get update -q --fix-missing && \
 # Enables Clamav
 RUN (echo "0 0,6,12,18 * * * /usr/bin/freshclam --quiet" ; crontab -l) | crontab -
 RUN chmod 644 /etc/clamav/freshclam.conf && freshclam
-RUN sed -i 's/Foreground false/Foreground true/g' /etc/clamav/clamd.conf && mkdir /var/run/clamav && chown -R clamav:root /var/run/clamav
+RUN sed -i 's/Foreground false/Foreground true/g' /etc/clamav/clamd.conf && \
+sed -i 's/AllowSupplementaryGroups false/AllowSupplementaryGroups true/g' /etc/clamav/clamd.conf && \
+mkdir /var/run/clamav && chown -R clamav:root /var/run/clamav
 
 # Configures Dovecot
 RUN sed -i -e 's/include_try \/usr\/share\/dovecot\/protocols\.d/include_try \/etc\/dovecot\/protocols\.d/g' /etc/dovecot/dovecot.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ RUN apt-get update -q --fix-missing && \
 # Enables Clamav
 RUN (echo "0 0,6,12,18 * * * /usr/bin/freshclam --quiet" ; crontab -l) | crontab -
 RUN chmod 644 /etc/clamav/freshclam.conf && freshclam
+RUN sed -i 's/Foreground false/Foreground true/g' /etc/clamav/clamd.conf && mkdir /var/run/clamav && chown -R clamav:root /var/run/clamav
 
 # Configures Dovecot
 RUN sed -i -e 's/include_try \/usr\/share\/dovecot\/protocols\.d/include_try \/etc\/dovecot\/protocols\.d/g' /etc/dovecot/dovecot.conf
@@ -101,7 +102,7 @@ RUN (echo "0 4 * * * /usr/local/bin/virus-wiper" ; crontab -l) | crontab -
 # Configure Fail2ban
 COPY target/fail2ban/jail.conf /etc/fail2ban/jail.conf
 COPY target/fail2ban/filter.d/dovecot.conf /etc/fail2ban/filter.d/dovecot.conf
-RUN echo "ignoreregex =" >> /etc/fail2ban/filter.d/postfix-sasl.conf
+RUN echo "ignoreregex =" >> /etc/fail2ban/filter.d/postfix-sasl.conf && mkdir /var/run/fail2ban
 
 # Enables Pyzor and Razor
 USER amavis
@@ -153,7 +154,7 @@ RUN chmod +x /usr/local/bin/*
 
 EXPOSE 25 587 143 993 110 995 4190
 
-CMD /usr/local/bin/start-mailserver.sh
+CMD /usr/local/bin/start-mailserver.sh > /var/log/container-startup.log
 
 
 ADD target/filebeat.yml.tmpl /etc/filebeat/filebeat.yml.tmpl

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update -q --fix-missing && \
     rsyslog \
     sasl2-bin \
     spamassassin \
+    supervisor \
     postgrey \
     unzip \
     && \
@@ -120,6 +121,9 @@ COPY target/opendmarc/ignore.hosts /etc/opendmarc/ignore.hosts
 # Configure fetchmail
 COPY target/fetchmail/fetchmailrc /etc/fetchmailrc_general
 RUN sed -i 's/START_DAEMON=no/START_DAEMON=yes/g' /etc/default/fetchmail
+
+# Configure supervisor
+COPY target/supervisor/supervisor-app.conf /etc/supervisor/conf.d/
 
 # Configures Postfix
 COPY target/postfix/main.cf target/postfix/master.cf /etc/postfix/

--- a/Dockerfile
+++ b/Dockerfile
@@ -154,7 +154,7 @@ RUN chmod +x /usr/local/bin/*
 
 EXPOSE 25 587 143 993 110 995 4190
 
-CMD /usr/local/bin/start-mailserver.sh > /var/log/container-startup.log
+CMD /usr/local/bin/start-mailserver.sh | tee /var/log/container-startup.log
 
 
 ADD target/filebeat.yml.tmpl /etc/filebeat/filebeat.yml.tmpl

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,7 @@ ENV ONE_DIR=0
 # Packages
 RUN apt-get update -q --fix-missing && \
   apt-get -y upgrade && \
-  apt-get -y install postfix
-RUN apt-get update -q --fix-missing && \
-  apt-get -y upgrade && \
+  apt-get -y install postfix && \
   apt-get -y install --no-install-recommends \
     amavisd-new \
     arj \

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ run:
 		-e SASL_PASSWD="external-domain.com username:password" \
 		-e ENABLE_MANAGESIEVE=1 \
 		-e PERMIT_DOCKER=host \
-		-e DMS_DEBUG=0 \
+		-e DMS_DEBUG=1 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
 	docker run -d --name mail_pop3 \
@@ -48,6 +48,7 @@ run:
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e SMTP_ONLY=1 \
 		-e PERMIT_DOCKER=network \
+		-e DMS_DEBUG=1 \
 		-e OVERRIDE_HOSTNAME=mail.my-domain.com \
 		-t $(NAME)
 	sleep 15
@@ -55,6 +56,7 @@ run:
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e PERMIT_DOCKER=network \
+		-e DMS_DEBUG=1 \
 		-e OVERRIDE_HOSTNAME=mail.my-domain.com \
 		-h mail.my-domain.com \
 		-t $(NAME)
@@ -71,6 +73,7 @@ run:
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e ENABLE_FETCHMAIL=1 \
 		--cap-add=NET_ADMIN \
+		-e DMS_DEBUG=1 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
 	docker run -d --name mail_disabled_clamav_spamassassin \
@@ -78,6 +81,7 @@ run:
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e ENABLE_CLAMAV=0 \
 		-e ENABLE_SPAMASSASSIN=0 \
+		-e DMS_DEBUG=1 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
 	docker run -d --name mail_manual_ssl \
@@ -86,6 +90,7 @@ run:
 		-e SSL_TYPE=manual \
 		-e SSL_CERT_PATH=/tmp/docker-mailserver/letsencrypt/mail.my-domain.com/fullchain.pem \
 		-e SSL_KEY_PATH=/tmp/docker-mailserver/letsencrypt/mail.my-domain.com/privkey.pem \
+		-e DMS_DEBUG=1 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
 	docker run -d --name ldap_for_mail \
@@ -106,6 +111,7 @@ run:
 		-e SASLAUTHD_LDAP_PASSWORD=admin \
 		-e SASLAUTHD_LDAP_SEARCH_BASE=ou=people,dc=localhost,dc=localdomain \
 		-e POSTMASTER_ADDRESS=postmaster@localhost.localdomain \
+		-e DMS_DEBUG=1 \
 		--link ldap_for_mail:ldap \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
@@ -116,6 +122,7 @@ run:
 		-e SASLAUTHD_MECHANISMS=rimap \
 		-e SASLAUTHD_MECH_OPTIONS=127.0.0.1 \
 		-e POSTMASTER_ADDRESS=postmaster@localhost.localdomain \
+		-e DMS_DEBUG=1 \
 		-h mail.my-domain.com -t $(NAME)
 	# Wait for containers to fully start
 	sleep 15
@@ -125,6 +132,7 @@ run:
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e ENABLE_POSTFIX_VIRTUAL_TRANSPORT=1 \
 		-e POSTFIX_DAGENT=lmtp:127.0.0.1:24 \
+		-e DMS_DEBUG=1 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 30
 	docker run -d --name mail_with_postgrey \
@@ -134,6 +142,7 @@ run:
 		-e POSTGREY_DELAY=15 \
 		-e POSTGREY_MAX_AGE=35 \
 		-e POSTGREY_TEXT="Delayed by postgrey" \
+		-e DMS_DEBUG=1 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 20
 

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1129,17 +1129,17 @@ function start_daemons() {
 
 function _start_daemons_cron() {
 	notify 'task' 'Starting cron' 'n'
-	display_startup_daemon "cron"
+    supervisorctl start cron
 }
 
 function _start_daemons_rsyslog() {
 	notify 'task' 'Starting rsyslog' 'n'
-	display_startup_daemon "/etc/init.d/rsyslog start"
+    supervisorctl start rsyslog
 }
 
 function _start_daemons_saslauthd() {
 	notify 'task' 'Starting saslauthd' 'n'
-	display_startup_daemon "/etc/init.d/saslauthd start"
+    supervisorctl start saslauthd
 }
 
 function _start_daemons_fail2ban() {
@@ -1149,28 +1149,28 @@ function _start_daemons_fail2ban() {
 	if [ -e /var/run/fail2ban/fail2ban.sock ]; then
 		rm /var/run/fail2ban/fail2ban.sock
 	fi
-	display_startup_daemon "/etc/init.d/fail2ban start"
+    supervisorctl start fail2ban
 }
 
 function _start_daemons_opendkim() {
 	notify 'task' 'Starting opendkim' 'n'
-	display_startup_daemon "/etc/init.d/opendkim start"
+    supervisorctl start opendkim
 }
 
 function _start_daemons_opendmarc() {
 	notify 'task' 'Starting opendmarc' 'n'
-	display_startup_daemon "/etc/init.d/opendmarc start"
+    supervisorctl start opendmarc
 }
 
 function _start_daemons_postfix() {
 	notify 'task' 'Starting postfix' 'n'
-	display_startup_daemon "/etc/init.d/postfix start"
+    supervisorctl start postfix
 }
 
 function _start_daemons_dovecot() {
 	# Here we are starting sasl and imap, not pop3 because it's disabled by default
 	notify 'task' 'Starting dovecot services' 'n'
-	display_startup_daemon "/usr/sbin/dovecot -c /etc/dovecot/dovecot.conf"
+    supervisorctl start dovecot
 
 	if [ "$ENABLE_POP3" = 1 ]; then
 		notify 'task' 'Starting pop3 services' 'n'
@@ -1195,29 +1195,29 @@ function _start_daemons_dovecot() {
 
 function _start_daemons_filebeat() {
 	notify 'task' 'Starting filebeat' 'n'
-	display_startup_daemon "/etc/init.d/filebeat start"
+    supervisorctl start filebeat
 }
 
 function _start_daemons_fetchmail() {
 	notify 'task' 'Starting fetchmail' 'n'
 	/usr/local/bin/setup-fetchmail
-	display_startup_daemon "/etc/init.d/fetchmail start"
+    supervisorctl start fetchmail
 }
 
 function _start_daemons_clamav() {
 	notify 'task' 'Starting clamav' 'n'
-	display_startup_daemon "/etc/init.d/clamav-daemon start"
+    supervisorctl start clamav
 }
 
 function _start_daemons_postgrey() {
 	notify 'task' 'Starting postgrey' 'n'
-	display_startup_daemon "/etc/init.d/postgrey start"
+    supervisorctl start postgrey
 }
 
 
 function _start_daemons_amavis() {
 	notify 'task' 'Starting amavis' 'n'
-	display_startup_daemon "/etc/init.d/amavis start"
+    supervisorctl start amavis
 }
 
 ##########################################################################
@@ -1251,6 +1251,8 @@ notify 'taskgrp' "# docker-mailserver"
 notify 'taskgrp' "#"
 notify 'taskgrp' "#"
 notify 'taskgrp' ""
+
+supervisord
 
 register_functions
 

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1253,7 +1253,7 @@ notify 'taskgrp' "#"
 notify 'taskgrp' "#"
 notify 'taskgrp' ""
 
-supervisord -c /etc/supervisor/conf.d/supervisor-app.conf
+supervisord -c /etc/supervisor/supervisord.conf
 
 register_functions
 
@@ -1269,7 +1269,7 @@ notify 'taskgrp' "# $HOSTNAME is up and running"
 notify 'taskgrp' "#"
 notify 'taskgrp' ""
 
-
+touch /var/log/mail/mail.log
 tail -fn 0 /var/log/mail/mail.log
 
 

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1128,9 +1128,8 @@ function start_daemons() {
 }
 
 function _start_daemons_cron() {
-	notify 'task' 'Skipping starting cron\n' 'n'
-    # cron starts automatically. I don't think this is necessary.
-    #supervisorctl start cron
+	notify 'task' 'Starting cron' 'n'
+	display_startup_daemon "cron"
 }
 
 function _start_daemons_rsyslog() {

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1169,19 +1169,22 @@ function _start_daemons_postfix() {
 
 function _start_daemons_dovecot() {
 	# Here we are starting sasl and imap, not pop3 because it's disabled by default
-	notify 'task' 'Starting dovecot services' 'n'
-    supervisorctl start dovecot
+
+	notify 'task' 'Starting dovecot services' 'n'	
 
 	if [ "$ENABLE_POP3" = 1 ]; then
 		notify 'task' 'Starting pop3 services' 'n'
 		mv /etc/dovecot/protocols.d/pop3d.protocol.disab /etc/dovecot/protocols.d/pop3d.protocol
-		/usr/sbin/dovecot reload
+		# /usr/sbin/dovecot reload
 	fi
 
 	if [ -f /tmp/docker-mailserver/dovecot.cf ]; then
 		cp /tmp/docker-mailserver/dovecot.cf /etc/dovecot/local.conf
-		/usr/sbin/dovecot reload
+		# /usr/sbin/dovecot reload
 	fi
+	
+
+    supervisorctl start dovecot
 
 	# @TODO fix: on integration test
 	# doveadm: Error: userdb lookup: connect(/var/run/dovecot/auth-userdb) failed: No such file or directory

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1128,22 +1128,23 @@ function start_daemons() {
 }
 
 function _start_daemons_cron() {
-	notify 'task' 'Starting cron' 'n'
-    supervisorctl start cron
+	notify 'task' 'Skipping starting cron\n' 'n'
+    # cron starts automatically. I don't think this is necessary.
+    #supervisorctl start cron
 }
 
 function _start_daemons_rsyslog() {
-	notify 'task' 'Starting rsyslog' 'n'
+	notify 'task' 'Starting rsyslog ' 'n'
     supervisorctl start rsyslog
 }
 
 function _start_daemons_saslauthd() {
 	notify 'task' 'Starting saslauthd' 'n'
-    supervisorctl start saslauthd
+    display_startup_daemon "/etc/init.d/saslauthd start"
 }
 
 function _start_daemons_fail2ban() {
-	notify 'task' 'Starting fail2ban' 'n'
+	notify 'task' 'Starting fail2ban ' 'n'
 	touch /var/log/auth.log
 	# Delete fail2ban.sock that probably was left here after container restart
 	if [ -e /var/run/fail2ban/fail2ban.sock ]; then
@@ -1153,18 +1154,18 @@ function _start_daemons_fail2ban() {
 }
 
 function _start_daemons_opendkim() {
-	notify 'task' 'Starting opendkim' 'n'
+	notify 'task' 'Starting opendkim ' 'n'
     supervisorctl start opendkim
 }
 
 function _start_daemons_opendmarc() {
-	notify 'task' 'Starting opendmarc' 'n'
+	notify 'task' 'Starting opendmarc ' 'n'
     supervisorctl start opendmarc
 }
 
 function _start_daemons_postfix() {
 	notify 'task' 'Starting postfix' 'n'
-    supervisorctl start postfix
+    display_startup_daemon "/etc/init.d/postfix start"
 }
 
 function _start_daemons_dovecot() {
@@ -1175,7 +1176,7 @@ function _start_daemons_dovecot() {
 	if [ "$ENABLE_POP3" = 1 ]; then
 		notify 'task' 'Starting pop3 services' 'n'
 		mv /etc/dovecot/protocols.d/pop3d.protocol.disab /etc/dovecot/protocols.d/pop3d.protocol
-		display_startup_daemon "/usr/sbin/dovecot reload"
+		/usr/sbin/dovecot reload
 	fi
 
 	if [ -f /tmp/docker-mailserver/dovecot.cf ]; then
@@ -1201,7 +1202,7 @@ function _start_daemons_filebeat() {
 function _start_daemons_fetchmail() {
 	notify 'task' 'Starting fetchmail' 'n'
 	/usr/local/bin/setup-fetchmail
-    supervisorctl start fetchmail
+	display_startup_daemon "/etc/init.d/fetchmail start"
 }
 
 function _start_daemons_clamav() {
@@ -1252,7 +1253,7 @@ notify 'taskgrp' "#"
 notify 'taskgrp' "#"
 notify 'taskgrp' ""
 
-supervisord
+supervisord -c /etc/supervisor/conf.d/supervisor-app.conf
 
 register_functions
 

--- a/target/supervisor/supervisor-app.conf
+++ b/target/supervisor/supervisor-app.conf
@@ -1,83 +1,81 @@
 # each program entry below is a separate terminal command.
-# Each command is expected to run in the foreground and stay running.
+# Each command MUST run in the foreground and stay running.
 # If the command ever exits, the supervisor daemon will automatically run it again.
 # Programs can be controlled like this: 'supervisorctl start fail2ban' 'supervisorctl stop fail2ban'
 # supervisor writes program statuses in /var/log/supervisor
-
-[program:cron]
-startsecs=0
-autostart=false
-autorestart=true
-command = /usr/sbin/cron
 
 [program:rsyslog]
 startsecs=0
 autostart=false
 autorestart=true
-command = /etc/init.d/rsyslog start
+command = /usr/sbin/rsyslogd -n
 
-[program:saslauthd]
-startsecs=0
-autostart=false
-autorestart=true
-command = /etc/init.d/saslauthd start
+
+# Couldn't figure out how to run this in the foreground. We'll start it without supervisor.
+#[program:saslauthd]
+#startsecs=0
+#autostart=false
+#autorestart=true
+#command = /etc/init.d/saslauthd start
 
 [program:fail2ban]
 startsecs=0
 autostart=false
 autorestart=true
-command = /etc/init.d/fail2ban start
+command = /usr/bin/fail2ban-server -f
 
 [program:opendkim]
 startsecs=0
 autostart=false
 autorestart=true
-command = /etc/init.d/opendkim start
+command = /usr/sbin/opendkim -f
 
 [program:opendmarc]
 startsecs=0
 autostart=false
 autorestart=true
-command = /etc/init.d/opendmarc start
+command = /usr/sbin/opendmarc -f -p local:/var/run/opendmarc/opendmarc.sock
 
-[program:postfix]
-startsecs=0
-autostart=false
-autorestart=true
-command = /etc/init.d/postfix start
+# Couldn't figure out how to run this in the foreground. We'll start it without supervisor.
+#[program:postfix]
+#startsecs=0
+#autostart=false
+#autorestart=true
+#command = /etc/init.d/postfix start
 
 [program:dovecot]
 startsecs=0
 autostart=false
 autorestart=true
-command = /usr/sbin/dovecot -c /etc/dovecot/dovecot.conf
+command = /usr/sbin/dovecot -F -c /etc/dovecot/dovecot.conf
 
 [program:filebeat]
 startsecs=0
 autostart=false
 autorestart=true
-command = /etc/init.d/filebeat start
+command = /usr/bin/filebeat -c /etc/filebeat/filebeat.yml
 
-[program:fetchmail]
-startsecs=0
-autostart=false
-autorestart=true
-command = /etc/init.d/fetchmail start
+# Couldn't figure out how to run this in the foreground. We'll start it without supervisor.
+#[program:fetchmail]
+#startsecs=0
+#autostart=false
+#autorestart=true
+#command = /usr/bin/fetchmail
 
 [program:clamav]
 startsecs=0
 autostart=false
 autorestart=true
-command = /etc/init.d/clamav-daemon start
+command = /usr/sbin/clamd -c /etc/clamav/clamd.conf
 
 [program:postgrey]
 startsecs=0
 autostart=false
 autorestart=true
-command = /etc/init.d/postgrey start
+command = /usr/sbin/postgrey --inet=127.0.0.1:10023
 
 [program:amavis]
 startsecs=0
 autostart=false
 autorestart=true
-command = /etc/init.d/amavis start
+command = /usr/sbin/amavisd-new foreground

--- a/target/supervisor/supervisor-app.conf
+++ b/target/supervisor/supervisor-app.conf
@@ -8,54 +8,90 @@
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0 
 command = /usr/sbin/rsyslogd -n
 
 [program:fail2ban]
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0 
 command = /usr/bin/fail2ban-server -f
 
 [program:opendkim]
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0 
 command = /usr/sbin/opendkim -f
 
 [program:opendmarc]
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0 
 command = /usr/sbin/opendmarc -f -p "inet:8893@localhost"
 
 [program:dovecot]
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0 
 command = /usr/sbin/dovecot -F -c /etc/dovecot/dovecot.conf
 
 [program:filebeat]
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 command = /usr/bin/filebeat -c /etc/filebeat/filebeat.yml
 
 [program:clamav]
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 command = /usr/sbin/clamd -c /etc/clamav/clamd.conf
 
 [program:postgrey]
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 command = /usr/sbin/postgrey --inet=127.0.0.1:10023
 
 [program:amavis]
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 command = /usr/sbin/amavisd-new foreground
 
 

--- a/target/supervisor/supervisor-app.conf
+++ b/target/supervisor/supervisor-app.conf
@@ -1,0 +1,83 @@
+# each program entry below is a separate terminal command.
+# Each command is expected to run in the foreground and stay running.
+# If the command ever exits, the supervisor daemon will automatically run it again.
+# Programs can be controlled like this: 'supervisorctl start fail2ban' 'supervisorctl stop fail2ban'
+# supervisor writes program statuses in /var/log/supervisor
+
+[program:cron]
+startsecs=0
+autostart=false
+autorestart=true
+command = /usr/sbin/cron
+
+[program:rsyslog]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/rsyslog start
+
+[program:saslauthd]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/saslauthd start
+
+[program:fail2ban]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/fail2ban start
+
+[program:opendkim]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/opendkim start
+
+[program:opendmarc]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/opendmarc start
+
+[program:postfix]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/postfix start
+
+[program:dovecot]
+startsecs=0
+autostart=false
+autorestart=true
+command = /usr/sbin/dovecot -c /etc/dovecot/dovecot.conf
+
+[program:filebeat]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/filebeat start
+
+[program:fetchmail]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/fetchmail start
+
+[program:clamav]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/clamav-daemon start
+
+[program:postgrey]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/postgrey start
+
+[program:amavis]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/amavis start

--- a/target/supervisor/supervisor-app.conf
+++ b/target/supervisor/supervisor-app.conf
@@ -10,14 +10,6 @@ autostart=false
 autorestart=true
 command = /usr/sbin/rsyslogd -n
 
-
-# Couldn't figure out how to run this in the foreground. We'll start it without supervisor.
-#[program:saslauthd]
-#startsecs=0
-#autostart=false
-#autorestart=true
-#command = /etc/init.d/saslauthd start
-
 [program:fail2ban]
 startsecs=0
 autostart=false
@@ -36,13 +28,6 @@ autostart=false
 autorestart=true
 command = /usr/sbin/opendmarc -f -p local:/var/run/opendmarc/opendmarc.sock
 
-# Couldn't figure out how to run this in the foreground. We'll start it without supervisor.
-#[program:postfix]
-#startsecs=0
-#autostart=false
-#autorestart=true
-#command = /etc/init.d/postfix start
-
 [program:dovecot]
 startsecs=0
 autostart=false
@@ -54,13 +39,6 @@ startsecs=0
 autostart=false
 autorestart=true
 command = /usr/bin/filebeat -c /etc/filebeat/filebeat.yml
-
-# Couldn't figure out how to run this in the foreground. We'll start it without supervisor.
-#[program:fetchmail]
-#startsecs=0
-#autostart=false
-#autorestart=true
-#command = /usr/bin/fetchmail
 
 [program:clamav]
 startsecs=0
@@ -79,3 +57,23 @@ startsecs=0
 autostart=false
 autorestart=true
 command = /usr/sbin/amavisd-new foreground
+
+
+# Couldn't figure out how to run these in the foreground. We'll start them without supervisor.
+#[program:fetchmail]
+#startsecs=0
+#autostart=false
+#autorestart=true
+#command = /usr/bin/fetchmail
+
+#[program:postfix]
+#startsecs=0
+#autostart=false
+#autorestart=true
+#command = /etc/init.d/postfix start
+
+#[program:saslauthd]
+#startsecs=0
+#autostart=false
+#autorestart=true
+#command = /etc/init.d/saslauthd start

--- a/target/supervisor/supervisor-app.conf
+++ b/target/supervisor/supervisor-app.conf
@@ -26,7 +26,7 @@ command = /usr/sbin/opendkim -f
 startsecs=0
 autostart=false
 autorestart=true
-command = /usr/sbin/opendmarc -f -p local:/var/run/opendmarc/opendmarc.sock
+command = /usr/sbin/opendmarc -f -p "inet:8893@localhost"
 
 [program:dovecot]
 startsecs=0

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -117,6 +117,52 @@ load 'test_helper/bats-assert/load'
 }
 
 #
+# supervisor
+#
+
+# <postfix isn't run with supervisor. No test for it.>
+
+@test "checking restart of process: clamd" {
+  run docker exec mail /bin/bash -c "pkill -f clamav && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/clamd'"
+  assert_success
+}
+
+@test "checking process: new" {
+  run docker exec mail /bin/bash -c "pkill -f amavis && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/amavisd-new'"
+  assert_success
+}
+
+@test "checking process: opendkim" {
+  run docker exec mail /bin/bash -c "pkill -f opendkim && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/opendkim'"
+  assert_success
+}
+
+@test "checking process: opendmarc" {
+  run docker exec mail /bin/bash -c "pkill -f opendmarc && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/opendmarc'"
+  assert_success
+}
+
+@test "checking process: fail2ban (fail2ban server enabled)" {
+  run docker exec mail_fail2ban /bin/bash -c "pkill -f fail2ban && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/bin/python3 /usr/bin/fail2ban-server'"
+  assert_success
+}
+
+# <fetchmail isn't run with supervisor. No test for it.>
+
+@test "checking process: clamav (clamav disabled by ENABLED_CLAMAV=0)" {
+  run docker exec mail_disabled_clamav_spamassassin /bin/bash -c "pkill -f clamd && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/clamd'"
+  assert_failure
+}
+
+@test "checking process: saslauthd (saslauthd server enabled)" {
+  run docker exec mail_with_ldap /bin/bash -c "pkill -f saslauthd && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/saslauthd'"
+  assert_success
+}
+
+# <saslauthd isn't run with supervisor. No test for it.>
+
+
+#
 # postgrey
 #
 


### PR DESCRIPTION
With this change, most of the services are run via supervisor, so they'll be automatically restarted if they die. Fixes #434 and #575

Note that to run the processes with supervisor I had to use the 'run in foreground' version of their start commands, rather than the init.d script that was used before.  @tomav you should verify that I haven't lost any special configurations you had for those services. 

Also, I added tests, but I'm having an error actually running the automated test suite on my machine. The problem seems unrelated to my changes. When I run `make`, the container `mail` fails to stay up. It looks like its start-mailserver.sh is exiting with this error:

```
Check that hostname/domainname is provided or overidden (no default docker hostname/kubernetes) [_check_hostname]
  * Setting hostname/domainname is required
```

Is any special environment required to run `make`?