### PR TITLE
Generate SRS secret on first run and store it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,8 @@ RUN apt-get update -q --fix-missing && \
   rm -rf /usr/share/doc/* && \
   touch /var/log/auth.log && \
   update-locale && \
-  rm -f /etc/cron.weekly/fstrim
+  rm -f /etc/cron.weekly/fstrim && \
+  rm -f /etc/postsrsd.secret
 
 RUN echo "0 0,6,12,18 * * * /usr/bin/freshclam --quiet" > /etc/cron.d/freshclam && \
   chmod 644 /etc/clamav/freshclam.conf && \

--- a/README.md
+++ b/README.md
@@ -508,8 +508,8 @@ Note: This postgrey setting needs `ENABLE_POSTGREY=1`
 
 ##### SRS_SECRET
 
-  - **empty** => generated when the image is built
-  - provide a secret to use in base64 **(recommended)**
+  - **empty** => generated when the container is started for the first time
+  - provide a secret to use in base64
   - you may specify multiple keys, comma separated. the first one is used for signing and the remaining will be used for verification. this is how you rotate and expire keys
   - if you have a cluster/swarm make sure the same keys are on all nodes
   - example command to generate a key: `dd if=/dev/urandom bs=24 count=1 2>/dev/null | base64`

--- a/target/postsrsd-wrapper.sh
+++ b/target/postsrsd-wrapper.sh
@@ -4,8 +4,28 @@
 DOMAINNAME="$(hostname -d)"
 sed -i -e "s/localdomain/$DOMAINNAME/g" /etc/default/postsrsd
 
+postsrsd_secret_file='/etc/postsrsd.secret'
+postsrsd_state_dir='/var/mail-state/etc-postsrsd'
+postsrsd_state_secret_file="${postsrsd_state_dir}/postsrsd.secret"
+
+generate_secret() {
+  ( umask 0077
+    dd if=/dev/urandom bs=24 count=1 2>/dev/null | base64 -w0 > "$1" )
+}
+
 if [ -n "$SRS_SECRET" ]; then
-  echo "$SRS_SECRET" | tr ',' '\n' > /etc/postsrsd.secret
+  ( umask 0077
+    echo "$SRS_SECRET" | tr ',' '\n' > "$postsrsd_secret_file" )
+else
+  if [ "$ONE_DIR" = 1 ]; then
+    if [ ! -f "$postsrsd_state_secret_file" ]; then
+      install -d -m 0775 "$postsrsd_state_dir"
+      generate_secret "$postsrsd_state_secret_file"
+    fi
+    install -m 0400 "$postsrsd_state_secret_file" "$postsrsd_secret_file"
+  elif [ ! -f "$postsrsd_secret_file" ]; then
+    generate_secret "$postsrsd_secret_file"
+  fi
 fi
 
 if [ -n "$SRS_EXCLUDE_DOMAINS" ]; then


### PR DESCRIPTION
This will generate an SRS secret the first time the container runs and store it in state or /etc for future invocations. If the user defines any secrets that will be used instead.

Thanks and keep up the good work!