### PR TITLE
Issue 631 run services with supervisor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,10 @@ RUN apt-get update -q --fix-missing && \
 
 RUN echo "0 0,6,12,18 * * * /usr/bin/freshclam --quiet" > /etc/cron.d/freshclam && \
   chmod 644 /etc/clamav/freshclam.conf && \
-  freshclam
+  freshclam && \
+  sed -i 's/Foreground false/Foreground true/g' /etc/clamav/clamd.conf && \
+  mkdir /var/run/clamav && \
+  chown -R clamav:root /var/run/clamav
 
 # Configures Dovecot
 COPY target/dovecot/auth-passwdfile.inc target/dovecot/??-*.conf /etc/dovecot/conf.d/
@@ -111,7 +114,7 @@ RUN sed -i -r 's/#(@|   \\%)bypass/\1bypass/g' /etc/amavis/conf.d/15-content_fil
 # Configure Fail2ban
 COPY target/fail2ban/jail.conf /etc/fail2ban/jail.conf
 COPY target/fail2ban/filter.d/dovecot.conf /etc/fail2ban/filter.d/dovecot.conf
-RUN echo "ignoreregex =" >> /etc/fail2ban/filter.d/postfix-sasl.conf
+RUN echo "ignoreregex =" >> /etc/fail2ban/filter.d/postfix-sasl.conf && mkdir /var/run/fail2ban
 
 # Enables Pyzor and Razor
 USER amavis
