### PR TITLE
Prevent syslog logrotate warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -182,7 +182,10 @@ RUN sed -i -r "/^#?compress/c\compress\ncopytruncate" /etc/logrotate.conf && \
   sed -i -r 's|UpdateLogFile /var/log/clamav/|UpdateLogFile /var/log/mail/|g' /etc/clamav/freshclam.conf && \
   sed -i -r 's|/var/log/clamav|/var/log/mail|g' /etc/logrotate.d/clamav-daemon && \
   sed -i -r 's|/var/log/clamav|/var/log/mail|g' /etc/logrotate.d/clamav-freshclam && \
-  sed -i -r 's|/var/log/mail|/var/log/mail/mail|g' /etc/logrotate.d/rsyslog
+  sed -i -r 's|/var/log/mail|/var/log/mail/mail|g' /etc/logrotate.d/rsyslog && \
+  # prevent syslog logrotate warnings \
+  sed -i -e 's/\(printerror "could not determine current runlevel"\)/#\1/' /usr/sbin/invoke-rc.d && \
+  sed -i -e 's/^\(POLICYHELPER=\).*/\1/' /usr/sbin/invoke-rc.d
 
 # Get LetsEncrypt signed certificate
 RUN curl -s https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > /etc/ssl/certs/lets-encrypt-x3-cross-signed.pem


### PR DESCRIPTION
This should fix #661. There are two changes to `/usr/sbin/invoke-rc.d` which is used for syslog logrotation. A warning that the (systemd) runlevel cannot be determined was commented out and a "policy helper" was deactivated (instead of removing the script `/usr/sbin/policy-rc.d`). Syslog logrotation still works and in manual the daily mail was not sent anymore.
