### PR TITLE
Improve the privacy of the client by removing sensitive details

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update -q --fix-missing && \
     pax \
     p7zip-full \
     postfix-ldap \
+    postfix-pcre \
     postfix-policyd-spf-python \
     pyzor \
     rar \
@@ -127,7 +128,7 @@ RUN chmod 755 /etc/init.d/postgrey && \
   chown postgrey:postgrey /var/run/postgrey
 
 # Enables Amavis
-COPY target/amavis/conf.d/60-dms_default_config /etc/amavis/conf.d/
+COPY target/amavis/conf.d/* /etc/amavis/conf.d/
 RUN sed -i -r 's/#(@|   \\%)bypass/\1bypass/g' /etc/amavis/conf.d/15-content_filter_mode && \
   adduser clamav amavis && \
   adduser amavis clamav && \
@@ -163,6 +164,7 @@ RUN mkdir /var/run/fetchmail && chown fetchmail /var/run/fetchmail
 
 # Configures Postfix
 COPY target/postfix/main.cf target/postfix/master.cf /etc/postfix/
+COPY target/postfix/sender_header_filter.pcre /etc/postfix/maps/sender_header_filter.pcre
 RUN echo "" > /etc/aliases && \
   openssl dhparam -out /etc/postfix/dhparams.pem 2048
 

--- a/target/amavis/conf.d/62-improve_privacy_remove_headers
+++ b/target/amavis/conf.d/62-improve_privacy_remove_headers
@@ -1,0 +1,11 @@
+use strict;
+
+# disable the "Received" headers to be added to the mail header
+$allowed_added_header_fields{lc('Received')} = 0;
+
+# Hide with whay virus scanner we scan
+$X_HEADER_LINE = "Yes";
+
+#------------ Do not modify anything below this line -------------
+1;  # ensure a defined return
+

--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -76,3 +76,7 @@ non_smtpd_milters = $dkim_milter
 
 # SPF policy settings
 policyd-spf_time_limit = 3600
+
+# Remove unwanted headers that reveail our privacy
+smtp_header_checks = pcre:/etc/postfix/maps/sender_header_filter.pcre
+

--- a/target/postfix/master.cf
+++ b/target/postfix/master.cf
@@ -22,6 +22,7 @@ submission inet n       -       n       -       -       smtpd
   -o smtpd_client_restrictions=permit_sasl_authenticated,reject
   -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
   -o milter_macro_daemon_name=ORIGINATING
+  -o cleanup_service_name=sender-cleanup
 
 smtps     inet  n       -       n       -       -       smtpd
   -o syslog_name=postfix/smtps
@@ -34,6 +35,7 @@ smtps     inet  n       -       n       -       -       smtpd
   -o smtpd_client_restrictions=permit_sasl_authenticated,reject
   -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
   -o milter_macro_daemon_name=ORIGINATING
+  -o cleanup_service_name=sender-cleanup
 
 pickup    fifo  n       -       y       60      1       pickup
   -o content_filter=
@@ -75,6 +77,9 @@ scalemail-backend unix	-	n	n	-	2	pipe
 mailman   unix  -       n       n       -       -       pipe
   flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
   ${nexthop} ${user}
+sender-cleanup unix n   -       -       -       0       cleanup
+  -o syslog_name=postfix/sender-cleanup
+  -o header_checks=pcre:/etc/postfix/maps/sender_header_filter.pcre
 
 #
 # SPF configuration

--- a/target/postfix/sender_header_filter.pcre
+++ b/target/postfix/sender_header_filter.pcre
@@ -1,0 +1,11 @@
+/^\s*Received:.*with ESMTPSA/       IGNORE
+/^\s*Received:.*amavisd-new/        IGNORE
+/^\s*X-Originating-IP:/             IGNORE
+/^\s*X-Mailer:/                     IGNORE
+/^\s*Mime-Version: 1.0.*/           REPLACE Mime-Version: 1.0
+/^\s*User-Agent/                    IGNORE
+/^\s*X-Enigmail/                    IGNORE
+/^\s*X-Mailer/                      IGNORE
+/^\s*X-Originating-IP/              IGNORE
+/^\s*Received: from.*127.0.0.1/     IGNORE
+

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -882,6 +882,9 @@ function _setup_postfix_override_configuration() {
 	else
 		notify 'inf' "No extra postfix settings loaded because optional '/tmp/docker-mailserver/postfix-master.cf' not provided."
 	fi
+
+    notify 'inf' "set the compatibility level to 2"
+    postconf compatibility_level=2
 }
 
 function _setup_postfix_sasl_password() {

--- a/test/email-templates/send-privacy-email.txt
+++ b/test/email-templates/send-privacy-email.txt
@@ -1,0 +1,14 @@
+EHLO mail
+AUTH LOGIN dXNlcjFAbG9jYWxob3N0LmxvY2FsZG9tYWlu
+bXlwYXNzd29yZA==
+mail from: <user1@localhost.localdomain>
+rcpt to: <user1@localhost.localdomain>
+data
+From: Some User <user1@localhost.localdomain>
+To: Some User <user1@localhost.localdomain>
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:52.0)
+ Gecko/20100101 Thunderbird/52.2.1
+Subject: Test ESMTP Auth LOGIN and remove privacy
+testing
+.
+quit

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1101,6 +1101,15 @@ load 'test_helper/bats-assert/load'
  assert_success
 }
 
+@test "checking postfix: remove privacy details of the sender" {
+  run docker exec mail /bin/sh -c "openssl s_client -quiet -starttls smtp -connect 0.0.0.0:587 < /tmp/docker-mailserver-test/email-templates/send-privacy-email.txt | grep 'queued'"
+  assert_success
+  sleep 10
+  run docker exec mail /bin/sh -c "grep -rE "^User-Agent:" /var/mail/localhost.localdomain/user1/new | wc -l"
+  assert_success
+  assert_output 0
+}
+
 # dovecot
 @test "checking dovecot: ldap imap connection and authentication works" {
   run docker exec mail_with_ldap /bin/sh -c "nc -w 1 0.0.0.0 143 < /tmp/docker-mailserver-test/auth/imap-ldap-auth.txt"


### PR DESCRIPTION
We should care about our privacy and hide information when we send emails.
See ticket #681 

The PR has tests to ensure the filter is working. Multiple items are added that I think should be filtered. The minimal compatibility level had to be set to 2 in order for pcre to work and not creating errors in the logging.