### PR TITLE
Diffie-Hellman 2048 Bit Parameters should be changed regularly.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -178,7 +178,9 @@ RUN mkdir /var/run/fetchmail && chown fetchmail /var/run/fetchmail
 COPY target/postfix/main.cf target/postfix/master.cf /etc/postfix/
 COPY target/postfix/sender_header_filter.pcre /etc/postfix/maps/sender_header_filter.pcre
 RUN echo "" > /etc/aliases && \
-  openssl dhparam -out /etc/postfix/dhparams.pem 2048
+  openssl dhparam -out /etc/postfix/dhparams.pem 2048 && \
+  echo "@daily FILE=`mktemp` ; openssl dhparam -out $FILE 2048 > /dev/null 2>&1 && mv -f $FILE /etc/postfix/dhparams.pem" > /etc/cron.d/dh2048
+
 
 # Configuring Logs
 RUN sed -i -r "/^#?compress/c\compress\ncopytruncate" /etc/logrotate.conf && \


### PR DESCRIPTION
Since it is assumed that the NSA uses rainbowtables to break default-DHE-Parameters, one is encouraged to change those parameters periodically.

See: 
Paper: [Imperfect Forward Secrecy: How Diffie-Hellman Fails in Practice](https://weakdh.org/imperfect-forward-secrecy-ccs15.pdf)
Consideration: [Wie die NSA den Diffie-Hellman Schlüsseltausch knackt](https://www.heinlein-support.de/blog/news/wie-die-nsa-den-diffie-hellman-schluesseltausch-knackt/)(German)