### PR TITLE
fixes issue #792 by setting quiet mode on invoke-rc.d

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -199,7 +199,9 @@ RUN sed -i -r "/^#?compress/c\compress\ncopytruncate" /etc/logrotate.conf && \
   sed -i -r 's|/var/log/mail|/var/log/mail/mail|g' /etc/logrotate.d/rsyslog && \
   # prevent syslog logrotate warnings \
   sed -i -e 's/\(printerror "could not determine current runlevel"\)/#\1/' /usr/sbin/invoke-rc.d && \
-  sed -i -e 's/^\(POLICYHELPER=\).*/\1/' /usr/sbin/invoke-rc.d
+  sed -i -e 's/^\(POLICYHELPER=\).*/\1/' /usr/sbin/invoke-rc.d && \
+  # prevent email when /sbin/init or init system is not existing \
+  sed -i -e 's/invoke-rc.d rsyslog rotate > \/dev\/null/invoke-rc.d rsyslog --quiet rotate > \/dev\/null/g' /etc/logrotate.d/rsyslog
 
 # Get LetsEncrypt signed certificate
 RUN curl -s https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > /etc/ssl/certs/lets-encrypt-x3-cross-signed.pem


### PR DESCRIPTION
on some hosts logrotating may cause emails to get sent out (see #792).
by setting the --quiet option on that action, a single warning is suppressed.

Works on a daily basis in my production environments and in artificial testing environment, where daily cronjobs are executed once an hour.