### PR TITLE
Letsencrypt : do not check the optional cert.pem

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -747,8 +747,7 @@ function _setup_ssl() {
 	case $SSL_TYPE in
 		"letsencrypt" )
 			# letsencrypt folders and files mounted in /etc/letsencrypt
-			if [ -e "/etc/letsencrypt/live/$HOSTNAME/cert.pem" ] \
-			&& [ -e "/etc/letsencrypt/live/$HOSTNAME/fullchain.pem" ]; then
+			if [ -e "/etc/letsencrypt/live/$HOSTNAME/fullchain.pem" ]; then
 				KEY=""
 				if [ -e "/etc/letsencrypt/live/$HOSTNAME/privkey.pem" ]; then
 					KEY="privkey"


### PR DESCRIPTION
This letsencrypt docker image [https://github.com/janeczku/rancher-letsencrypt](url) doesn't create the cert.pem required to pass this test.