### PR TITLE
update postmaster_address in dovecot config according to POSTMASTER_ADDRESS env var

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -23,6 +23,7 @@ DEFAULT_VARS["ENABLE_SASLAUTHD"]="${ENABLE_SASLAUTHD:="0"}"
 DEFAULT_VARS["SMTP_ONLY"]="${SMTP_ONLY:="0"}"
 DEFAULT_VARS["DMS_DEBUG"]="${DMS_DEBUG:="0"}"
 DEFAULT_VARS["OVERRIDE_HOSTNAME"]="${OVERRIDE_HOSTNAME}"
+DEFAULT_VARS["POSTMASTER_ADDRESS"]="${POSTMASTER_ADDRESS:="postmaster@domain.com"}"
 DEFAULT_VARS["POSTSCREEN_ACTION"]="${POSTSCREEN_ACTION:="enforce"}"
 DEFAULT_VARS["TLS_LEVEL"]="${TLS_LEVEL:="modern"}"
 ##########################################################################
@@ -445,6 +446,7 @@ function _setup_dovecot() {
 	sed -i -e 's/#port = 993/port = 993/g' /etc/dovecot/conf.d/10-master.conf
 	sed -i -e 's/#port = 995/port = 995/g' /etc/dovecot/conf.d/10-master.conf
 	sed -i -e 's/#ssl = yes/ssl = required/g' /etc/dovecot/conf.d/10-ssl.conf
+	sed -i 's/^postmaster_address = .*$/postmaster_address = '$POSTMASTER_ADDRESS'/g' /etc/dovecot/conf.d/15-lda.conf
 
 	# Enable Managesieve service by setting the symlink
 	# to the configuration file Dovecot will actually find

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1322,6 +1322,11 @@ load 'test_helper/bats-assert/load'
   assert_success
 }
 
+@test "checking dovecot: postmaster address" {
+  run docker exec mail_with_ldap /bin/sh -c "grep 'postmaster_address = postmaster@localhost.localdomain' /etc/dovecot/conf.d/15-lda.conf"
+  assert_success
+}
+
 # saslauthd
 @test "checking saslauthd: sasl ldap authentication works" {
   run docker exec mail_with_ldap bash -c "testsaslauthd -u some.user -p secret"

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1323,6 +1323,9 @@ load 'test_helper/bats-assert/load'
 }
 
 @test "checking dovecot: postmaster address" {
+  run docker exec mail /bin/sh -c "grep 'postmaster_address = postmaster@domain.com' /etc/dovecot/conf.d/15-lda.conf"
+  assert_success
+  
   run docker exec mail_with_ldap /bin/sh -c "grep 'postmaster_address = postmaster@localhost.localdomain' /etc/dovecot/conf.d/15-lda.conf"
   assert_success
 }


### PR DESCRIPTION
Update the postmaster_address in the `start-mailserver.sh` script.

At the moment this config is set in the `Dockerfile` at: https://github.com/tomav/docker-mailserver/blob/c36e878d76827fc7062558f1edada05d7ba38880/Dockerfile#L111
But this code is executed only when the docker image is built and not at runtime.