### PR TITLE
[opendmarc] Skip dmarc checks for email sent over authenticated sockets

### DIFF
--- a/target/opendmarc/opendmarc.conf
+++ b/target/opendmarc/opendmarc.conf
@@ -10,3 +10,5 @@ HistoryFile  /var/run/opendmarc/opendmarc.dat
 
 AuthservID          HOSTNAME
 TrustedAuthservIDs  HOSTNAME
+
+IgnoreAuthenticatedClients true


### PR DESCRIPTION
opendmarc checks fail for mail sent over (SMTP AUTH) submission
ports. Adding this directive skips checks for those emails, and
clears the logs of related errors.

See https://github.com/tomav/docker-mailserver/issues/703