### PR TITLE
Fix: Add SRS to fix SPF issues on redirect #611

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,71 +18,71 @@ RUN apt-get update -q --fix-missing && \
   apt-get -y upgrade && \
   apt-get -y install postfix && \
   apt-get -y install --no-install-recommends \
-    amavisd-new \
-    arj \
-    binutils \
-    bzip2 \
-    ca-certificates \
-    cabextract \
-    clamav \
-    clamav-daemon \
-    cpio \
-    curl \
-    dovecot-core \
-    dovecot-imapd \
-    dovecot-ldap \
-    dovecot-lmtpd \
-    dovecot-managesieved \
-    dovecot-pop3d \
-    dovecot-sieve \
-    ed \
-    fail2ban \
-    fetchmail \
-    file \
-    gamin \
-    gzip \
-    gnupg \
-    iproute2 \
-    iptables \
-    locales \
-    liblz4-tool \
-    libmail-spf-perl \
-    libnet-dns-perl \
-    libsasl2-modules \
-    lrzip \
-    lzop \
-    netcat-openbsd \
-    nomarch \
-    opendkim \
-    opendkim-tools \
-    opendmarc \
-    pax \
-    p7zip-full \
-    postfix-ldap \
-    postfix-pcre \
-    postfix-policyd-spf-python \
-    postsrsd \
-    pyzor \
-    razor \
-    ripole \
-    rpm2cpio \
-    rsyslog \
-    sasl2-bin \
-    spamassassin \
-    supervisor \
-    postgrey \
-    unrar-free \
-    unzip \
-    xz-utils \
-    zoo \
-    && \
+  amavisd-new \
+  arj \
+  binutils \
+  bzip2 \
+  ca-certificates \
+  cabextract \
+  clamav \
+  clamav-daemon \
+  cpio \
+  curl \
+  dovecot-core \
+  dovecot-imapd \
+  dovecot-ldap \
+  dovecot-lmtpd \
+  dovecot-managesieved \
+  dovecot-pop3d \
+  dovecot-sieve \
+  ed \
+  fail2ban \
+  fetchmail \
+  file \
+  gamin \
+  gzip \
+  gnupg \
+  iproute2 \
+  iptables \
+  locales \
+  liblz4-tool \
+  libmail-spf-perl \
+  libnet-dns-perl \
+  libsasl2-modules \
+  lrzip \
+  lzop \
+  netcat-openbsd \
+  nomarch \
+  opendkim \
+  opendkim-tools \
+  opendmarc \
+  pax \
+  p7zip-full \
+  postfix-ldap \
+  postfix-pcre \
+  postfix-policyd-spf-python \
+  postsrsd \
+  pyzor \
+  razor \
+  ripole \
+  rpm2cpio \
+  rsyslog \
+  sasl2-bin \
+  spamassassin \
+  supervisor \
+  postgrey \
+  unrar-free \
+  unzip \
+  xz-utils \
+  zoo \
+  && \
   curl https://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add - && \
   echo "deb http://packages.elastic.co/beats/apt stable main" | tee -a /etc/apt/sources.list.d/beats.list && \
   apt-get update -q --fix-missing && \
   apt-get -y upgrade \
