### PR TITLE
SSL Bundle

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -776,6 +776,13 @@ function _setup_ssl() {
 			sed -i -e 's~ssl_cert = </etc/dovecot/dovecot\.pem~ssl_cert = </etc/postfix/ssl/cert~g' /etc/dovecot/conf.d/10-ssl.conf
 			sed -i -e 's~ssl_key = </etc/dovecot/private/dovecot\.pem~ssl_key = </etc/postfix/ssl/key~g' /etc/dovecot/conf.d/10-ssl.conf
 
+			if [ -n "$SSL_BUNDLE_PATH" ]; then
+				cp "$SSL_BUNDLE_PATH" /etc/postfix/ssl/bundle
+				chmod 600 /etc/postfix/ssl/bundle
+
+				sed -i -r 's~#smtpd_tls_CAfile=~smtpd_tls_CAfile=/etc/postfix/ssl/bundle~g' /etc/postfix/main.cf
+			fi
+
 			notify 'inf' "SSL configured with 'Manual' certificates"
 		fi
 	;;


### PR DESCRIPTION
Added in the functionality for bundle files for SSL.
To use this feature, add the following to the wideside variables SSL_BUNDLE_PATH
This will work identically to SSL_KEY_PATH and SSL_CERT_PATH. 
The field is not required and can be ignored if not required.