### PR TITLE
Disable logrotate and cron job for updating clamav if clamav is disabled (fixes #660)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,7 @@ RUN apt-get update -q --fix-missing && \
   touch /var/log/auth.log && \
   update-locale
 
-# Enables Clamav
-RUN (echo "0 0,6,12,18 * * * /usr/bin/freshclam --quiet" ; crontab -l) | crontab - && \
+RUN echo "0 0,6,12,18 * * * /usr/bin/freshclam --quiet" > /etc/cron.d/freshclam && \
   chmod 644 /etc/clamav/freshclam.conf && \
   freshclam
 

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -129,6 +129,9 @@ function register_functions() {
 
 	_register_fix_function "_fix_var_mail_permissions"
 	_register_fix_function "_fix_var_amavis_permissions"
+	if [ "$ENABLE_CLAMAV" = 0 ]; then
+        _register_fix_function "_fix_cleanup_clamav"
+	fi
 
 	################### << fix funcs
 
@@ -1048,6 +1051,12 @@ function _fix_var_amavis_permissions() {
 		notify 'inf' "Permissions in $amavis_state_dir look OK"
 		return 0
 	fi
+}
+
+function _fix_cleanup_clamav() {
+    notify 'task' 'Cleaning up disabled Clamav'
+    rm -f /etc/logrotate.d/clamav-*
+    rm -f /etc/cron.d/freshclam
 }
 
 ##########################################################################

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -716,7 +716,7 @@ load 'test_helper/bats-assert/load'
 #
 
 @test "checking system: freshclam cron is enabled" {
-  run docker exec mail bash -c "crontab -l | grep '/usr/bin/freshclam'"
+  run docker exec mail bash -c "grep '/usr/bin/freshclam' -r /etc/cron.d"
   assert_success
 }
 


### PR DESCRIPTION
This should fix #660.

Cron-Job is now written to `/etc/cron.d/freshclam`. On start, the cron job and logrotate files regarding clamav are removed if clamav is disabled. This means that this can not be reversed, but changing the environment should also spawn a new container with the files intact (in case someone wants to reenable clamav)

