### PR TITLE
fail2ban handling integrated in setup.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ run:
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e ENABLE_LDAP=1 \
 		-e LDAP_SERVER_HOST=ldap \
+		-e LDAP_START_TLS=no \
 		-e LDAP_SEARCH_BASE=ou=people,dc=localhost,dc=localdomain \
 		-e LDAP_BIND_DN=cn=admin,dc=localhost,dc=localdomain \
 		-e LDAP_BIND_PW=admin \
@@ -135,6 +136,7 @@ run:
 		-e LDAP_QUERY_FILTER_GROUP="(&(mailGroupMember=%s)(mailEnabled=TRUE))" \
 		-e LDAP_QUERY_FILTER_ALIAS="(&(mailAlias=%s)(mailEnabled=TRUE))" \
 		-e LDAP_QUERY_FILTER_DOMAIN="(&(|(mail=*@%s)(mailalias=*@%s)(mailGroupMember=*@%s))(mailEnabled=TRUE))" \
+		-e DOVECOT_TLS=no \
 		-e DOVECOT_PASS_FILTER="(&(objectClass=PostfixBookMailAccount)(uniqueIdentifier=%n))" \
 		-e DOVECOT_USER_FILTER="(&(objectClass=PostfixBookMailAccount)(uniqueIdentifier=%n))" \
 		-e ENABLE_SASLAUTHD=1 \

--- a/README.md
+++ b/README.md
@@ -268,6 +268,11 @@ Otherwise, `iptables` won't be able to ban IPs.
     - A second container for the ldap service is necessary (e.g. [docker-openldap](https://github.com/osixia/docker-openldap))
     - For preparing the ldap server to use in combination with this continer [this](http://acidx.net/wordpress/2014/06/installing-a-mailserver-with-postfix-dovecot-sasl-ldap-roundcube/) article may be helpful
 
+##### LDAP_START_TLS
+
+  - **empty** => no
+  - yes => LDAP over TLS enabled for Postfix
+
 ##### LDAP_SERVER_HOST
 
   - **empty** => mail.domain.com
@@ -303,6 +308,11 @@ Otherwise, `iptables` won't be able to ban IPs.
 
   - e.g. `"(&(mailAlias=%s)(mailEnabled=TRUE))"`
   - => Specify how ldap should be asked for aliases
+
+##### DOVECOT_TLS
+
+  - **empty** => no
+  - yes => LDAP over TLS enabled for Dovecot
 
 ##### DOVECOT_USER_FILTER
 

--- a/setup.sh
+++ b/setup.sh
@@ -203,8 +203,13 @@ case $1 in
               shift
               if [ -n "$1" ]; then
                 for JAIL in $JAILS; do
-                  echo "unbanning $@ from $JAIL:"
-                  _docker_container fail2ban-client set $JAIL unbanip $@
+                  RESULT=`_docker_container fail2ban-client set $JAIL unbanip $@`
+		  case "$RESULT" in
+		    *"is not banned"*) ;;
+		    *"NOK"*) ;;
+		    *)  echo -n "unbanned IP from $JAIL: " 
+			echo "$RESULT";;
+		  esac
                 done
               else
                 echo "You need to specify an IP address. Run \"./setup.sh debug fail2ban\" to get a list of banned IP addresses."

--- a/target/dovecot/dovecot-ldap.conf.ext
+++ b/target/dovecot/dovecot-ldap.conf.ext
@@ -3,6 +3,7 @@ default_pass_scheme = SSHA
 dn                  = cn=admin,dc=domain,dc=com
 dnpass              = admin
 hosts               = mail.domain.com
+tls                 = no
 ldap_version        = 3
 pass_attrs          = uniqueIdentifier=user,userPassword=password
 pass_filter         = (&(objectClass=PostfixBookMailAccount)(uniqueIdentifier=%n))

--- a/target/postfix/ldap-aliases.cf
+++ b/target/postfix/ldap-aliases.cf
@@ -5,4 +5,5 @@ query_filter     = (&(mailAlias=%s)(mailEnabled=TRUE))
 result_attribute = mail
 search_base      = ou=people,dc=domain,dc=com
 server_host      = mail.domain.com
