### PR TITLE
Clean any leftover pid file from a stop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ fixtures:
 
 	docker exec mail_override_hostname /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user1.txt"
 	# Wait for mails to be analyzed
-	sleep 40
+	sleep 60
 
 tests:
 	# Start tests

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1012,6 +1012,9 @@ function fix() {
 		$_func
 		[ $? != 0 ] && defunc
 	done
+
+        notify 'taskgrg' "Remove leftover pid files from a stop/start"
+        rm -rf /var/run/*.pid /var/run/*/*.pid
 }
 
 function _fix_var_mail_permissions() {


### PR DESCRIPTION
During a stop and start pid files can be left over with wrong information.
Clean them before starting new services.

See #697