### PR TITLE
Use PCRE for alias regular expressions instead of the basic type

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -686,8 +686,8 @@ function _setup_postfix_aliases() {
 		notify 'inf' "Adding regexp alias file postfix-regexp.cf"
 		cp -f /tmp/docker-mailserver/postfix-regexp.cf /etc/postfix/regexp
 		sed -i -e '/^virtual_alias_maps/{
-		s/ regexp:.*//
-		s/$/ regexp:\/etc\/postfix\/regexp/
+		s/ pcre:.*//
+		s/$/ pcre:\/etc\/postfix\/regexp/
 		}' /etc/postfix/main.cf
 	fi
 }


### PR DESCRIPTION
I spent quite a while trying to set up an alias in `config/postfix-regexp.cf` like this:

```
/^(?!info|bob)\S+@customer.com/ webmaster@serviceprovider.com
```

I wanted the client to recieve mail for a couple of users @customer.com and everything else to be sent to me so I can deal with maintenence stuff. The negative-lookahead regular expression seemed to be the solution but I couldn't get Postfix to understand it.

It turns out Postfix has 2 regular expression implementations denoted by the prefixes `regexp:` and `pcre:` in config files. Perl-compatibe regular expressions (PCRE) seem to be the main implementation wherever I've used them before, however the Postfix config here uses the basic type by default.

I am currently overriding by putting the following in `config/postfix-main.cf` but I think it would save people a lot of trouble if `pcre:` was enabled by default for aliases.

```
virtual_alias_maps = texthash:/etc/postfix/virtual pcre:/etc/postfix/regexp
```