### PR TITLE
Add dovecot mysql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update -q --fix-missing && \
     dovecot-imapd \
     dovecot-ldap \
     dovecot-lmtpd \
+    dovecot-mysql \
     dovecot-managesieved \
     dovecot-pop3d \
     dovecot-sieve \
@@ -60,6 +61,7 @@ RUN apt-get update -q --fix-missing && \
     p7zip-full \
     postfix-ldap \
     postfix-pcre \
+    postfix-mysql \
     postfix-policyd-spf-python \
     pyzor \
     razor \
@@ -116,7 +118,8 @@ RUN sed -i -e 's/include_try \/usr\/share\/dovecot\/protocols\.d/include_try \/e
 
 # Configures LDAP
 COPY target/dovecot/dovecot-ldap.conf.ext /etc/dovecot
-COPY target/postfix/ldap-users.cf target/postfix/ldap-groups.cf target/postfix/ldap-aliases.cf target/postfix/ldap-domains.cf /etc/postfix/
+COPY target/dovecot/dovecot-sql.conf.ext /etc/dovecot
+COPY target/postfix/mysql-aliases.cf target/postfix/mysql-domains.cf target/postfix/mysql-maps.cf target/postfix/ldap-users.cf target/postfix/ldap-groups.cf target/postfix/ldap-aliases.cf  target/postfix/ldap-domains.cf /etc/postfix/
 
 # Enables Spamassassin CRON updates and update hook for supervisor
 RUN sed -i -r 's/^(CRON)=0/\1=1/g' /etc/default/spamassassin && \

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Easy to deploy and upgrade.
 
 Includes:
 
-- postfix with smtp or ldap auth
-- dovecot for sasl, imap (and optional pop3) with ssl support, with ldap auth
+- postfix with smtp, mysql or ldap auth
+- dovecot for sasl, imap (and optional pop3) with ssl support, with ldap or mysql auth
 - saslauthd with ldap auth
 - amavis
 - spamassasin supporting custom rules
@@ -260,6 +260,11 @@ Otherwise, `iptables` won't be able to ban IPs.
 ##### FETCHMAIL_POLL
   - **300** => `fetchmail` The number of seconds for the interval
 
+=======
+##### ENABLE_MYSQL
+  - **empty** => MYSQL authentification is disabled
+  - 1 => MYSQL authentification is enabled
+  
 ##### ENABLE_LDAP
 
   - **empty** => LDAP authentification is disabled

--- a/target/check-for-changes.sh
+++ b/target/check-for-changes.sh
@@ -42,7 +42,7 @@ if ! [ $resu_acc = "OK" ] || ! [ $resu_vir = "OK" ]; then
     #regen postfix accounts.
 	echo -n > /etc/postfix/vmailbox
 	echo -n > /etc/dovecot/userdb
-	if [ -f /tmp/docker-mailserver/postfix-accounts.cf -a "$ENABLE_LDAP" != 1 ]; then
+	if [[ -f /tmp/docker-mailserver/postfix-accounts.cf ]] && [[ ${ENABLE_LDAP} != 1 ]] && [[ ${ENABLE_MYSQL} != 1 ]]]; then
 		sed -i 's/\r//g' /tmp/docker-mailserver/postfix-accounts.cf
 		echo "# WARNING: this file is auto-generated. Modify config/postfix-accounts.cf to edit user list." > /etc/postfix/vmailbox
 		# Checking that /tmp/docker-mailserver/postfix-accounts.cf ends with a newline

--- a/target/dovecot/dovecot-sql.conf.ext
+++ b/target/dovecot/dovecot-sql.conf.ext
@@ -1,0 +1,8 @@
+driver 				= mysql
+connect 			= "host=127.0.0.1 dbname=vmail user=vmail password=vmaildbpass"
+default_pass_scheme = SHA512-CRYPT
+
+password_query 		= SELECT username AS user,password FROM mailbox WHERE username = '%u' AND active='1'
+
+user_query 			= SELECT CONCAT('/var/mail/', maildir) AS home, 5000 AS uid, 5000 AS gid, CONCAT('*:bytes=', quota) AS quota_rule FROM mailbox WHERE username = '%u' AND active='1'
+iterate_query 		= SELECT username AS user FROM mailbox

--- a/target/postfix/mysql-aliases.cf
+++ b/target/postfix/mysql-aliases.cf
@@ -1,0 +1,5 @@
+user = {{DB_USER}}
+password = {{DB_PASS}}
+hosts = {{DB_HOST}}
+dbname = {{DB_NAME}}
+query = SELECT goto FROM alias WHERE address='%s' AND active='1'

