### PR TITLE
Added  reject_sender_login_mismatch

### DIFF
--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -47,7 +47,7 @@ smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_una
 smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unauth_destination, check_policy_service unix:private/policyd-spf,
     reject_unauth_pipelining, reject_invalid_helo_hostname, reject_non_fqdn_helo_hostname, reject_unknown_recipient_domain, reject_rbl_client zen.spamhaus.org, reject_rbl_client bl.spamcop.net
 smtpd_client_restrictions = permit_mynetworks, permit_sasl_authenticated, reject_unauth_destination, reject_unauth_pipelining
-smtpd_sender_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unknown_sender_domain
+smtpd_sender_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unknown_sender_domain,  reject_sender_login_mismatch
 disable_vrfy_command = yes
 
 # Postscreen settings to drop zombies/open relays/spam early


### PR DESCRIPTION
Added reject_sender_login_mismatch parameter to prevent users from sending email using arbitrary email address. #811 