### PR TITLE
Workaround for an issue on sha512sum

### DIFF
--- a/target/check-for-changes.sh
+++ b/target/check-for-changes.sh
@@ -119,7 +119,7 @@ if ! [ $resu_acc = "OK" ] || ! [ $resu_vir = "OK" ]; then
     supervisorctl restart postfix
     
     # Prevent restart of dovecot when smtp_only=1
-    if [ ! -f $SMTP_ONLY = 1 ]; then
+    if [ ! $SMTP_ONLY = 1 ]; then
         supervisorctl restart dovecot
     fi 
 

--- a/target/check-for-changes.sh
+++ b/target/check-for-changes.sh
@@ -29,7 +29,7 @@ while true; do
 log_date=$(date +"%Y-%m-%d %H:%M:%S ")
 
 # Get chksum and check it.
-chksum=$(sha512sum -c --ignore-missing chksum)
+chksum=$(sha512sum -c chksum)
 resu_acc=${chksum:21:2}
 if [ -f postfix-virtual.cf ]; then
 	resu_vir=${chksum:44:2}


### PR DESCRIPTION
For some reason, on my container, the sha512sum command ignores my `postfix-accounts.cf` even if it exists when the command executed with `--ignore-missing` option. As a result, a change is detected falsely every 5 seconds and the server keep restarting forever.

To get around this issue, I've removed the option from the shell script.

### Symptom

Below shows the content in the `/tmp/docker-mailserver` directory in my container:

```
root@mail:/tmp/docker-mailserver# ls -l
total 24
-rw-r--r-- 1 root root  319 Dec 17 11:53 chksum
-rw-rw-r-- 1 1000 1000   24 Dec 17 11:46 dovecot.cf
drwxr-xr-x 3 root root 4096 Dec 16 20:47 opendkim
-rw-rw-r-- 1 1000 1000  135 Dec 17 11:22 postfix-accounts.cf
-rw-rw-r-- 1 1000 1000   24 Dec 16 20:43 postfix-main.cf
-rw-rw-r-- 1 1000 1000   80 Dec 17 11:48 postfix-virtual.cf
```
`postfix-accounts.cf` is here.

```
root@mail:/tmp/docker-mailserver# cat chksum
SHA512 (postfix-accounts.cf) = 00b42f4a9b80a90c44316991c96737859f23e69f1572b72586eb91f2ee2ec2daf7c5ddd60c0a5f22f4aab2c034e861a77b985bf400290111c174fc4b1b3af418
SHA512 (postfix-virtual.cf) = 2d0dbd894f77825374b406d853a497affa921f74fe001ead893586f8cab638e1e7e1fac43d2977786890195f07fd8c0833b6b8c1b251c403bd3a4ae965cd3f91
```
Also in the checksum.

```
root@mail:/tmp/docker-mailserver# sha512sum -c chksum
postfix-accounts.cf: OK
postfix-virtual.cf: OK
```
Without `--ignore-missing`, it works just fine.

```
root@mail:/tmp/docker-mailserver# sha512sum -c --ignore-missing chksum
postfix-virtual.cf: OK
```
But for some reason, `postfix-accounts.cf` is *ignored* with `--ignore-missing`!

### Is this safe?

I believe this modification is safe for other users. If you remove `postfix-accounts.cf` then the sha512sum outputs like:
```
postfix-accounts.cf: FAILED open or read
postfix-virtual.cf: OK
```
So the `if` statement below still works as expected since the `[ $resu_acc = "OK" ]` fails anyway:
```
if ! [ $resu_acc = "OK" ] || ! [ $resu_vir = "OK" ]; then
```