-    fail2ban \
-    filebeat \
-    && \
+  fail2ban \
+  filebeat \
+  && \
   apt-get autoclean && \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /usr/share/locale/* && \
@@ -121,7 +121,7 @@ COPY target/postfix/ldap-users.cf target/postfix/ldap-groups.cf target/postfix/l
 
 # Enables Spamassassin CRON updates and update hook for supervisor
 RUN sed -i -r 's/^(CRON)=0/\1=1/g' /etc/default/spamassassin && \
-    sed -i -r 's/^\$INIT restart/supervisorctl restart amavis/g' /etc/spamassassin/sa-update-hooks.d/amavisd-new
+  sed -i -r 's/^\$INIT restart/supervisorctl restart amavis/g' /etc/spamassassin/sa-update-hooks.d/amavisd-new
 
 # Enables Postgrey
 COPY target/postgrey/postgrey /etc/default/postgrey
@@ -199,7 +199,7 @@ RUN curl -s https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > /et
 
 COPY ./target/bin /usr/local/bin
 # Start-mailserver script
-COPY ./target/check-for-changes.sh ./target/start-mailserver.sh ./target/fail2ban-wrapper.sh ./target/postfix-wrapper.sh ./target/docker-configomat/configomat.sh /usr/local/bin/
+COPY ./target/check-for-changes.sh ./target/start-mailserver.sh ./target/fail2ban-wrapper.sh ./target/postfix-wrapper.sh ./target/postsrsd-wrapper.sh ./target/docker-configomat/configomat.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/*
 
 # Configure supervisor

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,6 +130,9 @@ RUN chmod 755 /etc/init.d/postgrey && \
   mkdir /var/run/postgrey && \
   chown postgrey:postgrey /var/run/postgrey
 
+# Enables PostSRSd
+COPY target/postsrsd/postsrsd /etc/default/postsrsd
+
 # Enables Amavis
 COPY target/amavis/conf.d/* /etc/amavis/conf.d/
 RUN sed -i -r 's/#(@|   \\%)bypass/\1bypass/g' /etc/amavis/conf.d/15-content_filter_mode && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN apt-get update -q --fix-missing && \
     postfix-ldap \
     postfix-pcre \
     postfix-policyd-spf-python \
+    postsrsd \
     pyzor \
     razor \
     ripole \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,71 +18,71 @@ RUN apt-get update -q --fix-missing && \
   apt-get -y upgrade && \
   apt-get -y install postfix && \
   apt-get -y install --no-install-recommends \
-  amavisd-new \
-  arj \
-  binutils \
-  bzip2 \
-  ca-certificates \
-  cabextract \
-  clamav \
-  clamav-daemon \
-  cpio \
-  curl \
-  dovecot-core \
-  dovecot-imapd \
-  dovecot-ldap \
-  dovecot-lmtpd \
-  dovecot-managesieved \
-  dovecot-pop3d \
-  dovecot-sieve \
-  ed \
-  fail2ban \
-  fetchmail \
-  file \
-  gamin \
-  gzip \
-  gnupg \
-  iproute2 \
-  iptables \
-  locales \
-  liblz4-tool \
-  libmail-spf-perl \
-  libnet-dns-perl \
-  libsasl2-modules \
-  lrzip \
-  lzop \
-  netcat-openbsd \
-  nomarch \
-  opendkim \
-  opendkim-tools \
-  opendmarc \
-  pax \
-  p7zip-full \
-  postfix-ldap \
-  postfix-pcre \
-  postfix-policyd-spf-python \
-  postsrsd \
-  pyzor \
-  razor \
-  ripole \
-  rpm2cpio \
-  rsyslog \
-  sasl2-bin \
-  spamassassin \
-  supervisor \
-  postgrey \
-  unrar-free \
-  unzip \
-  xz-utils \
-  zoo \
-  && \
+    amavisd-new \
+    arj \
+    binutils \
+    bzip2 \
+    ca-certificates \
+    cabextract \
+    clamav \
+    clamav-daemon \
+    cpio \
+    curl \
+    dovecot-core \
+    dovecot-imapd \
+    dovecot-ldap \
+    dovecot-lmtpd \
+    dovecot-managesieved \
+    dovecot-pop3d \
+    dovecot-sieve \
+    ed \
+    fail2ban \
+    fetchmail \
+    file \
+    gamin \
+    gzip \
+    gnupg \
+    iproute2 \
+    iptables \
+    locales \
+    liblz4-tool \
+    libmail-spf-perl \
+    libnet-dns-perl \
+    libsasl2-modules \
+    lrzip \
+    lzop \
+    netcat-openbsd \
+    nomarch \
+    opendkim \
+    opendkim-tools \
+    opendmarc \
+    pax \
+    p7zip-full \
+    postfix-ldap \
+    postfix-pcre \
+    postfix-policyd-spf-python \
+    postsrsd \
+    pyzor \
+    razor \
+    ripole \
+    rpm2cpio \
+    rsyslog \
+    sasl2-bin \
+    spamassassin \
+    supervisor \
+    postgrey \
+    unrar-free \
+    unzip \
+    xz-utils \
+    zoo \
+    && \
   curl https://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add - && \
   echo "deb http://packages.elastic.co/beats/apt stable main" | tee -a /etc/apt/sources.list.d/beats.list && \
   apt-get update -q --fix-missing && \
   apt-get -y upgrade \
-  fail2ban \
-  filebeat \
-  && \
+    fail2ban \
+    filebeat \
+    && \
   apt-get autoclean && \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /usr/share/locale/* && \
@@ -121,7 +121,7 @@ COPY target/postfix/ldap-users.cf target/postfix/ldap-groups.cf target/postfix/l
 
 # Enables Spamassassin CRON updates and update hook for supervisor
 RUN sed -i -r 's/^(CRON)=0/\1=1/g' /etc/default/spamassassin && \
-  sed -i -r 's/^\$INIT restart/supervisorctl restart amavis/g' /etc/spamassassin/sa-update-hooks.d/amavisd-new
+    sed -i -r 's/^\$INIT restart/supervisorctl restart amavis/g' /etc/spamassassin/sa-update-hooks.d/amavisd-new
 
 # Enables Postgrey
 COPY target/postgrey/postgrey /etc/default/postgrey
@@ -130,7 +130,7 @@ RUN chmod 755 /etc/init.d/postgrey && \
   mkdir /var/run/postgrey && \
   chown postgrey:postgrey /var/run/postgrey
 
-# Enables PostSRSd
+# Copy PostSRSd Config
 COPY target/postsrsd/postsrsd /etc/default/postsrsd
 
 # Enables Amavis

--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -82,3 +82,9 @@ policyd-spf_time_limit = 3600
 
 # Remove unwanted headers that reveail our privacy
 smtp_header_checks = pcre:/etc/postfix/maps/sender_header_filter.pcre
+
+# postSRSd rules to process spf mail forwarding
+sender_canonical_maps = tcp:localhost:10001
+sender_canonical_classes = envelope_sender
+recipient_canonical_maps = tcp:localhost:10002
+recipient_canonical_classes = envelope_recipient,header_recipient

--- a/target/postsrsd-wrapper.sh
+++ b/target/postsrsd-wrapper.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# postsrsd-wrapper.sh, version 0.1.0
+
+DOMAINNAME="$(hostname -d)"
+sed -i -e "s/localdomain/$DOMAINNAME/g" /etc/default/postsrsd
+
+/etc/init.d/postsrsd start
+

--- a/target/postsrsd/postsrsd
+++ b/target/postsrsd/postsrsd
@@ -1,0 +1,41 @@
+# Default settings for postsrsd
+
+# Local domain name.
+# Addresses are rewritten to originate from this domain. The default value
+# is taken from `postconf -h mydomain` and probably okay.
+#
+SRS_DOMAIN=localdomain
+
+# Exclude additional domains.
+# You may list domains which shall not be subjected to address rewriting.
+# If a domain name starts with a dot, it matches all subdomains, but not
+# the domain itself. Separate multiple domains by space or comma.
+#
+#SRS_EXCLUDE_DOMAINS=.example.com,example.org
+
+# First separator character after SRS0 or SRS1.
+# Can be one of: -+=
+SRS_SEPARATOR==
+
+# Secret key to sign rewritten addresses.
+# When postsrsd is installed for the first time, a random secret is generated
+# and stored in /etc/postsrsd.secret. For most installations, that's just fine.
+#
+SRS_SECRET=/etc/postsrsd.secret
+
+# Local ports for TCP list.
+# These ports are used to bind the TCP list for postfix. If you change
+# these, you have to modify the postfix settings accordingly. The ports
+# are bound to the loopback interface, and should never be exposed on
+# the internet.
+#
+SRS_FORWARD_PORT=10001
+SRS_REVERSE_PORT=10002
+
+# Drop root privileges and run as another user after initialization.
+# This is highly recommended as postsrsd handles untrusted input.
+#
+RUN_AS=postsrsd
+
+# Jail daemon in chroot environment
+CHROOT=/var/lib/postsrsd

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -105,6 +105,7 @@ function register_functions() {
 	_register_setup_function "_setup_amavis"
 	_register_setup_function "_setup_dmarc_hostname"
 	_register_setup_function "_setup_postfix_hostname"
+	_register_setup_function "_setup_postsrsd_hostname"
 	_register_setup_function "_setup_dovecot_hostname"
 
 	_register_setup_function "_setup_postfix_sasl"
@@ -421,6 +422,12 @@ function _setup_postfix_hostname() {
 	notify 'inf' "Applying hostname to /etc/postfix/main.cf"
 	postconf -e "myhostname = $HOSTNAME"
 	postconf -e "mydomain = $DOMAINNAME"
+}
+
+function _setup_postsrsd_hostname() {
+	notify 'task' 'Applying hostname to PostSRSd'
+	notify 'inf' 'Applying hostname to /etc/default/postsrsd'
+	sed -i -e "s/localdomain/$DOMAINNAME/g" /etc/default/postsrsd
 }
 
 function _setup_dovecot_hostname() {

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -105,7 +105,6 @@ function register_functions() {
 	_register_setup_function "_setup_amavis"
 	_register_setup_function "_setup_dmarc_hostname"
 	_register_setup_function "_setup_postfix_hostname"
-	_register_setup_function "_setup_postsrsd_hostname"
 	_register_setup_function "_setup_dovecot_hostname"
 
 	_register_setup_function "_setup_postfix_sasl"
@@ -422,12 +421,6 @@ function _setup_postfix_hostname() {
 	notify 'inf' "Applying hostname to /etc/postfix/main.cf"
 	postconf -e "myhostname = $HOSTNAME"
 	postconf -e "mydomain = $DOMAINNAME"
-}
-
-function _setup_postsrsd_hostname() {
-	notify 'task' 'Applying hostname to PostSRSd'
-	notify 'inf' 'Applying hostname to /etc/default/postsrsd'
-	sed -i -e "s/localdomain/$DOMAINNAME/g" /etc/default/postsrsd
 }
 
 function _setup_dovecot_hostname() {

--- a/target/supervisor/conf.d/supervisor-app.conf
+++ b/target/supervisor/conf.d/supervisor-app.conf
@@ -121,3 +121,11 @@ autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 command=/usr/local/bin/check-for-changes.sh
+
+[program:postsrsd]
+startsecs=0
+autostart=true
+autorestart=true
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/etc/init.d/postsrsd start

--- a/target/supervisor/conf.d/supervisor-app.conf
+++ b/target/supervisor/conf.d/supervisor-app.conf
@@ -128,4 +128,4 @@ autostart=true
 autorestart=unexpected
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
-command=/etc/init.d/postsrsd start
+command=/usr/local/bin/postsrsd-wrapper.sh

--- a/target/supervisor/conf.d/supervisor-app.conf
+++ b/target/supervisor/conf.d/supervisor-app.conf
@@ -125,7 +125,7 @@ command=/usr/local/bin/check-for-changes.sh
 [program:postsrsd]
 startsecs=0
 autostart=true
-autorestart=true
+autorestart=unexpected
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 command=/etc/init.d/postsrsd start

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -345,13 +345,13 @@ load 'test_helper/bats-assert/load'
 }
 
 @test "checking smtp: rejects spam" {
-  run docker exec mail /bin/sh -c "grep 'Blocked SPAM' /var/log/mail/mail.log | grep spam@external.tld | wc -l"
+  run docker exec mail /bin/sh -c "grep 'Blocked SPAM' /var/log/mail/mail.log | grep external.tld=spam@my-domain.com | wc -l"
   assert_success
   assert_output 1
 }
 
 @test "checking smtp: rejects virus" {
-  run docker exec mail /bin/sh -c "grep 'Blocked INFECTED' /var/log/mail/mail.log | grep virus@external.tld | wc -l"
+  run docker exec mail /bin/sh -c "grep 'Blocked INFECTED' /var/log/mail/mail.log | grep external.tld=virus@my-domain.com | wc -l"
   assert_success
   assert_output 1
 }


### PR DESCRIPTION
This PR fixes an issue regarding redirecting emails to an external provider. Previously it ended in a softfail SPFs, because no sender rewriting was applied to the from address. 

For example if you add the following to your config, you should end up with softfails
```
# /config/postfix-virtual.cf

mymail@domain.com user@gmail.com

```

Partly this fixes issue #611 if i understood everything correctly. Also huge thanks to @tuxpowered for pointing into the right direction 👍 

There are no tests atm, but i'm not sure how to test for something like this? 
