### PR TITLE
fixed greedy postgrey sed command

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -592,7 +592,7 @@ function _setup_ldap() {
 
 function _setup_postgrey() {
 	notify 'inf' "Configuring postgrey"
-	sed -i -e 's/bl.spamcop.net$/bl.spamcop.net, check_policy_service inet:127.0.0.1:10023/' /etc/postfix/main.cf
+	sed -i -e 's/, reject_rbl_client bl.spamcop.net$/, reject_rbl_client bl.spamcop.net, check_policy_service inet:127.0.0.1:10023/' /etc/postfix/main.cf
 	sed -i -e "s/\"--inet=127.0.0.1:10023\"/\"--inet=127.0.0.1:10023 --delay=$POSTGREY_DELAY --max-age=$POSTGREY_MAX_AGE\"/" /etc/default/postgrey
 	TEXT_FOUND=`grep -i "POSTGREY_TEXT" /etc/default/postgrey | wc -l`
 
@@ -608,7 +608,7 @@ function _setup_postfix_postscreen() {
 	notify 'inf' "Configuring postscreen"
 	sed -i -e "s/postscreen_dnsbl_action = enforce/postscreen_dnsbl_action = $POSTSCREEN_ACTION/" \
 	       -e "s/postscreen_greet_action = enforce/postscreen_greet_action = $POSTSCREEN_ACTION/" \
-	       -e "s/postscreen_bare_newline_action = enforce/postscreen_bare_newline_action = $POSTSCREEN_ACTION/" /etc/postfix/main.cf 
+	       -e "s/postscreen_bare_newline_action = enforce/postscreen_bare_newline_action = $POSTSCREEN_ACTION/" /etc/postfix/main.cf
 }
 
 function _setup_postfix_sasl() {


### PR DESCRIPTION
funny bug.
there was a sed command searching for `bl.spamcop.net$` and we had two occurrences of bl.spamcop.net in the main.cf file. The correct one and one from the postscreen dnsbl list.
Why wasn't this detected with the initial PR of postscreen?
Because there was a trailing space behind bl.spamcop.net, which then got removed with some other PR.. m(
So this should fix #840 
Test passed on my machine