### PR TITLE
Integrate docker-configomat for configuration parts of start-mailserver.sh #648

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "test/test_helper/bats-assert"]
 	path = test/test_helper/bats-assert
 	url = https://github.com/ztombol/bats-assert
+[submodule "target/docker-configomat"]
+	path = target/docker-configomat
+	url = https://github.com/alinmear/docker-configomat

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,7 @@ RUN curl -s https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > /et
 
 COPY ./target/bin /usr/local/bin
 # Start-mailserver script
-COPY ./target/start-mailserver.sh /usr/local/bin/
+COPY ./target/start-mailserver.sh ./target/docker-configomat/configomat.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/*
 
 EXPOSE 25 587 143 993 110 995 4190


### PR DESCRIPTION
This pr integrates my project https://github.com/alinmear/docker-configomat for dealing with container configurations via ENV Variables. 

With this separate project testing whether substitution is working or not and also updating the logics behind them is much easier then doing this within `start-mailserver.sh` (own travis and bats).

This should also fix the problems with the special character `|` from https://github.com/tomav/docker-mailserver/pull/644#issuecomment-313879711 (@johansmitsnl).