### PR TITLE
RFC: add option for user to change password

### DIFF
--- a/target/supervisor/conf.d/supervisor-app.conf
+++ b/target/supervisor/conf.d/supervisor-app.conf
@@ -129,3 +129,11 @@ autorestart=unexpected
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 command=/usr/local/bin/postsrsd-wrapper.sh
+
+[program:updateuserpassword]
+startsecs=0
+autostart=true
+autorestart=true
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/usr/local/bin/update-user-password/main

--- a/target/update-user-password/gocrypt.go
+++ b/target/update-user-password/gocrypt.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	simplejson "github.com/bitly/go-simplejson"
+	"github.com/jaredfolkins/badactor"
+	"github.com/julienschmidt/httprouter"
+	"github.com/tredoe/osutil/user/crypt/sha512_crypt"
+	"github.com/urfave/negroni"
+)
+
+var st *badactor.Studio
+
+func getDirectory() string {
+	return "/tmp/docker-mailserver/postfix-accounts.cf"
+}
+
+func getHash(salt string, secret string) string {
+	c := sha512_crypt.New()
+	hash, err := c.Generate([]byte(secret), []byte(salt))
+	if err != nil {
+		panic(err)
+	}
+	return hash
+}
+
+type User struct {
+	mail string
+	hash string
+	salt string
+}
+
+func findUser(mail string) User {
+	directory := getDirectory()
+	file, err := os.Open(directory)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+	var u User
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		str := scanner.Text()
+
+		i := strings.Index(str, "|")
+		email := str[:i]
+
+		startSalt := strings.Index(str, "$")
+		endSalt := strings.LastIndex(str, "$")
+		salt := str[startSalt : endSalt+1]
+		hash := str[startSalt:]
+		if mail == email {
+			u.hash = hash
+			u.mail = email
+			u.salt = salt
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		log.Fatal(err)
+	}
+	return u
+}
+
+func writeToFile(mail string, newHash string) {
+	directory := getDirectory()
+	input, err := ioutil.ReadFile(directory)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	lines := strings.Split(string(input), "\n")
+
+	for i, line := range lines {
+		if strings.HasPrefix(line, mail) {
+			lines[i] = mail + "|{SHA512-CRYPT}" + newHash
+		}
+	}
+	output := strings.Join(lines, "\n")
+	err = ioutil.WriteFile(directory, []byte(output), 0644)
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+
+type UserInput struct {
+	Mail          string
+	CurrentSecret string
+	NewSecret     string
+}
+
+func changePassword(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	var err error
+	decoder := json.NewDecoder(r.Body)
+	var u UserInput
+
+	err = decoder.Decode(&u)
+	if err != nil {
+		panic(err)
+	}
+	an, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		panic(err)
+	}
+
+	json := simplejson.New()
+	user := findUser(u.Mail)
+	if (User{}) == user {
+		err = st.Infraction(an, "Login")
+		if err != nil {
+			log.Printf("[%v] has err %v", an, err)
+		}
+		json.Set("status", "user not found")
+		w.WriteHeader(http.StatusNotFound)
+	} else {
+		currentHash := getHash(string(user.salt), u.CurrentSecret)
+		if currentHash == user.hash {
+			newHash := getHash(string(user.salt), u.NewSecret)
+			writeToFile(user.mail, newHash)
+			json.Set("status", "changed password")
+		} else {
+			err = st.Infraction(an, "Login")
+			if err != nil {
+				log.Printf("[%v] has err %v", an, err)
+			}
+			json.Set("status", "wrong password")
+			w.WriteHeader(http.StatusForbidden)
+		}
+	}
+	payload, err := json.MarshalJSON()
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(payload)
+}
+
+type MyAction struct{}
+
+func (ma *MyAction) WhenJailed(a *badactor.Actor, r *badactor.Rule) error {
+	return nil
+}
+
+func (ma *MyAction) WhenTimeServed(a *badactor.Actor, r *badactor.Rule) error {
+	return nil
+}
+
+func main() {
+	// studio capacity
+	var sc int32
+	// director capacity
+	var dc int32
+
+	sc = 1024
+	dc = 1024
+	st = badactor.NewStudio(sc)
+	ru := &badactor.Rule{
+		Name:        "Login",
+		Message:     "You have failed to login too many times",
+		StrikeLimit: 5,
+		ExpireBase:  time.Second * 1,
+		Sentence:    time.Second * 10,
+		Action:      &MyAction{},
+	}
+	st.AddRule(ru)
+
+	err := st.CreateDirectors(dc)
+	if err != nil {
+		log.Fatal(err)
+	}
+	//poll duration
+	dur := time.Minute * time.Duration(60)
+	// Start the reaper
+	st.StartReaper(dur)
+
+	router := httprouter.New()
+	router.POST("/change", changePassword)
+
+	// middleware
+	n := negroni.Classic()
+	n.Use(negroni.NewStatic(http.Dir("/usr/local/bin/update-user-password/static")))
+	n.Use(NewBadActorMiddleware())
+	n.UseHandler(router)
+	n.Run(":8000")
+}
+
+// BadActorMiddleware Middleware
+type BadActorMiddleware struct {
+	negroni.Handler
+}
+
+// NewBadActorMiddleware restrict usage by IP
+func NewBadActorMiddleware() *BadActorMiddleware {
+	return &BadActorMiddleware{}
+}
+
+func (bam *BadActorMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+
+	// get IP
+	an, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		panic(err)
+	}
+
+	// if the IP is jailed, send them StatusUnauthorized
+	if st.IsJailed(an) {
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
+	}
+
+	// call the next middleware in the chain
+	next(w, r)
+}

