### PR TITLE
Changed Junk folder to be created and subscribed by default

### DIFF
--- a/target/dovecot/15-mailboxes.conf
+++ b/target/dovecot/15-mailboxes.conf
@@ -21,6 +21,7 @@ namespace inbox {
     special_use = \Drafts
   }
   mailbox Junk {
+    auto = subscribe
     special_use = \Junk
   }
   mailbox Trash {


### PR DESCRIPTION
The Junk folder is currently not created by default. Also there is no documentation on how to setup the Junk folder. Imho the Junk folder should be created and subscribed by default as the other folders. #795 #768 