+start_tls        = no
 version          = 3

--- a/target/postfix/ldap-domains.cf
+++ b/target/postfix/ldap-domains.cf
@@ -5,4 +5,5 @@ query_filter     = (&(|(mail=*@%s)(mailalias=*@%s))(mailEnabled=TRUE))
 result_attribute = mail
 search_base      = ou=people,dc=domain,dc=com
 server_host      = mail.domain.com
+start_tls        = no
 version          = 3

--- a/target/postfix/ldap-groups.cf
+++ b/target/postfix/ldap-groups.cf
@@ -5,4 +5,5 @@ query_filter             = (&(mailGroupMember=%s)(mailEnabled=TRUE))
 result_attribute         = mail
 search_base              = ou=people,dc=domain,dc=com
 server_host              = mail.domain.com
+start_tls                = no
 version                  = 3

--- a/target/postfix/ldap-users.cf
+++ b/target/postfix/ldap-users.cf
@@ -5,4 +5,5 @@ query_filter     = (&(mail=%s)(mailEnabled=TRUE))
 result_attribute = mail
 search_base      = ou=people,dc=domain,dc=com
 server_host      = mail.domain.com
+start_tls        = no
 version          = 3

--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -49,6 +49,7 @@ smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, rej
     reject_rbl_client zen.spamhaus.org, reject_rbl_client bl.spamcop.net
 smtpd_client_restrictions = permit_mynetworks, permit_sasl_authenticated, reject_unauth_destination, reject_unauth_pipelining
 smtpd_sender_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unknown_sender_domain
+disable_vrfy_command = yes
 
 # SASL
 smtpd_sasl_auth_enable = yes

--- a/test/config/dovecot-lmtp/dovecot-ldap.conf.ext
+++ b/test/config/dovecot-lmtp/dovecot-ldap.conf.ext
@@ -3,6 +3,7 @@ default_pass_scheme = SSHA
 dn                  = cn=admin,dc=domain,dc=com
 dnpass              = admin
 hosts               = mail.domain.com
+tls                 = no
 ldap_version        = 3
 pass_attrs          = uniqueIdentifier=user,userPassword=password
 pass_filter         = (&(objectClass=PostfixBookMailAccount)(uniqueIdentifier=%n))

--- a/test/config/ldap-aliases.cf
+++ b/test/config/ldap-aliases.cf
@@ -6,4 +6,5 @@ query_filter     = (&(mailAlias=%s)(mailEnabled=TRUE))
 result_attribute = mail
 search_base      = ou=people,dc=domain,dc=com
 server_host      = mail.domain.com
+start_tls        = no
 version          = 3

--- a/test/config/ldap-groups.cf
+++ b/test/config/ldap-groups.cf
@@ -6,4 +6,5 @@ query_filter             = (&(mailGroupMember=%s)(mailEnabled=TRUE))
 result_attribute         = mail
 search_base              = ou=people,dc=domain,dc=com
 server_host              = mail.domain.com
+start_tls                = no
 version                  = 3

--- a/test/config/ldap-users.cf
+++ b/test/config/ldap-users.cf
@@ -6,4 +6,5 @@ query_filter     = (&(mail=%s)(mailEnabled=TRUE))
 result_attribute = mail
 search_base      = ou=people,dc=domain,dc=com
 server_host      = mail.domain.com
