### PR TITLE
Also test on the submission port if the login is succesful

### DIFF
--- a/test/config/opendkim/KeyTable
+++ b/test/config/opendkim/KeyTable
@@ -1,2 +1,2 @@
-mail._domainkey.localhost.localdomain localhost.localdomain:mail:/tmp/docker-mailserver/opendkim/keys/localhost.localdomain/mail.private
-mail._domainkey.otherdomain.tld otherdomain.tld:mail:/tmp/docker-mailserver/opendkim/keys/otherdomain.tld/mail.private
+mail._domainkey.localhost.localdomain localhost.localdomain:mail:/etc/opendkim/keys/localhost.localdomain/mail.private
+mail._domainkey.otherdomain.tld otherdomain.tld:mail:/etc/opendkim/keys/otherdomain.tld/mail.private

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1117,6 +1117,8 @@ load 'test_helper/bats-assert/load'
 @test "checking saslauthd: ldap smtp authentication" {
   run docker exec mail_with_ldap /bin/sh -c "nc -w 5 0.0.0.0 25 < /tmp/docker-mailserver-test/auth/sasl-ldap-smtp-auth.txt | grep 'Authentication successful'"
   assert_success
+  run docker exec mail_with_ldap /bin/sh -c "openssl s_client -quiet -starttls smtp -connect 0.0.0.0:587 < /tmp/docker-mailserver-test/auth/sasl-ldap-smtp-auth.txt | grep 'Authentication successful'"
+  assert_success
 }
 
 


### PR DESCRIPTION
When making a new PR I noticed that there was no test for smtp authentication on the submission port.
While adding it opendkim is complaining about the permission in the KeyTable location. It is set to /tmp/... but this is wrong.
This PR fixes the path and adds a test for smtp authentication on the submission port.