--- a/target/postfix/mysql-domains.cf
+++ b/target/postfix/mysql-domains.cf
@@ -1,0 +1,5 @@
+user = user
+password = password
+hosts = host
+dbname = dbname
+query = SELECT 1 FROM domain WHERE domain='%s'

--- a/target/postfix/mysql-maps.cf
+++ b/target/postfix/mysql-maps.cf
@@ -1,0 +1,5 @@
+user = {{DB_USER}}
+password = {{DB_PASS}}
+hosts = {{DB_HOST}}
+dbname = {{DB_NAME}}
+query = SELECT 1 FROM mailbox WHERE username=’%s’

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -15,6 +15,7 @@ DEFAULT_VARS["ENABLE_MANAGESIEVE"]="${ENABLE_MANAGESIEVE:="0"}"
 DEFAULT_VARS["ENABLE_FETCHMAIL"]="${ENABLE_FETCHMAIL:="0"}"
 DEFAULT_VARS["FETCHMAIL_POLL"]="${FETCHMAIL_POLL:="300"}"
 DEFAULT_VARS["ENABLE_LDAP"]="${ENABLE_LDAP:="0"}"
+DEFAULT_VARS["ENABLE_MYSQL"]="${ENABLE_MYSQL:="0"}"
 DEFAULT_VARS["ENABLE_POSTGREY"]="${ENABLE_POSTGREY:="0"}"
 DEFAULT_VARS["POSTGREY_DELAY"]="${POSTGREY_DELAY:="300"}"
 DEFAULT_VARS["POSTGREY_MAX_AGE"]="${POSTGREY_MAX_AGE:="35"}"
