### PR TITLE
Fix arguments for [ command

### DIFF
--- a/target/check-for-changes.sh
+++ b/target/check-for-changes.sh
@@ -119,7 +119,7 @@ if ! [ $resu_acc = "OK" ] || ! [ $resu_vir = "OK" ]; then
     supervisorctl restart postfix
     
     # Prevent restart of dovecot when smtp_only=1
-    if [ ! -f $SMTP_ONLY = 1 ]; then
+    if [ ! $SMTP_ONLY = 1 ]; then
         supervisorctl restart dovecot
     fi 
 


### PR DESCRIPTION
`-f` option for the `[` (`test`) commend is not valid on string comparison.