--- a/target/update-user-password/static/index.html
+++ b/target/update-user-password/static/index.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Change Password</title>
+  <style>
+    html,
+    body {
+      margin: 0;
+      padding: 0;
+      background-color: #f1f3f5;
+      min-height: 90vh;
+      color: #495057;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      font-size: 18px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    .wrapper {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 90vh;
+    }
+
+    .container {
+      width: 100%;
+      max-width: 20em;
+      background-color: white;
+      box-shadow: 0 4px 6px rgba(50, 50, 93, 0.11), 0 1px 3px rgba(0, 0, 0, 0.08);
+      padding: 1em;
+    }
+
+    label {
+      display: block;
+      margin-bottom: 0.5em;
+    }
+
+    .email,
+    .password {
+      display: block;
+      width: 100%;
+      padding: 0.5em 0;
+      outline: none;
+      border-top: none;
+      border-left: none;
+      border-right: none;
+      border-bottom: 1px solid #ced4da;
+      font-size: 18px;
+    }
+
+    .email:active,
+    .password:active,
+    .email:focus,
+    .password:focus {
+      border-bottom: 1px solid #343a40;
+    }
+
+    .button {
+      margin-top: 1em;
+      padding: 0.5em 0;
+      position: relative;
+      display: block;
+      width: 100%;
+      background-color: #3ecf8e;
+      border: none;
+      border-radius: 0.25em;
+      box-shadow: 0 4px 6px rgba(50, 50, 93, 0.11), 0 1px 3px rgba(0, 0, 0, 0.08);
+      color: white;
+      text-shadow: 0 1px 3px rgba(36, 180, 126, 0.4);
+      font-size: 18px;
+      cursor: pointer;
+      transition: all 0.15s ease;
+      outline: none;
+    }
+
+    .button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 7px 14px rgba(50, 50, 93, 0.1), 0 3px 6px rgba(0, 0, 0, 0.08);
+    }
+
+    .button:active {
+      transform: translateY(1px);
+      box-shadow: 0 4px 6px rgba(50, 50, 93, 0.11), 0 1px 3px rgba(0, 0, 0, 0.08);
+    }
+
+    .errorMessage {
+      color: #e03131;
+    }
+
+    .successMessage {
+      color: #2f9e44;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="wrapper">
+    <div class="container">
+      <p id="errorMessage" class="errorMessage"></p>
+      <p id="successMessage" class="successMessage"></p>
+      <form id="form">
+        <label for="Email">
+          Email
+          <input required type="email" id="email" class="email">
+        </label>
+        <label for="currentSecret">
+          Current Password
+          <input required type="password" id="currentSecret" class="password">
+        </label>
+        <label for="newSecret">
+          New Password
+          <input required type="password" id="newSecret" class="password">
+        </label>
+        <label for="newSecretRetype">
+          Retype New Password
+          <input required type="password" id="newSecretRetype" class="password">
+        </label>
+        <input required class="button" type="submit" value="Change Password" />
+      </form>
+    </div>
+  </div>
+  <script>
+    const form = document.getElementById('form');
+    const errorMessage = document.getElementById('errorMessage');
+    const successMessage = document.getElementById('successMessage');
+    const emailEl = document.getElementById('email');
+    const currentSecretEl = document.getElementById('currentSecret');
+    const newSecretEl = document.getElementById('newSecret');
+    const newSecretRetypeEl = document.getElementById('newSecretRetype');
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const email = emailEl.value;
+      const currentSecret = currentSecretEl.value;
+      const newSecret = newSecretEl.value;
+      const newSecretRetype = newSecretRetypeEl.value;
+      let ok = true
+      if (newSecret !== newSecretRetype) {
+        ok = false;
+        errorMessage.innerHTML = "New Password didn't match";
+      }
+      if (ok) {
+        const data = {
+          Mail: email, CurrentSecret: currentSecret, NewSecret: newSecret
+        }
+        fetch(
+          '/change',
+          {
+            method: 'POST',
+            body: JSON.stringify(data)
+          }
+        ).then(res => res.json()).then(json => {
+          const { status } = json;
+          if (status === 'changed password') {
+            errorMessage.innerHTML = "";
+            successMessage.innerHTML = status;
+            form.reset();
+          } else {
+            successMessage.innerHTML = "";
+            errorMessage.innerHTML = status;
+          }
+        }).catch(err => {
+          console.log(err);
+          errorMessage.innerHTML = "You have failed to change too many times";
+        })
+      }
+
+    })
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
It's an easy interface to change the password. It's a small server written in Go. There're no shell scripts involved and it only works with SHA512 encryption at the moment. 
If you startup the server you should also expose port 8000 or run it through a proxy like traefik or nginx.
There's a webinterface included which is accessible on `http://localhost:8000`. The API Endpoint is located on `http://localhost:8000/change` which listens for POST Requests. The body should be JSON encoded. And the object should look something like this:
```
{"Mail":"test@domain.tld", "CurrentSecret": "yoursecret", "NewSecret": "yournewsecret"}
```

There's something like fail2ban in place. 
