### PR TITLE
remove /etc/cron.weekly/fstrim since we don't want to fstrim in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,8 @@ RUN apt-get update -q --fix-missing && \
   rm -rf /usr/share/man/* && \
   rm -rf /usr/share/doc/* && \
   touch /var/log/auth.log && \
-  update-locale
+  update-locale && \
+  rm -f /etc/cron.weekly/fstrim
 
 # Enables Clamav
 RUN (echo "0 0,6,12,18 * * * /usr/bin/freshclam --quiet" ; crontab -l) | crontab - && \


### PR DESCRIPTION
This fixes #662 