@@ -87,6 +88,10 @@ function register_functions() {
 
 	if [ "$ENABLE_LDAP" = 1 ];then
 		_register_setup_function "_setup_ldap"
+	fi
+
+	if [ "$ENABLE_MYSQL" = 1 ];then
+		_register_setup_function "_setup_mysql"
 	fi
 
 	if [ "$ENABLE_SASLAUTHD" = 1 ];then
@@ -364,6 +369,10 @@ function _check_hostname() {
 
 function _check_environment_variables() {
 	notify "task" "Check that there are no conflicts with env variables [$FUNCNAME]"
+	if [[ ${ENABLE_LDAP} = 1 ]] && [[ ${ENABLE_MYSQL} = 1 ]]; then
+		notify 'fatal' "Mysql and LDAP must not be enabled at the same time."
+		defunc
+	fi
 	return 0
 }
 ##########################################################################
@@ -468,7 +477,7 @@ function _setup_dovecot_local_user() {
 	notify 'task' 'Setting up Dovecot Local User'
 	echo -n > /etc/postfix/vmailbox
 	echo -n > /etc/dovecot/userdb
-	if [ -f /tmp/docker-mailserver/postfix-accounts.cf -a "$ENABLE_LDAP" != 1 ]; then
+	if [[ -f /tmp/docker-mailserver/postfix-accounts.cf ]] && [[ ${ENABLE_LDAP} != 1 ]] && [[ ${ENABLE_MYSQL} != 1 ]]; then
 		notify 'inf' "Checking file line endings"
 		sed -i 's/\r//g' /tmp/docker-mailserver/postfix-accounts.cf
 		notify 'inf' "Regenerating postfix user list"
@@ -517,8 +526,8 @@ function _setup_dovecot_local_user() {
 	fi
 
 	if [[ ! $(grep '@' /tmp/docker-mailserver/postfix-accounts.cf | grep '|') ]]; then
-		if [ $ENABLE_LDAP -eq 0 ]; then
-			notify 'fatal' "Unless using LDAP, you need at least 1 email account to start the server."
+		if [ $ENABLE_LDAP -eq 0 -a $ENABLE_MYSQL -eq 0 ]; then
+			notify 'fatal' "Unless using LDAP or MySQL, you need at least 1 email account to start the server."
 			defunc
 		fi
 	fi
@@ -570,7 +579,10 @@ function _setup_ldap() {
 
 	notify 'inf' "Enabling dovecot LDAP authentification"
 	sed -i -e '/\!include auth-ldap\.conf\.ext/s/^#//' /etc/dovecot/conf.d/10-auth.conf
+	sed -i -e '/\!include auth-sql\.conf\.ext/s/^/#/' /etc/dovecot/conf.d/10-auth.conf
 	sed -i -e '/\!include auth-passwdfile\.inc/s/^/#/' /etc/dovecot/conf.d/10-auth.conf
+
+
 
 	notify 'inf' "Configuring LDAP"
 	[ -f /etc/postfix/ldap-users.cf ] && \
@@ -584,6 +596,66 @@ function _setup_ldap() {
 	[ -f /etc/postfix/ldap-aliases.cf -a -f /etc/postfix/ldap-groups.cf ] && \
 		postconf -e "virtual_alias_maps = ldap:/etc/postfix/ldap-aliases.cf, ldap:/etc/postfix/ldap-groups.cf" || \
 		notify 'inf' "==> Warning: /etc/postfix/ldap-aliases.cf or /etc/postfix/ldap-groups.cf not found"
+
+	return 0
+}
+
+function _setup_mysql() {
+	notify 'task' 'Setting up MySQL'
+
+	notify 'inf' "Configuring postfix MySQL"
+
+	declare -A _postfix_mysql_mapping
+
+	_postfix_mysql_mapping["POSTFIX_MYSQL_HOSTS"]="${POSTFIX_MYSQL_HOSTS:="${MYSQL_HOST}"}"
+	_postfix_mysql_mapping["POSTFIX_MYSQL_DBNAME"]="${POSTFIX_MYSQL_DBNAME:="${MYSQL_DB}"}"
+	_postfix_mysql_mapping["POSTFIX_MYSQL_USER"]="${POSTFIX_MYSQL_USER:="${MYSQL_USER}"}"
+	_postfix_mysql_mapping["POSTFIX_MYSQL_PASSWORD"]="${POSTFIX_MYSQL_PASSWORD:="${MYSQL_PASSWORD}"}"
+	for var in ${!_postfix_mysql_mapping[@]}; do
+		export $var=${_postfix_mysql_mapping[$var]}
+	done
+	for f in /etc/postfix/mysql-aliases.cf /etc/postfix/mysql-domains.cf /etc/postfix/mysql-maps-aliases.cf
+	do
+		configomat.sh "POSTFIX_MYSQL_" "$f"
+	done
+
+	notify 'inf' "Configuring dovecot MySQL"
+	declare -A _dovecot_mysql_mapping
+	_dovecot_mysql_connect="host=${MYSQL_HOST} dbname=${MYSQL_DB} user=${MYSQL_USER} password=${MYSQL_PASSWORD}"
+
+
+	#_dovecot_mysql_mapping["DOVECOT_MYSQL_CONNECT"]="${DOVECOT_MYSQL_CONNECT:="${_dovecot_mysql_connect}"}"
+	# This is nor working as configomat does not support spaces in the value.
+	_dovecot_mysql_mapping["DOVECOT_MYSQL_DEFAULT_PASS_SCHEME"]="${DOVECOT_MYSQL_DEFAULT_PASS_SCHEME:="${MYSQL_PASS_SCHEME}"}"
+
+	for var in ${!_dovecot_mysql_mapping[@]}; do
+		export $var=${_dovecot_mysql_mapping[$var]}
+	done
+
+	configomat.sh "DOVECOT_MYSQL_" "/etc/dovecot/dovecot-sql.conf.ext"
+
+	_dovecot_mysql_connect_escaped=$(sed 's/[&/\]/\\&/g' <<<"$_dovecot_mysql_connect")
+	sed -i  "s/^connect.*/connect = $_dovecot_mysql_connect_escaped/g" "/etc/dovecot/dovecot-sql.conf.ext"
+	# Add  domainname to vhost.
+	echo $DOMAINNAME >> /tmp/vhost.tmp
+
+	notify 'inf' "Enabling dovecot mysql authentification"
+	sed -i -e '/\!include auth-sql\.conf\.ext/s/^#//' /etc/dovecot/conf.d/10-auth.conf
+	sed -i -e '/\!include auth-passwdfile\.inc/s/^/#/' /etc/dovecot/conf.d/10-auth.conf
+	sed -i -e '/\!include auth-ldap\.inc/s/^/#/' /etc/dovecot/conf.d/10-auth.conf
+
+	notify 'inf' "Configuring MySQL"
+	[ -f /etc/postfix/mysql-maps.cf ] && \
+		postconf -e "virtual_mailbox_maps = mysql:/etc/postfix/mysql-maps.cf" || \
+		notify 'inf' "==> Warning: /etc/postfix/mysql-maps.cf not found"
+
+	[ -f /etc/postfix/mysql-aliases.cf ] && \
+		postconf -e virtual_alias_maps="mysql:/etc/postfix/mysql-aliases.cf" || \
+		notify 'inf' "==> Warning: /etc/postfix/mysql-aliases.cf not found"
+
+	[ -f /etc/postfix/mysql-domains.cf ] && \
+		postconf -e virtual_mailbox_domains="mysql:/etc/postfix/mysql-domains.cf" || \
+		notify 'inf' "==> Warning: /etc/postfix/mysql-domains.cf not found"
 
 	return 0
 }


### PR DESCRIPTION
This PR allows to configure dovecot etc to have a mysql server as user backend. Actual mysql / mariadb has to be another docker machine.