+start_tls        = no
 version          = 3

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1177,6 +1177,8 @@ load 'test_helper/bats-assert/load'
 @test "checking postfix: ldap config overwrites success" {
  run docker exec mail_with_ldap /bin/sh -c "grep 'server_host = ldap' /etc/postfix/ldap-users.cf"
  assert_success
+ run docker exec mail_with_ldap /bin/sh -c "grep 'start_tls = no' /etc/postfix/ldap-users.cf"
+ assert_success
  run docker exec mail_with_ldap /bin/sh -c "grep 'search_base = ou=people,dc=localhost,dc=localdomain' /etc/postfix/ldap-users.cf"
  assert_success
  run docker exec mail_with_ldap /bin/sh -c "grep 'bind_dn = cn=admin,dc=localhost,dc=localdomain' /etc/postfix/ldap-users.cf"
@@ -1184,12 +1186,16 @@ load 'test_helper/bats-assert/load'
 
  run docker exec mail_with_ldap /bin/sh -c "grep 'server_host = ldap' /etc/postfix/ldap-groups.cf"
  assert_success
+ run docker exec mail_with_ldap /bin/sh -c "grep 'start_tls = no' /etc/postfix/ldap-groups.cf"
+ assert_success
  run docker exec mail_with_ldap /bin/sh -c "grep 'search_base = ou=people,dc=localhost,dc=localdomain' /etc/postfix/ldap-groups.cf"
  assert_success
  run docker exec mail_with_ldap /bin/sh -c "grep 'bind_dn = cn=admin,dc=localhost,dc=localdomain' /etc/postfix/ldap-groups.cf"
  assert_success
 
  run docker exec mail_with_ldap /bin/sh -c "grep 'server_host = ldap' /etc/postfix/ldap-aliases.cf"
+ assert_success
+ run docker exec mail_with_ldap /bin/sh -c "grep 'start_tls = no' /etc/postfix/ldap-aliases.cf"
  assert_success
  run docker exec mail_with_ldap /bin/sh -c "grep 'search_base = ou=people,dc=localhost,dc=localdomain' /etc/postfix/ldap-aliases.cf"
  assert_success
@@ -1230,6 +1236,8 @@ load 'test_helper/bats-assert/load'
 
 @test "checking dovecot: ldap config overwrites success" {
   run docker exec mail_with_ldap /bin/sh -c "grep 'hosts = ldap' /etc/dovecot/dovecot-ldap.conf.ext"
+  assert_success
+  run docker exec mail_with_ldap /bin/sh -c "grep 'tls = no' /etc/dovecot/dovecot-ldap.conf.ext"
   assert_success
   run docker exec mail_with_ldap /bin/sh -c "grep 'base = ou=people,dc=localhost,dc=localdomain' /etc/dovecot/dovecot-ldap.conf.ext"
   assert_success

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1131,6 +1131,21 @@ load 'test_helper/bats-assert/load'
   run ./setup.sh -c mail debug login ls
   assert_success
 }
+@test "checking setup.sh: setup.sh debug fail2ban" {
+  
+  run docker exec mail_fail2ban /bin/sh -c "fail2ban-client set dovecot banip 192.0.66.4"
+  run docker exec mail_fail2ban /bin/sh -c "fail2ban-client set dovecot banip 192.0.66.5"
+  sleep 10
+  run ./setup.sh -c mail_fail2ban debug fail2ban
+  assert_output "Banned in dovecot: 192.0.66.5 192.0.66.4"
+  run ./setup.sh -c mail_fail2ban debug fail2ban unban 192.0.66.4
+  assert_output --partial "unbanned IP from dovecot: 192.0.66.4"
+  run ./setup.sh -c mail_fail2ban debug fail2ban
+  assert_output "Banned in dovecot: 192.0.66.5"
+  run ./setup.sh -c mail_fail2ban debug fail2ban unban 192.0.66.5
+  run ./setup.sh -c mail_fail2ban debug fail2ban unban
+  assert_output --partial "You need to specify an IP address. Run"
+}
 
 #
 # LDAP


### PR DESCRIPTION
- calling \"./setup debug fail2ban\" lists all iptable chains whith blocked IPs 
(like: 
Banned in dovecot: 91.200.12.164
Banned in postfix-sasl: 91.200.12.164)
- calling \"./setup debug fail2ban unban xxx.xxx.xxx.xxx [yyy.yyy.yyy.yyy ...]\" unbans/removes those IPs from all jails.
- calling \"./setup debug fail2ban unban\" (without an IP) gives an descriptive error: (You need to specify an IP address. Run "./setup.sh debug fail2ban" to get a list of banned IP addresses.)