### PR TITLE
Implement AWS SES mail fetching from S3 bucket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update -q --fix-missing && \
   apt-get -y install --no-install-recommends \
     amavisd-new \
     arj \
+    awscli \
     binutils \
     bzip2 \
     ca-certificates \
@@ -195,6 +196,9 @@ COPY ./target/bin /usr/local/bin
 # Start-mailserver script
 COPY ./target/check-for-changes.sh ./target/start-mailserver.sh ./target/fail2ban-wrapper.sh ./target/postfix-wrapper.sh ./target/docker-configomat/configomat.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/*
+
+# Setup AWS SES Fetch Mail
+RUN (echo "*/1 * * * * /usr/local/bin/fetch-aws-ses-mail"; crontab -l) | crontab -
 
 # Configure supervisor
 COPY target/supervisor/supervisord.conf /etc/supervisor/supervisord.conf

--- a/target/bin/fetch-aws-ses-mail
+++ b/target/bin/fetch-aws-ses-mail
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ -z "$AWS_SES_KEY_ID" ] || [ -z "$AWS_SES_SECRET" ]; then
+  exit 0; # AWS mail fetching is not configured
+fi
+
 find /var/mail -maxdepth 1 -name '*.*' |while read -r domainPath; do
   domain=${domainPath##*/};
 

--- a/target/bin/fetch-aws-ses-mail
+++ b/target/bin/fetch-aws-ses-mail
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+find /var/mail -maxdepth 1 -name '*.*' |while read -r domainPath; do
+  domain=${domainPath##*/};
+
+  mkdir -p /var/mail-aws-ses/${domain} || exit 1;
+  aws s3 mv s3://mail-aws-ses/${domain} \
+           /var/mail-aws-ses/${domain} --recursive || exit 1;
+
+  find /var/mail-aws-ses -type f |while read -r file; do
+    while read -r name; do
+      mail_dir="/var/mail/${domain}/${name}";
+      if [ ! -f ${mail_dir}/new/${file##*/} ]; then
+        mv -v $file ${mail_dir}/new;
+        sieve-filter -e -W -C -u ${name}@${domain} \
+          ${mail_dir}/sieve/rainloop.user.sieve INBOX
+      fi
+    done < <(grep -Po "[a-zA-Z0-9.-]+(?=@${domain})" $file |sort |uniq)
+  done
+done

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -119,6 +119,10 @@ function register_functions() {
 		_register_setup_function "_setup_postfix_relay_amazon_ses"
 	fi
 
+	if [ ! -z "$AWS_SES_KEY_ID" -a ! -z "$AWS_SES_SECRET" ]; then
+		_register_setup_function "_setup_postfix_fetch_amazon_ses"
+	fi
+
 	if [ "$ENABLE_POSTFIX_VIRTUAL_TRANSPORT" = 1  ]; then
 		_register_setup_function "_setup_postfix_virtual_transport"
 	fi
@@ -927,6 +931,19 @@ function _setup_postfix_relay_amazon_ses() {
 		"smtp_tls_security_level = encrypt" \
 		"smtp_tls_note_starttls_offer = yes" \
 		"smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt"
+}
+
+function _setup_postfix_fetch_amazon_ses() {
+	notify 'task' 'Setting up Amazon CLI'
+
+	mkdir -p $HOME/.aws
+	echo -e "[default]\naws_access_key_id = ${AWS_SES_KEY_ID}\n" \
+		"aws_secret_access_key = ${AWS_SES_SECRET}" > $HOME/.aws/credentials
+
+	if [ -z "${AWS_SES_REGION}" ]; then
+		AWS_SES_REGION="eu-west-1";
+	fi
+	echo -e "[default]\nregion = ${AWS_SES_REGION}" > $HOME/.aws/config
 }
 
 function _setup_postfix_dhparam() {


### PR DESCRIPTION
A view days ago I decided to use AWS as main MX and the docker instance as backup MX.
I wanted to share my modification cause that could be interesting for more then only me.

I haven't tested this PR, yet! If you decide on implementing this I will test and "prettify"  it.

---

HowTo; We can achieve that by creating a bucket called mail-aws-ses
within the bucket the mail should be stored in a directory
with the domain name as folder name e.g. s3://mail-aws-ses/zauberstuhl.de/...
This can be achieved by creating the right filter rules in aws console

After that we need an aws ID and secret token with full-s3-permissions
and add it to the docker environment variables AWS_SES_KEY_ID and AWS_SES_SECRET

Optional you can set a default region with AWS_SES_REGION variable