@@ -168,7 +171,7 @@ RUN chmod +x /usr/local/bin/*
 
 EXPOSE 25 587 143 993 110 995 4190
 
-CMD /usr/local/bin/start-mailserver.sh
+CMD /usr/local/bin/start-mailserver.sh > /var/log/container-startup.log
 
 
 ADD target/filebeat.yml.tmpl /etc/filebeat/filebeat.yml.tmpl

--- a/Dockerfile
+++ b/Dockerfile
@@ -183,3 +183,4 @@ EXPOSE 25 587 143 993 110 995 4190
 CMD supervisord -c /etc/supervisor/supervisord.conf
 
 ADD target/filebeat.yml.tmpl /etc/filebeat/filebeat.yml.tmpl
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -172,7 +172,7 @@ RUN chmod +x /usr/local/bin/*
 
 EXPOSE 25 587 143 993 110 995 4190
 
-CMD /usr/local/bin/start-mailserver.sh > /var/log/container-startup.log
+CMD /usr/local/bin/start-mailserver.sh | tee /var/log/container-startup.log
 
 
 ADD target/filebeat.yml.tmpl /etc/filebeat/filebeat.yml.tmpl

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ RUN echo "0 0,6,12,18 * * * /usr/bin/freshclam --quiet" > /etc/cron.d/freshclam 
   chmod 644 /etc/clamav/freshclam.conf && \
   freshclam && \
   sed -i 's/Foreground false/Foreground true/g' /etc/clamav/clamd.conf && \
+  sed -i 's/AllowSupplementaryGroups false/AllowSupplementaryGroups true/g' /etc/clamav/clamd.conf && \
   mkdir /var/run/clamav && \
   chown -R clamav:root /var/run/clamav
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update -q --fix-missing && \
     rsyslog \
     sasl2-bin \
     spamassassin \
+    supervisor \
     postgrey \
     unzip \
     && \
@@ -132,6 +133,9 @@ COPY target/opendmarc/ignore.hosts /etc/opendmarc/ignore.hosts
 # Configure fetchmail
 COPY target/fetchmail/fetchmailrc /etc/fetchmailrc_general
 RUN sed -i 's/START_DAEMON=no/START_DAEMON=yes/g' /etc/default/fetchmail
+
+# Configure supervisor
+COPY target/supervisor/supervisor-app.conf /etc/supervisor/conf.d/
 
 # Configures Postfix
 COPY target/postfix/main.cf target/postfix/master.cf /etc/postfix/

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,6 @@ run:
 		-e POSTMASTER_ADDRESS=postmaster@localhost.localdomain \
 		-e DMS_DEBUG=0 \
 		-h mail.my-domain.com -t $(NAME)
-	# Wait for containers to fully start
 	sleep 15
 	docker run -d --name mail_lmtp_ip \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
@@ -188,7 +187,7 @@ fixtures:
 
 	docker exec mail_override_hostname /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user1.txt"
 	# Wait for mails to be analyzed
-	sleep 40
+	sleep 20
 
 tests:
 	# Start tests

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ run:
 		-e SASL_PASSWD="external-domain.com username:password" \
 		-e ENABLE_MANAGESIEVE=1 \
 		-e PERMIT_DOCKER=host \
-		-e DMS_DEBUG=1 \
+		-e DMS_DEBUG=0 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
 	docker run -d --name mail_pop3 \
@@ -40,7 +40,7 @@ run:
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-v "`pwd`/test/config/letsencrypt":/etc/letsencrypt/live \
 		-e ENABLE_POP3=1 \
-		-e DMS_DEBUG=1 \
+		-e DMS_DEBUG=0 \
 		-e SSL_TYPE=letsencrypt \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
@@ -49,7 +49,7 @@ run:
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e SMTP_ONLY=1 \
 		-e PERMIT_DOCKER=network \
-		-e DMS_DEBUG=1 \
+		-e DMS_DEBUG=0 \
 		-e OVERRIDE_HOSTNAME=mail.my-domain.com \
 		-t $(NAME)
 	sleep 15
@@ -64,7 +64,7 @@ run:
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e PERMIT_DOCKER=network \
-		-e DMS_DEBUG=1 \
+		-e DMS_DEBUG=0 \
 		-e OVERRIDE_HOSTNAME=mail.my-domain.com \
 		-h mail.my-domain.com \
 		-t $(NAME)
@@ -81,7 +81,7 @@ run:
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e ENABLE_FETCHMAIL=1 \
 		--cap-add=NET_ADMIN \
-		-e DMS_DEBUG=1 \
+		-e DMS_DEBUG=0 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
 	docker run -d --name mail_disabled_clamav_spamassassin \
@@ -89,7 +89,7 @@ run:
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e ENABLE_CLAMAV=0 \
 		-e ENABLE_SPAMASSASSIN=0 \
-		-e DMS_DEBUG=1 \
+		-e DMS_DEBUG=0 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
 	docker run -d --name mail_manual_ssl \
@@ -98,7 +98,7 @@ run:
 		-e SSL_TYPE=manual \
 		-e SSL_CERT_PATH=/tmp/docker-mailserver/letsencrypt/mail.my-domain.com/fullchain.pem \
 		-e SSL_KEY_PATH=/tmp/docker-mailserver/letsencrypt/mail.my-domain.com/privkey.pem \
-		-e DMS_DEBUG=1 \
+		-e DMS_DEBUG=0 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
 	docker run -d --name ldap_for_mail \
@@ -125,7 +125,7 @@ run:
 		-e SASLAUTHD_LDAP_PASSWORD=admin \
 		-e SASLAUTHD_LDAP_SEARCH_BASE=ou=people,dc=localhost,dc=localdomain \
 		-e POSTMASTER_ADDRESS=postmaster@localhost.localdomain \
-		-e DMS_DEBUG=1 \
+		-e DMS_DEBUG=0 \
 		--link ldap_for_mail:ldap \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
@@ -136,7 +136,7 @@ run:
 		-e SASLAUTHD_MECHANISMS=rimap \
 		-e SASLAUTHD_MECH_OPTIONS=127.0.0.1 \
 		-e POSTMASTER_ADDRESS=postmaster@localhost.localdomain \
-		-e DMS_DEBUG=1 \
+		-e DMS_DEBUG=0 \
 		-h mail.my-domain.com -t $(NAME)
 	# Wait for containers to fully start
 	sleep 15
@@ -146,7 +146,7 @@ run:
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e ENABLE_POSTFIX_VIRTUAL_TRANSPORT=1 \
 		-e POSTFIX_DAGENT=lmtp:127.0.0.1:24 \
-		-e DMS_DEBUG=1 \
+		-e DMS_DEBUG=0 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 30
 	docker run -d --name mail_with_postgrey \
@@ -156,7 +156,7 @@ run:
 		-e POSTGREY_DELAY=15 \
 		-e POSTGREY_MAX_AGE=35 \
 		-e POSTGREY_TEXT="Delayed by postgrey" \
-		-e DMS_DEBUG=1 \
+		-e DMS_DEBUG=0 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 20
 
@@ -188,7 +188,7 @@ fixtures:
 
 	docker exec mail_override_hostname /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user1.txt"
 	# Wait for mails to be analyzed
-	sleep 20
+	sleep 40
 
 tests:
 	# Start tests

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ run:
 		-e SASL_PASSWD="external-domain.com username:password" \
 		-e ENABLE_MANAGESIEVE=1 \
 		-e PERMIT_DOCKER=host \
-		-e DMS_DEBUG=0 \
+		-e DMS_DEBUG=1 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
 	docker run -d --name mail_pop3 \
@@ -49,6 +49,7 @@ run:
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e SMTP_ONLY=1 \
 		-e PERMIT_DOCKER=network \
+		-e DMS_DEBUG=1 \
 		-e OVERRIDE_HOSTNAME=mail.my-domain.com \
 		-t $(NAME)
 	sleep 15
@@ -63,6 +64,7 @@ run:
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e PERMIT_DOCKER=network \
+		-e DMS_DEBUG=1 \
 		-e OVERRIDE_HOSTNAME=mail.my-domain.com \
 		-h mail.my-domain.com \
 		-t $(NAME)
@@ -79,6 +81,7 @@ run:
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e ENABLE_FETCHMAIL=1 \
 		--cap-add=NET_ADMIN \
+		-e DMS_DEBUG=1 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
 	docker run -d --name mail_disabled_clamav_spamassassin \
@@ -86,6 +89,7 @@ run:
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e ENABLE_CLAMAV=0 \
 		-e ENABLE_SPAMASSASSIN=0 \
+		-e DMS_DEBUG=1 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
 	docker run -d --name mail_manual_ssl \
@@ -94,6 +98,7 @@ run:
 		-e SSL_TYPE=manual \
 		-e SSL_CERT_PATH=/tmp/docker-mailserver/letsencrypt/mail.my-domain.com/fullchain.pem \
 		-e SSL_KEY_PATH=/tmp/docker-mailserver/letsencrypt/mail.my-domain.com/privkey.pem \
+		-e DMS_DEBUG=1 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
 	docker run -d --name ldap_for_mail \
@@ -120,6 +125,7 @@ run:
 		-e SASLAUTHD_LDAP_PASSWORD=admin \
 		-e SASLAUTHD_LDAP_SEARCH_BASE=ou=people,dc=localhost,dc=localdomain \
 		-e POSTMASTER_ADDRESS=postmaster@localhost.localdomain \
+		-e DMS_DEBUG=1 \
 		--link ldap_for_mail:ldap \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
@@ -130,6 +136,7 @@ run:
 		-e SASLAUTHD_MECHANISMS=rimap \
 		-e SASLAUTHD_MECH_OPTIONS=127.0.0.1 \
 		-e POSTMASTER_ADDRESS=postmaster@localhost.localdomain \
+		-e DMS_DEBUG=1 \
 		-h mail.my-domain.com -t $(NAME)
 	# Wait for containers to fully start
 	sleep 15
@@ -139,6 +146,7 @@ run:
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e ENABLE_POSTFIX_VIRTUAL_TRANSPORT=1 \
 		-e POSTFIX_DAGENT=lmtp:127.0.0.1:24 \
+		-e DMS_DEBUG=1 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 30
 	docker run -d --name mail_with_postgrey \
@@ -148,6 +156,7 @@ run:
 		-e POSTGREY_DELAY=15 \
 		-e POSTGREY_MAX_AGE=35 \
 		-e POSTGREY_TEXT="Delayed by postgrey" \
+		-e DMS_DEBUG=1 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 20
 

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ fixtures:
 
 	docker exec mail_override_hostname /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user1.txt"
 	# Wait for mails to be analyzed
-	sleep 20
+	sleep 40
 
 tests:
 	# Start tests

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,7 @@
 INFO=$(docker ps \
   --no-trunc \
   --format="{{.Image}}\t{{.Names}}\t{{.Command}}" | \
-  grep '/bin/sh -c /usr/local/bin/start-mailserver.sh')
+  grep "/bin/sh -c 'supervisord -c /etc/supervisor/supervisord.conf'")
 
 IMAGE_NAME=$(echo $INFO | awk '{print $1}')
 CONTAINER_NAME=$(echo $INFO | awk '{print $2}')

--- a/target/fail2ban-wrapper.sh
+++ b/target/fail2ban-wrapper.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# fail2ban-wrapper.sh, version 0.0.1
+#
+# You cannot start fail2ban in some foreground mode and
+# it's more or less important that docker doesn't kill
+# fail2ban and its chilren if you stop the container.
+#
+# Use this script with supervisord and it will take
+# care about starting and stopping fail2ban correctly.
+#
+# supervisord config snippet for fail2ban-wrapper:
+#
+# [program:fail2ban]
+# process_name = fail2ban
+# command = /path/to/fail2ban-wrapper.sh
+# startsecs = 0
+# autorestart = false
+#
+
+trap "/usr/bin/fail2ban-client stop" SIGINT
+trap "/usr/bin/fail2ban-client stop" SIGTERM
+trap "/usr/bin/fail2ban-client reload" SIGHUP
+
+# start fail2ban
+/usr/bin/fail2ban-client start
+
+# lets give fail2ban some time to start
+sleep 5
+
+# wait until fail2ban is dead (triggered by trap)
+while kill -0 "`cat /var/run/fail2ban/fail2ban.pid`"; do
+  sleep 5
+done

--- a/target/fail2ban-wrapper.sh
+++ b/target/fail2ban-wrapper.sh
@@ -31,3 +31,4 @@ sleep 5
 while kill -0 "`cat /var/run/fail2ban/fail2ban.pid`"; do
   sleep 5
 done
+

--- a/target/postfix-wrapper.sh
+++ b/target/postfix-wrapper.sh
@@ -31,3 +31,4 @@ sleep 5
 while kill -0 "`cat /var/spool/postfix/pid/master.pid`"; do
   sleep 5
 done
+

--- a/target/postfix-wrapper.sh
+++ b/target/postfix-wrapper.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# postfix-wrapper.sh, version 0.1.0
+#
+# You cannot start postfix in some foreground mode and
+# it's more or less important that docker doesn't kill
+# postfix and its chilren if you stop the container.
+#
+# Use this script with supervisord and it will take
+# care about starting and stopping postfix correctly.
+#
+# supervisord config snippet for postfix-wrapper:
+#
+# [program:postfix]
+# process_name = postfix
+# command = /path/to/postfix-wrapper.sh
+# startsecs = 0
+# autorestart = false
+#
+
+trap "service postfix stop" SIGINT
+trap "service postfix stop" SIGTERM
+trap "service postfix reload" SIGHUP
+
+# start postfix
+service postfix start
+
+# lets give postfix some time to start
+sleep 5
+
+# wait until postfix is dead (triggered by trap)
+while kill -0 "`cat /var/spool/postfix/pid/master.pid`"; do
+  sleep 5
+done

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1249,7 +1249,7 @@ notify 'taskgrp' "#"
 notify 'taskgrp' "#"
 notify 'taskgrp' ""
 
-supervisord -c /etc/supervisor/conf.d/supervisor-app.conf
+supervisord -c /etc/supervisor/supervisord.conf
 
 register_functions
 
@@ -1265,7 +1265,7 @@ notify 'taskgrp' "# $HOSTNAME is up and running"
 notify 'taskgrp' "#"
 notify 'taskgrp' ""
 
-
+touch /var/log/mail/mail.log
 tail -fn 0 /var/log/mail/mail.log
 
 

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1123,22 +1123,23 @@ function start_daemons() {
 }
 
 function _start_daemons_cron() {
-	notify 'task' 'Starting cron' 'n'
-    supervisorctl start cron
+	notify 'task' 'Skipping starting cron\n' 'n'
+    # cron starts automatically. I don't think this is necessary.
+    #supervisorctl start cron
 }
 
 function _start_daemons_rsyslog() {
-	notify 'task' 'Starting rsyslog' 'n'
+	notify 'task' 'Starting rsyslog ' 'n'
     supervisorctl start rsyslog
 }
 
 function _start_daemons_saslauthd() {
 	notify 'task' 'Starting saslauthd' 'n'
-    supervisorctl start saslauthd
+    display_startup_daemon "/etc/init.d/saslauthd start"
 }
 
 function _start_daemons_fail2ban() {
-	notify 'task' 'Starting fail2ban' 'n'
+	notify 'task' 'Starting fail2ban ' 'n'
 	touch /var/log/auth.log
 	# Delete fail2ban.sock that probably was left here after container restart
 	if [ -e /var/run/fail2ban/fail2ban.sock ]; then
@@ -1148,18 +1149,18 @@ function _start_daemons_fail2ban() {
 }
 
 function _start_daemons_opendkim() {
-	notify 'task' 'Starting opendkim' 'n'
+	notify 'task' 'Starting opendkim ' 'n'
     supervisorctl start opendkim
 }
 
 function _start_daemons_opendmarc() {
-	notify 'task' 'Starting opendmarc' 'n'
+	notify 'task' 'Starting opendmarc ' 'n'
     supervisorctl start opendmarc
 }
 
 function _start_daemons_postfix() {
 	notify 'task' 'Starting postfix' 'n'
-    supervisorctl start postfix
+    display_startup_daemon "/etc/init.d/postfix start"
 }
 
 function _start_daemons_dovecot() {
@@ -1170,7 +1171,7 @@ function _start_daemons_dovecot() {
 	if [ "$ENABLE_POP3" = 1 ]; then
 		notify 'task' 'Starting pop3 services' 'n'
 		mv /etc/dovecot/protocols.d/pop3d.protocol.disab /etc/dovecot/protocols.d/pop3d.protocol
-		display_startup_daemon "/usr/sbin/dovecot reload"
+		/usr/sbin/dovecot reload
 	fi
 
 	if [ -f /tmp/docker-mailserver/dovecot.cf ]; then
@@ -1196,7 +1197,7 @@ function _start_daemons_filebeat() {
 function _start_daemons_fetchmail() {
 	notify 'task' 'Starting fetchmail' 'n'
 	/usr/local/bin/setup-fetchmail
-    supervisorctl start fetchmail
+	display_startup_daemon "/etc/init.d/fetchmail start"
 }
 
 function _start_daemons_clamav() {
@@ -1248,7 +1249,7 @@ notify 'taskgrp' "#"
 notify 'taskgrp' "#"
 notify 'taskgrp' ""
 
-supervisord
+supervisord -c /etc/supervisor/conf.d/supervisor-app.conf
 
 register_functions
 

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1124,17 +1124,17 @@ function start_daemons() {
 
 function _start_daemons_cron() {
 	notify 'task' 'Starting cron' 'n'
-	display_startup_daemon "cron"
+    supervisorctl start cron
 }
 
 function _start_daemons_rsyslog() {
 	notify 'task' 'Starting rsyslog' 'n'
-	display_startup_daemon "/etc/init.d/rsyslog start"
+    supervisorctl start rsyslog
 }
 
 function _start_daemons_saslauthd() {
 	notify 'task' 'Starting saslauthd' 'n'
-	display_startup_daemon "/etc/init.d/saslauthd start"
+    supervisorctl start saslauthd
 }
 
 function _start_daemons_fail2ban() {
@@ -1144,28 +1144,28 @@ function _start_daemons_fail2ban() {
 	if [ -e /var/run/fail2ban/fail2ban.sock ]; then
 		rm /var/run/fail2ban/fail2ban.sock
 	fi
-	display_startup_daemon "/etc/init.d/fail2ban start"
+    supervisorctl start fail2ban
 }
 
 function _start_daemons_opendkim() {
 	notify 'task' 'Starting opendkim' 'n'
-	display_startup_daemon "/etc/init.d/opendkim start"
+    supervisorctl start opendkim
 }
 
 function _start_daemons_opendmarc() {
 	notify 'task' 'Starting opendmarc' 'n'
-	display_startup_daemon "/etc/init.d/opendmarc start"
+    supervisorctl start opendmarc
 }
 
 function _start_daemons_postfix() {
 	notify 'task' 'Starting postfix' 'n'
-	display_startup_daemon "/etc/init.d/postfix start"
+    supervisorctl start postfix
 }
 
 function _start_daemons_dovecot() {
 	# Here we are starting sasl and imap, not pop3 because it's disabled by default
 	notify 'task' 'Starting dovecot services' 'n'
-	display_startup_daemon "/usr/sbin/dovecot -c /etc/dovecot/dovecot.conf"
+    supervisorctl start dovecot
 
 	if [ "$ENABLE_POP3" = 1 ]; then
 		notify 'task' 'Starting pop3 services' 'n'
@@ -1190,30 +1190,30 @@ function _start_daemons_dovecot() {
 
 function _start_daemons_filebeat() {
 	notify 'task' 'Starting filebeat' 'n'
-	display_startup_daemon "/etc/init.d/filebeat start"
+    supervisorctl start filebeat
 }
 
 function _start_daemons_fetchmail() {
 	notify 'task' 'Starting fetchmail' 'n'
 	/usr/local/bin/setup-fetchmail
-	display_startup_daemon "/etc/init.d/fetchmail start"
+    supervisorctl start fetchmail
 }
 
 function _start_daemons_clamav() {
 	notify 'task' 'Starting clamav' 'n'
-	display_startup_daemon "/etc/init.d/clamav-daemon start"
+    supervisorctl start clamav
 }
 
 function _start_daemons_postgrey() {
 	notify 'task' 'Starting postgrey' 'n'
 	rm -f /var/run/postgrey/postgrey.pid
-	display_startup_daemon "/etc/init.d/postgrey start"
+    supervisorctl start postgrey
 }
 
 
 function _start_daemons_amavis() {
 	notify 'task' 'Starting amavis' 'n'
-	display_startup_daemon "/etc/init.d/amavis start"
+    supervisorctl start amavis
 }
 
 ##########################################################################
@@ -1247,6 +1247,8 @@ notify 'taskgrp' "# docker-mailserver"
 notify 'taskgrp' "#"
 notify 'taskgrp' "#"
 notify 'taskgrp' ""
+
+supervisord
 
 register_functions
 

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1164,19 +1164,22 @@ function _start_daemons_postfix() {
 
 function _start_daemons_dovecot() {
 	# Here we are starting sasl and imap, not pop3 because it's disabled by default
-	notify 'task' 'Starting dovecot services' 'n'
-    supervisorctl start dovecot
+
+	notify 'task' 'Starting dovecot services' 'n'	
 
 	if [ "$ENABLE_POP3" = 1 ]; then
 		notify 'task' 'Starting pop3 services' 'n'
 		mv /etc/dovecot/protocols.d/pop3d.protocol.disab /etc/dovecot/protocols.d/pop3d.protocol
-		/usr/sbin/dovecot reload
+		# /usr/sbin/dovecot reload
 	fi
 
 	if [ -f /tmp/docker-mailserver/dovecot.cf ]; then
 		cp /tmp/docker-mailserver/dovecot.cf /etc/dovecot/local.conf
-		/usr/sbin/dovecot reload
+		# /usr/sbin/dovecot reload
 	fi
+	
+
+    supervisorctl start dovecot
 
 	# @TODO fix: on integration test
 	# doveadm: Error: userdb lookup: connect(/var/run/dovecot/auth-userdb) failed: No such file or directory

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1123,9 +1123,8 @@ function start_daemons() {
 }
 
 function _start_daemons_cron() {
-	notify 'task' 'Skipping starting cron\n' 'n'
-    # cron starts automatically. I don't think this is necessary.
-    #supervisorctl start cron
+	notify 'task' 'Starting cron' 'n'
+	display_startup_daemon "cron"
 }
 
 function _start_daemons_rsyslog() {

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1158,12 +1158,10 @@ function _start_daemons_dovecot() {
 	if [ "$ENABLE_POP3" = 1 ]; then
 		notify 'task' 'Starting pop3 services' 'n'
 		mv /etc/dovecot/protocols.d/pop3d.protocol.disab /etc/dovecot/protocols.d/pop3d.protocol
-		# /usr/sbin/dovecot reload
 	fi
 
 	if [ -f /tmp/docker-mailserver/dovecot.cf ]; then
 		cp /tmp/docker-mailserver/dovecot.cf /etc/dovecot/local.conf
-		# /usr/sbin/dovecot reload
 	fi
 
     supervisorctl start dovecot

--- a/target/supervisor/saslauth.conf
+++ b/target/supervisor/saslauth.conf
@@ -42,3 +42,4 @@ stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 command=/usr/sbin/saslauthd -d -a shadow -O %(ENV_SASLAUTHD_MECH_OPTIONS)s
 pidfile=/var/run/saslauthd/saslauthd.pid
+

--- a/target/supervisor/saslauth.conf
+++ b/target/supervisor/saslauth.conf
@@ -1,0 +1,44 @@
+[program:saslauthd_ldap]
+startsecs=0
+autostart=false
+autorestart=true
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/usr/sbin/saslauthd -d -a ldap -O /etc/saslauthd.conf
+pidfile=/var/run/saslauthd/saslauthd.pid
+
+[program:saslauthd_mysql]
+startsecs=0
+autostart=false
+autorestart=true
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/usr/sbin/saslauthd -d -a mysql -O %(ENV_SASLAUTHD_MECH_OPTIONS)s
+pidfile=/var/run/saslauthd/saslauthd.pid
+
+[program:saslauthd_pam]
+startsecs=0
+autostart=false
+autorestart=true
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/usr/sbin/saslauthd -d -a pam -O %(ENV_SASLAUTHD_MECH_OPTIONS)s
+pidfile=/var/run/saslauthd/saslauthd.pid
+
+[program:saslauthd_rimap]
+startsecs=0
+autostart=false
+autorestart=true
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/usr/sbin/saslauthd -d -a rimap -r -O %(ENV_SASLAUTHD_MECH_OPTIONS)s
+pidfile=/var/run/saslauthd/saslauthd.pid
+
+[program:saslauthd_shadow]
+startsecs=0
+autostart=false
+autorestart=true
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/usr/sbin/saslauthd -d -a shadow -O %(ENV_SASLAUTHD_MECH_OPTIONS)s
+pidfile=/var/run/saslauthd/saslauthd.pid

--- a/target/supervisor/supervisor-app.conf
+++ b/target/supervisor/supervisor-app.conf
@@ -1,83 +1,81 @@
 # each program entry below is a separate terminal command.
-# Each command is expected to run in the foreground and stay running.
+# Each command MUST run in the foreground and stay running.
 # If the command ever exits, the supervisor daemon will automatically run it again.
 # Programs can be controlled like this: 'supervisorctl start fail2ban' 'supervisorctl stop fail2ban'
 # supervisor writes program statuses in /var/log/supervisor
-
-[program:cron]
-startsecs=0
-autostart=false
-autorestart=true
-command = /usr/sbin/cron
 
 [program:rsyslog]
 startsecs=0
 autostart=false
 autorestart=true
-command = /etc/init.d/rsyslog start
+command = /usr/sbin/rsyslogd -n
 
-[program:saslauthd]
-startsecs=0
-autostart=false
-autorestart=true
-command = /etc/init.d/saslauthd start
+
+# Couldn't figure out how to run this in the foreground. We'll start it without supervisor.
+#[program:saslauthd]
+#startsecs=0
+#autostart=false
+#autorestart=true
+#command = /etc/init.d/saslauthd start
 
 [program:fail2ban]
 startsecs=0
 autostart=false
 autorestart=true
-command = /etc/init.d/fail2ban start
+command = /usr/bin/fail2ban-server -f
 
 [program:opendkim]
 startsecs=0
 autostart=false
 autorestart=true
-command = /etc/init.d/opendkim start
+command = /usr/sbin/opendkim -f
 
 [program:opendmarc]
 startsecs=0
 autostart=false
 autorestart=true
-command = /etc/init.d/opendmarc start
+command = /usr/sbin/opendmarc -f -p local:/var/run/opendmarc/opendmarc.sock
 
-[program:postfix]
-startsecs=0
-autostart=false
-autorestart=true
-command = /etc/init.d/postfix start
+# Couldn't figure out how to run this in the foreground. We'll start it without supervisor.
+#[program:postfix]
+#startsecs=0
+#autostart=false
+#autorestart=true
+#command = /etc/init.d/postfix start
 
 [program:dovecot]
 startsecs=0
 autostart=false
 autorestart=true
-command = /usr/sbin/dovecot -c /etc/dovecot/dovecot.conf
+command = /usr/sbin/dovecot -F -c /etc/dovecot/dovecot.conf
 
 [program:filebeat]
 startsecs=0
 autostart=false
 autorestart=true
-command = /etc/init.d/filebeat start
+command = /usr/bin/filebeat -c /etc/filebeat/filebeat.yml
 
-[program:fetchmail]
-startsecs=0
-autostart=false
-autorestart=true
-command = /etc/init.d/fetchmail start
+# Couldn't figure out how to run this in the foreground. We'll start it without supervisor.
+#[program:fetchmail]
+#startsecs=0
+#autostart=false
+#autorestart=true
+#command = /usr/bin/fetchmail
 
 [program:clamav]
 startsecs=0
 autostart=false
 autorestart=true
-command = /etc/init.d/clamav-daemon start
+command = /usr/sbin/clamd -c /etc/clamav/clamd.conf
 
 [program:postgrey]
 startsecs=0
 autostart=false
 autorestart=true
-command = /etc/init.d/postgrey start
+command = /usr/sbin/postgrey --inet=127.0.0.1:10023
 
 [program:amavis]
 startsecs=0
 autostart=false
 autorestart=true
-command = /etc/init.d/amavis start
+command = /usr/sbin/amavisd-new foreground

--- a/target/supervisor/supervisor-app.conf
+++ b/target/supervisor/supervisor-app.conf
@@ -4,112 +4,112 @@
 # Programs can be controlled like this: 'supervisorctl start fail2ban' 'supervisorctl stop fail2ban'
 # supervisor writes program statuses in /var/log/supervisor
 
+[supervisord]
+nodaemon=true
+
+[program:mailserver]
+startsecs=0
+autostart=true
+autorestart=false
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+command=/usr/local/bin/start-mailserver.sh
+
+[program:cron]
+startsecs=0
+autostart=false
+autorestart=true
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/usr/sbin/cron -f
+
 [program:rsyslog]
 startsecs=0
 autostart=false
 autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0 
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0 
-command = /usr/sbin/rsyslogd -n
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/usr/sbin/rsyslogd -n
 
 [program:fail2ban]
 startsecs=0
 autostart=false
 autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0 
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0 
-command = /usr/bin/fail2ban-server -f
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/usr/local/bin/fail2ban-wrapper.sh
 
 [program:opendkim]
 startsecs=0
 autostart=false
 autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0 
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0 
-command = /usr/sbin/opendkim -f
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/usr/sbin/opendkim -f
 
 [program:opendmarc]
 startsecs=0
 autostart=false
 autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0 
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0 
-command = /usr/sbin/opendmarc -f -p "inet:8893@localhost"
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/usr/sbin/opendmarc -f -p "inet:8893@localhost" -P /var/run/opendmarc/opendmarc.pid
 
 [program:dovecot]
 startsecs=0
 autostart=false
 autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0 
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0 
-command = /usr/sbin/dovecot -F -c /etc/dovecot/dovecot.conf
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/usr/sbin/dovecot -F -c /etc/dovecot/dovecot.conf
 
 [program:filebeat]
 startsecs=0
 autostart=false
 autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0 
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-command = /usr/bin/filebeat -c /etc/filebeat/filebeat.yml
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/usr/bin/filebeat -c /etc/filebeat/filebeat.yml
 
 [program:clamav]
 startsecs=0
 autostart=false
 autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0 
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-command = /usr/sbin/clamd -c /etc/clamav/clamd.conf
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/usr/sbin/clamd -c /etc/clamav/clamd.conf
 
 [program:postgrey]
 startsecs=0
 autostart=false
 autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0 
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-command = /usr/sbin/postgrey --inet=127.0.0.1:10023
+stdout_logfile=/var/log/mail/mail.log
+stderr_logfile=/var/log/mail/mail.log
+command=/usr/sbin/postgrey --inet=127.0.0.1:10023 --syslog-facility=mail --delay=%(ENV_POSTGREY_DELAY)s --max-age=%(ENV_POSTGREY_MAX_AGE)s --greylist-text="%(ENV_POSTGREY_TEXT)s"
 
 [program:amavis]
 startsecs=0
 autostart=false
 autorestart=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0 
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-command = /usr/sbin/amavisd-new foreground
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/usr/sbin/amavisd-new foreground
 
+[program:fetchmail]
+startsecs=0
+autostart=false
+autorestart=true
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+user=fetchmail
+command=/usr/bin/fetchmail -f /etc/fetchmailrc -v --nodetach --daemon 300 -i /var/lib/fetchmail/.fetchmail-UIDL-cache --pidfile /var/run/fetchmail/fetchmail.pid
 
-# Couldn't figure out how to run these in the foreground. We'll start them without supervisor.
-#[program:fetchmail]
-#startsecs=0
-#autostart=false
-#autorestart=true
-#command = /usr/bin/fetchmail
-
-#[program:postfix]
-#startsecs=0
-#autostart=false
-#autorestart=true
-#command = /etc/init.d/postfix start
-
-#[program:saslauthd]
-#startsecs=0
-#autostart=false
-#autorestart=true
-#command = /etc/init.d/saslauthd start
+[program:postfix]
+startsecs=0
+autostart=false
+autorestart=true
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/usr/local/bin/postfix-wrapper.sh

--- a/target/supervisor/supervisor-app.conf
+++ b/target/supervisor/supervisor-app.conf
@@ -8,54 +8,90 @@
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0 
 command = /usr/sbin/rsyslogd -n
 
 [program:fail2ban]
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0 
 command = /usr/bin/fail2ban-server -f
 
 [program:opendkim]
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0 
 command = /usr/sbin/opendkim -f
 
 [program:opendmarc]
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0 
 command = /usr/sbin/opendmarc -f -p "inet:8893@localhost"
 
 [program:dovecot]
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0 
 command = /usr/sbin/dovecot -F -c /etc/dovecot/dovecot.conf
 
 [program:filebeat]
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 command = /usr/bin/filebeat -c /etc/filebeat/filebeat.yml
 
 [program:clamav]
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 command = /usr/sbin/clamd -c /etc/clamav/clamd.conf
 
 [program:postgrey]
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 command = /usr/sbin/postgrey --inet=127.0.0.1:10023
 
 [program:amavis]
 startsecs=0
 autostart=false
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0 
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 command = /usr/sbin/amavisd-new foreground
 
 

--- a/target/supervisor/supervisor-app.conf
+++ b/target/supervisor/supervisor-app.conf
@@ -113,3 +113,4 @@ autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 command=/usr/local/bin/postfix-wrapper.sh
+

--- a/target/supervisor/supervisor-app.conf
+++ b/target/supervisor/supervisor-app.conf
@@ -1,0 +1,83 @@
+# each program entry below is a separate terminal command.
+# Each command is expected to run in the foreground and stay running.
+# If the command ever exits, the supervisor daemon will automatically run it again.
+# Programs can be controlled like this: 'supervisorctl start fail2ban' 'supervisorctl stop fail2ban'
+# supervisor writes program statuses in /var/log/supervisor
+
+[program:cron]
+startsecs=0
+autostart=false
+autorestart=true
+command = /usr/sbin/cron
+
+[program:rsyslog]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/rsyslog start
+
+[program:saslauthd]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/saslauthd start
+
+[program:fail2ban]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/fail2ban start
+
+[program:opendkim]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/opendkim start
+
+[program:opendmarc]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/opendmarc start
+
+[program:postfix]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/postfix start
+
+[program:dovecot]
+startsecs=0
+autostart=false
+autorestart=true
+command = /usr/sbin/dovecot -c /etc/dovecot/dovecot.conf
+
+[program:filebeat]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/filebeat start
+
+[program:fetchmail]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/fetchmail start
+
+[program:clamav]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/clamav-daemon start
+
+[program:postgrey]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/postgrey start
+
+[program:amavis]
+startsecs=0
+autostart=false
+autorestart=true
+command = /etc/init.d/amavis start

--- a/target/supervisor/supervisor-app.conf
+++ b/target/supervisor/supervisor-app.conf
@@ -10,14 +10,6 @@ autostart=false
 autorestart=true
 command = /usr/sbin/rsyslogd -n
 
-
-# Couldn't figure out how to run this in the foreground. We'll start it without supervisor.
-#[program:saslauthd]
-#startsecs=0
-#autostart=false
-#autorestart=true
-#command = /etc/init.d/saslauthd start
-
 [program:fail2ban]
 startsecs=0
 autostart=false
@@ -36,13 +28,6 @@ autostart=false
 autorestart=true
 command = /usr/sbin/opendmarc -f -p local:/var/run/opendmarc/opendmarc.sock
 
-# Couldn't figure out how to run this in the foreground. We'll start it without supervisor.
-#[program:postfix]
-#startsecs=0
-#autostart=false
-#autorestart=true
-#command = /etc/init.d/postfix start
-
 [program:dovecot]
 startsecs=0
 autostart=false
@@ -54,13 +39,6 @@ startsecs=0
 autostart=false
 autorestart=true
 command = /usr/bin/filebeat -c /etc/filebeat/filebeat.yml
-
-# Couldn't figure out how to run this in the foreground. We'll start it without supervisor.
-#[program:fetchmail]
-#startsecs=0
-#autostart=false
-#autorestart=true
-#command = /usr/bin/fetchmail
 
 [program:clamav]
 startsecs=0
@@ -79,3 +57,23 @@ startsecs=0
 autostart=false
 autorestart=true
 command = /usr/sbin/amavisd-new foreground
+
+
+# Couldn't figure out how to run these in the foreground. We'll start them without supervisor.
+#[program:fetchmail]
+#startsecs=0
+#autostart=false
+#autorestart=true
+#command = /usr/bin/fetchmail
+
+#[program:postfix]
+#startsecs=0
+#autostart=false
+#autorestart=true
+#command = /etc/init.d/postfix start
+
+#[program:saslauthd]
+#startsecs=0
+#autostart=false
+#autorestart=true
+#command = /etc/init.d/saslauthd start

--- a/target/supervisor/supervisor-app.conf
+++ b/target/supervisor/supervisor-app.conf
@@ -26,7 +26,7 @@ command = /usr/sbin/opendkim -f
 startsecs=0
 autostart=false
 autorestart=true
-command = /usr/sbin/opendmarc -f -p local:/var/run/opendmarc/opendmarc.sock
+command = /usr/sbin/opendmarc -f -p "inet:8893@localhost"
 
 [program:dovecot]
 startsecs=0

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1233,3 +1233,4 @@ load 'test_helper/bats-assert/load'
   run docker exec mail_with_ldap /bin/bash -c "pkill saslauthd && sleep 10 && ps aux --forest | grep -v grep | grep '/usr/sbin/saslauthd'"
   assert_success
 }
+

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -111,56 +111,6 @@ load 'test_helper/bats-assert/load'
   assert_success
 }
 
-@test "checking process: saslauthd (saslauthd server enabled)" {
-  run docker exec mail_with_imap /bin/bash -c "ps aux --forest | grep -v grep | grep '/usr/sbin/saslauthd'"
-  assert_success
-}
-
-#
-# supervisor
-#
-
-# <postfix isn't run with supervisor. No test for it.>
-
-@test "checking restart of process: clamd" {
-  run docker exec mail /bin/bash -c "pkill -f clamav && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/clamd'"
-  assert_success
-}
-
-@test "checking process: new" {
-  run docker exec mail /bin/bash -c "pkill -f amavis && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/amavisd-new'"
-  assert_success
-}
-
-@test "checking process: opendkim" {
-  run docker exec mail /bin/bash -c "pkill -f opendkim && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/opendkim'"
-  assert_success
-}
-
-@test "checking process: opendmarc" {
-  run docker exec mail /bin/bash -c "pkill -f opendmarc && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/opendmarc'"
-  assert_success
-}
-
-@test "checking process: fail2ban (fail2ban server enabled)" {
-  run docker exec mail_fail2ban /bin/bash -c "pkill -f fail2ban && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/bin/python3 /usr/bin/fail2ban-server'"
-  assert_success
-}
-
-# <fetchmail isn't run with supervisor. No test for it.>
-
-@test "checking process: clamav (clamav disabled by ENABLED_CLAMAV=0)" {
-  run docker exec mail_disabled_clamav_spamassassin /bin/bash -c "pkill -f clamd && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/clamd'"
-  assert_failure
-}
-
-@test "checking process: saslauthd (saslauthd server enabled)" {
-  run docker exec mail_with_ldap /bin/bash -c "pkill -f saslauthd && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/saslauthd'"
-  assert_success
-}
-
-# <saslauthd isn't run with supervisor. No test for it.>
-
 
 #
 # postgrey
@@ -1232,4 +1182,54 @@ load 'test_helper/bats-assert/load'
       'nmap --script ssl-enum-ciphers -p 587 postfix | grep "warnings" | wc -l'
   assert_success
   assert_output 0
+}
+
+
+#
+# supervisor
+#
+
+@test "checking restart of process: postfix" {
+  run docker exec mail /bin/bash -c "pkill master && sleep 10 && ps aux --forest | grep -v grep | grep '/usr/lib/postfix/sbin/master'"
+  assert_success
+}
+
+@test "checking restart of process: clamd" {
+  run docker exec mail /bin/bash -c "pkill clamd && sleep 10 && ps aux --forest | grep -v grep | grep '/usr/sbin/clamd'"
+  assert_success
+}
+
+@test "checking restart of process: amavisd-new" {
+  run docker exec mail /bin/bash -c "pkill amavi && sleep 10 && ps aux --forest | grep -v grep | grep '/usr/sbin/amavisd-new (master)'"
+  assert_success
+}
+
+@test "checking restart of process: opendkim" {
+  run docker exec mail /bin/bash -c "pkill opendkim && sleep 10 && ps aux --forest | grep -v grep | grep '/usr/sbin/opendkim'"
+  assert_success
+}
+
+@test "checking restart of process: opendmarc" {
+  run docker exec mail /bin/bash -c "pkill opendmarc && sleep 10 && ps aux --forest | grep -v grep | grep '/usr/sbin/opendmarc'"
+  assert_success
+}
+
+@test "checking restart of process: fail2ban (fail2ban server enabled)" {
+  run docker exec mail_fail2ban /bin/bash -c "pkill fail2ban && sleep 10 && ps aux --forest | grep -v grep | grep '/usr/bin/python3 /usr/bin/fail2ban-server'"
+  assert_success
+}
+
+@test "checking restart of process: fetchmail" {
+  run docker exec mail_fetchmail /bin/bash -c "pkill fetchmail && sleep 10 && ps aux --forest | grep -v grep | grep '/usr/bin/fetchmail'"
+  assert_success
+}
+
+@test "checking restart of process: clamav (clamav disabled by ENABLED_CLAMAV=0)" {
+  run docker exec mail_disabled_clamav_spamassassin /bin/bash -c "pkill -f clamd && sleep 10 && ps aux --forest | grep -v grep | grep '/usr/sbin/clamd'"
+  assert_failure
+}
+
+@test "checking restart of process: saslauthd (saslauthd server enabled)" {
+  run docker exec mail_with_ldap /bin/bash -c "pkill saslauthd && sleep 10 && ps aux --forest | grep -v grep | grep '/usr/sbin/saslauthd'"
+  assert_success
 }

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -117,6 +117,52 @@ load 'test_helper/bats-assert/load'
 }
 
 #
+# supervisor
+#
+
+# <postfix isn't run with supervisor. No test for it.>
+
+@test "checking restart of process: clamd" {
+  run docker exec mail /bin/bash -c "pkill -f clamav && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/clamd'"
+  assert_success
+}
+
+@test "checking process: new" {
+  run docker exec mail /bin/bash -c "pkill -f amavis && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/amavisd-new'"
+  assert_success
+}
+
+@test "checking process: opendkim" {
+  run docker exec mail /bin/bash -c "pkill -f opendkim && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/opendkim'"
+  assert_success
+}
+
+@test "checking process: opendmarc" {
+  run docker exec mail /bin/bash -c "pkill -f opendmarc && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/opendmarc'"
+  assert_success
+}
+
+@test "checking process: fail2ban (fail2ban server enabled)" {
+  run docker exec mail_fail2ban /bin/bash -c "pkill -f fail2ban && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/bin/python3 /usr/bin/fail2ban-server'"
+  assert_success
+}
+
+# <fetchmail isn't run with supervisor. No test for it.>
+
+@test "checking process: clamav (clamav disabled by ENABLED_CLAMAV=0)" {
+  run docker exec mail_disabled_clamav_spamassassin /bin/bash -c "pkill -f clamd && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/clamd'"
+  assert_failure
+}
+
+@test "checking process: saslauthd (saslauthd server enabled)" {
+  run docker exec mail_with_ldap /bin/bash -c "pkill -f saslauthd && sleep 5 && ps aux --forest | grep -v grep | grep '/usr/sbin/saslauthd'"
+  assert_success
+}
+
+# <saslauthd isn't run with supervisor. No test for it.>
+
+
+#
 # postgrey
 #
 


### PR DESCRIPTION
Use the supervisor as the main process. The start-mailserver is started
from the supervisord and then this process triggers others.

Defined some default variable in the Dockerfile. In order for
supervisored to build the command lines the ENV variable need to be set.
Therefore the defaults are defined.

Some processes are not single processes like postfix and fail2ban and
they have a wrapper. The wrapper takes care of proper shutdown and checking
if the process is running or not. Supervisored will restart the wrapping
script if the process is gone.

Increased some delays between tests because sometimes they where to short
for all containers to be running.