### PR TITLE
disable_vrfy_command

### DIFF
--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -49,6 +49,7 @@ smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, rej
     reject_rbl_client zen.spamhaus.org, reject_rbl_client bl.spamcop.net
 smtpd_client_restrictions = permit_mynetworks, permit_sasl_authenticated, reject_unauth_destination, reject_unauth_pipelining
 smtpd_sender_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unknown_sender_domain
+disable_vrfy_command = yes
 
 # SASL
 smtpd_sasl_auth_enable = yes


### PR DESCRIPTION
Prevents Spammers from collecting existing mail-addresses by probing the mailserver for them.
(http://www.postfix.org/postconf.5.html#disable_vrfy_command)