### PR TITLE
Change Email-Folder to /var/mail/%d/%u/mails

### DIFF
--- a/target/dovecot/10-mail.conf
+++ b/target/dovecot/10-mail.conf
@@ -27,7 +27,7 @@
 #
 # <doc/wiki/MailLocation.txt>
 #
-mail_location = maildir:/var/mail/%d/%n
+mail_location = maildir:/var/mail/%d/%n/mails
 
 # If you need to set multiple mailbox locations or want to change default
 # namespace settings, you can do it by defining namespace sections.

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -534,15 +534,16 @@ function _setup_dovecot_local_user() {
 			# user:password:uid:gid:(gecos):home:(shell):extra_fields
 			# Example :
 			# ${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::userdb_mail=maildir:/var/mail/${domain}/${user}
-			echo "${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::" >> /etc/dovecot/userdb
+			echo "${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::userdb_mail=maildir:/var/mail/${domain}/${user}/mails" >> /etc/dovecot/userdb
 			mkdir -p /var/mail/${domain}
 			if [ ! -d "/var/mail/${domain}/${user}" ]; then
-				maildirmake.dovecot "/var/mail/${domain}/${user}"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Sent"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Trash"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Drafts"
-				echo -e "INBOX\nSent\nTrash\nDrafts" >> "/var/mail/${domain}/${user}/subscriptions"
-				touch "/var/mail/${domain}/${user}/.Sent/maildirfolder"
+			        mkdir -p /var/mail/${domain}/${user}
+				maildirmake.dovecot "/var/mail/${domain}/${user}/mails"
+				maildirmake.dovecot "/var/mail/${domain}/${user}/mails/.Sent"
+				maildirmake.dovecot "/var/mail/${domain}/${user}/mails/.Trash"
+				maildirmake.dovecot "/var/mail/${domain}/${user}/mails/.Drafts"
+				echo -e "INBOX\nSent\nTrash\nDrafts" >> "/var/mail/${domain}/${user}/mails/subscriptions"
+				touch "/var/mail/${domain}/${user}/mails/.Sent/maildirfolder"
 			fi
 			# Copy user provided sieve file, if present
 			test -e /tmp/docker-mailserver/${login}.dovecot.sieve && cp /tmp/docker-mailserver/${login}.dovecot.sieve /var/mail/${domain}/${user}/.dovecot.sieve

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -42,13 +42,13 @@ load 'test_helper/bats-assert/load'
 }
 
 @test "checking configuration: hostname/domainname override: check headers of received mail" {
-  run docker exec mail_override_hostname /bin/sh -c "ls -A /var/mail/localhost.localdomain/user1/new | wc -l | grep 1"
+  run docker exec mail_override_hostname /bin/sh -c "ls -A /var/mail/localhost.localdomain/user1/mails/new | wc -l | grep 1"
   assert_success
-  run docker exec mail_override_hostname /bin/sh -c "cat /var/mail/localhost.localdomain/user1/new/* | grep mail.my-domain.com"
+  run docker exec mail_override_hostname /bin/sh -c "cat /var/mail/localhost.localdomain/user1/mails/new/* | grep mail.my-domain.com"
   assert_success
 
   # test whether the container hostname is not found in received mail
-  run docker exec mail_override_hostname /bin/sh -c "cat /var/mail/localhost.localdomain/user1/new/* | grep unknown.domain.tld"
+  run docker exec mail_override_hostname /bin/sh -c "cat /var/mail/localhost.localdomain/user1/mails/new/* | grep unknown.domain.tld"
   assert_failure
 }
 
@@ -302,7 +302,7 @@ load 'test_helper/bats-assert/load'
 }
 
 @test "checking smtp: user1 should have received 6 mails" {
-  run docker exec mail /bin/sh -c "ls -A /var/mail/localhost.localdomain/user1/new | wc -l"
+  run docker exec mail /bin/sh -c "ls -A /var/mail/localhost.localdomain/user1/mails/new | wc -l"
   assert_success
   assert_output 6
 }
@@ -356,13 +356,13 @@ load 'test_helper/bats-assert/load'
 }
 
 @test "checking accounts: user mail folders for user1" {
-  run docker exec mail /bin/bash -c "ls -A /var/mail/localhost.localdomain/user1 | grep -E '.Drafts|.Sent|.Trash|cur|new|subscriptions|tmp' | wc -l"
+  run docker exec mail /bin/bash -c "ls -A /var/mail/localhost.localdomain/user1/mails | grep -E '.Drafts|.Sent|.Trash|cur|new|subscriptions|tmp' | wc -l"
   assert_success
   assert_output 7
 }
 
 @test "checking accounts: user mail folders for user2" {
-  run docker exec mail /bin/bash -c "ls -A /var/mail/otherdomain.tld/user2 | grep -E '.Drafts|.Sent|.Trash|cur|new|subscriptions|tmp' | wc -l"
+  run docker exec mail /bin/bash -c "ls -A /var/mail/otherdomain.tld/user2/mails | grep -E '.Drafts|.Sent|.Trash|cur|new|subscriptions|tmp' | wc -l"
   assert_success
   assert_output 7
 }
@@ -436,9 +436,9 @@ load 'test_helper/bats-assert/load'
 }
 
 @test "checking spamassassin: all registered domains should see spam headers" {
-  run docker exec mail /bin/sh -c "grep -ir 'X-Spam-' /var/mail/localhost.localdomain/user1/new"
+  run docker exec mail /bin/sh -c "grep -ir 'X-Spam-' /var/mail/localhost.localdomain/user1/mails/new"
   assert_success
-  run docker exec mail /bin/sh -c "grep -ir 'X-Spam-' /var/mail/otherdomain.tld/user2/new"
+  run docker exec mail /bin/sh -c "grep -ir 'X-Spam-' /var/mail/otherdomain.tld/user2/mails/new"
   assert_success
 }
 
@@ -781,7 +781,7 @@ load 'test_helper/bats-assert/load'
 #
 
 @test "checking sieve: user1 should have received 1 email in folder INBOX.spam" {
-  run docker exec mail /bin/sh -c "ls -A /var/mail/localhost.localdomain/user1/.INBOX.spam/new | wc -l"
+  run docker exec mail /bin/sh -c "ls -A /var/mail/localhost.localdomain/user1/mails/.INBOX.spam/new | wc -l"
   assert_success
   assert_output 1
 }
@@ -1073,6 +1073,7 @@ load 'test_helper/bats-assert/load'
   assert_success
 }
 
+# This is ldap, so the mail directory gets set differently!
 @test "checking dovecot: mail delivery works" {
   run docker exec mail_with_ldap /bin/sh -c "sendmail -f user@external.tld some.user@localhost.localdomain < /tmp/docker-mailserver-test/email-templates/test-email.txt"
   sleep 10


### PR DESCRIPTION
This solves the issue that when running managesieve, the .sieve-folder shows up as subscribable for IMAP clients but will produce an error when selecting. Mainly to remove clutter and to follow dovecot recommendations on not setting the same directory for user home and user mail.

This should not be merged as of yet, because it will break existing mail-stores. Hopefully though, this pull request will let me automatically run the travis-suite to check if the changes are safe for new installations.

Later, if the request is desirable, we could add a config flag like the many other's that already exist,