### PR TITLE
Support for detecting running container mount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,3 +292,6 @@ clean:
 		mv testconfig.bak test/config ;\
 	fi
 	-sudo rm -rf test/onedir
+	-sudo rm -rf test/alias
+	-sudo rm -rf test/relay
+


### PR DESCRIPTION
This modification proposes to support the running configured mounted volume for configuration.

This removes the need to pass a path from the command line when the container is running and configured in another way that yours.