### PR TITLE
Delmailuser

### DIFF
--- a/target/bin/addalias
+++ b/target/bin/addalias
@@ -6,7 +6,7 @@ EMAIL="$1"
 RECIPIENT="$2"
 
 usage() {
-	echo "Usage: addalias <user@domain> <recipient@other>"
+	echo "Usage: addalias <alias@domain> <recipient@other>"
 }
 
 errex() {
@@ -24,7 +24,7 @@ grep -qi "^$(escape $EMAIL)[a-zA-Z@.\ ]*$(escape $RECIPIENT)" $DATABASE 2>/dev/n
 	errex "Alias \"$EMAIL $RECIPIENT\" already exists"
 
 if grep -qi "^$(escape $EMAIL)" $DATABASE 2>/dev/null; then
-        sed -i "/$EMAIL/s/$/ $RECIPIENT,/" $DATABASE
+        sed -i "/$EMAIL/s/$/,$RECIPIENT/" $DATABASE
     else
-        echo "$EMAIL $RECIPIENT," >> $DATABASE
+        echo "$EMAIL $RECIPIENT" >> $DATABASE
 fi

--- a/target/bin/delalias
+++ b/target/bin/delalias
@@ -6,7 +6,7 @@ EMAIL="$1"
 RECIPIENT="$2"
 
 usage() {
-	echo "Usage: delalias <user@domain> <recipient@other>"
+	echo "Usage: delalias <alias@domain> <recipient@other>"
 }
 
 errex() {
@@ -26,5 +26,5 @@ CNT=$(grep "^$EMAIL" $DATABASE | wc -w | awk '{print $1}')
 if [[ $CNT -eq 2 ]]; then
         sed -i "/^$EMAIL/d" $DATABASE
     else
-        sed -i "/^$EMAIL/s/ $RECIPIENT,//g" $DATABASE
+        sed -i "/^$EMAIL/s/,$RECIPIENT//g" $DATABASE
 fi

--- a/target/bin/delmailuser
+++ b/target/bin/delmailuser
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 DATABASE=${DATABASE:-/tmp/docker-mailserver/postfix-accounts.cf}
-ALIAS_DATABASE=${ALIAS_DATABASE:-/tmp/docker-mailserver/postfix-virtual.cf}
+ALIAS_DATABASE="/tmp/docker-mailserver/postfix-virtual.cf"
 
 usage() {
 	echo "Usage: delmailuser <-y> <user@domain> <user2@anotherdomain> ..."
@@ -31,22 +31,27 @@ done
 shift $((OPTIND-1))
 
 [ -z "$@" ] && { usage; errex "No user specifed"; }
-[ -s "$DATABASE" ] || errex "Database not found: $DATABASE"
+[ -s "$DATABASE" ] || exit 0
 
 for USER in "$@"; do
+	#very simple plausibility check
 	[[ "$USER" != *"@"*"."* ]] && errex "No valid address: $USER"
-	#USER="$1"
-	# XXX $USER must not contain /s and other syntactic characters
 	MAILARR=(${USER//@/ })
+	# XXX $USER must not contain /s and other syntactic characters
 	USER=$(escape "$USER")
 	sed -i "/^"$USER"|/d" $DATABASE
-	sed -i "/"$USER"|/d" $ALIAS_DATABASE
-	echo "$USER and potential aliases deleted."
+	[ $? != 0 ] && errex "$USER couldn't be deleted in $DATABASE. $?"
+	# Delete all aliases where the user is the only recipient( " $USER$" )
+	# Delete user only for all aliases that deliver to multiple recipients ( ",$USER" "$USER," )
+	sed -i -e "/ "$USER"$/d" \
+				 -e "s/,"$USER"//g" \
+				 -e "s/"$USER",//g" $ALIAS_DATABASE
+	[ $? = 0 ] && echo "$USER and potential aliases deleted." || errex "Aliases for $USER couldn't be deleted in $ALIAS_DATABASE. $?"
 	if [ "$MAILDEL" != "y" ]; then
 	  read -p "Do you want to delete the maildir as well(all mails will be removed)?(y/n) " MAILDEL
 		echo
 	fi
 	[ "$MAILDEL" != "y" ] && errex "Leaving the maildir untouched. If you want to delete it at a later point use \"sudo docker exec mail rm -R /var/mail/${MAILARR[1]}/${MAILARR[0]}\""
 	rm -r -f /var/mail/${MAILARR[1]}/${MAILARR[0]}
-	echo "Maildir deleted."
+	[ $? = 0 ] && echo "Maildir deleted." || errex "Maildir couldn't be deleted: $?"
 done

--- a/target/bin/delmailuser
+++ b/target/bin/delmailuser
@@ -1,15 +1,15 @@
 #! /bin/bash
 
 DATABASE=${DATABASE:-/tmp/docker-mailserver/postfix-accounts.cf}
-
-USER="$1"
+ALIAS_DATABASE=${ALIAS_DATABASE:-/tmp/docker-mailserver/postfix-virtual.cf}
 
 usage() {
-	echo "Usage: delmailuser <user@domain>"
+	echo "Usage: delmailuser <-y> <user@domain> <user2@anotherdomain> ..."
+	echo "	-y: don't prompt for confirmations"
 }
 
 errex() {
-	echo "$@" 1>&2
+	echo -e "$@" 1>&2
 	exit 1
 }
 
@@ -17,8 +17,36 @@ escape() {
 	echo "${1//./\\.}"
 }
 
-[ -z "$USER" ] && { usage; errex "No user specifed"; }
-[ -s "$DATABASE" ] || exit 0
+while getopts ":y" OPT; do
+  case $OPT in
+    y)
+      MAILDEL="y"
+      ;;
+   \?)
+		 usage; errex "Invalid option: -$OPTARG"
+     ;;
+  esac
+done
 
-# XXX $USER must not contain /s and other syntactic characters
-sed -i "/^$(escape "$USER")|/d" $DATABASE
+shift $((OPTIND-1))
+
+[ -z "$@" ] && { usage; errex "No user specifed"; }
+[ -s "$DATABASE" ] || errex "Database not found: $DATABASE"
+
+for USER in "$@"; do
+	[[ "$USER" != *"@"*"."* ]] && errex "No valid address: $USER"
+	#USER="$1"
+	# XXX $USER must not contain /s and other syntactic characters
+	MAILARR=(${USER//@/ })
+	USER=$(escape "$USER")
+	sed -i "/^"$USER"|/d" $DATABASE
+	sed -i "/"$USER"|/d" $ALIAS_DATABASE
+	echo "$USER and potential aliases deleted."
+	if [ "$MAILDEL" != "y" ]; then
+	  read -p "Do you want to delete the maildir as well(all mails will be removed)?(y/n) " MAILDEL
+		echo
+	fi
+	[ "$MAILDEL" != "y" ] && errex "Leaving the maildir untouched. If you want to delete it at a later point use \"sudo docker exec mail rm -R /var/mail/${MAILARR[1]}/${MAILARR[0]}\""
+	rm -r -f /var/mail/${MAILARR[1]}/${MAILARR[0]}
+	echo "Maildir deleted."
+done

--- a/target/bin/updatemailuser
+++ b/target/bin/updatemailuser
@@ -3,7 +3,7 @@
 DATABASE=${DATABASE:-/tmp/docker-mailserver/postfix-accounts.cf}
 
 USER="$1"
-PASSWD="$2"
+PASSWD=$(doveadm pw -s SHA512-CRYPT -u "$USER" -p "$2")
 
 usage() {
 	echo "Usage: updatemailuser <user@domain.tld> [password]"
@@ -22,6 +22,5 @@ escape() {
 
 grep -qi "^$(escape "$USER")|" $DATABASE 2>/dev/null ||
 	errex "User \"$USER\" does not exist"
-
-delmailuser "$USER"
-addmailuser "$USER" "$PASSWD"
+sed -i "s ^"$USER"|.* "$USER"|"$PASSWD" " $DATABASE
+#sed -i "s/^"$(escape "$USER")"|*/"$USER"|"$(doveadm pw -s SHA512-CRYPT -u "$USER" -p "$PASSWD")"/" $DATABASE

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -700,6 +700,8 @@ function _setup_postfix_aliases() {
 	echo -n > /etc/postfix/virtual
 	echo -n > /etc/postfix/regexp
 	if [ -f /tmp/docker-mailserver/postfix-virtual.cf ]; then
+    # fixing old virtual user file
+	  [[ $(grep ",$" /tmp/docker-mailserver/postfix-virtual.cf) ]] && sed -i -e "s/, /,/g" -e "s/,$//g" /tmp/docker-mailserver/postfix-virtual.cf
 		# Copying virtual file
 		cp -f /tmp/docker-mailserver/postfix-virtual.cf /etc/postfix/virtual
 		while read from to

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1185,10 +1185,12 @@ load 'test_helper/bats-assert/load'
   assert_success
 }
 @test "checking setup.sh: setup.sh email del" {
-  run ./setup.sh -c mail email del lorem@impsum.org
+  run ./setup.sh -c mail email del -y lorem@impsum.org
+  assert_success
+  run docker exec mail ls /var/mail/impsum.org/lorem | grep "No such file or directory"
   assert_success
   run value=$(cat ./config/postfix-accounts.cf | grep lorem@impsum.org)
-  [ -z "$value" ]
+  assert_success
 }
 
 @test "checking setup.sh: setup.sh email restrict" {


### PR DESCRIPTION
solves #878

- `delmailuser` is now capable of deleting multiple accounts at once, prompting for confirmation to delete the maildir as well. An additional `-y` flag was introduced to assume yes on this question.
I had to modify most of the shell scripts which are modifying the postfix-accounts and postfix-virtual databases due to the modified delmailuser script.
- `updatemailuser` was just deleting and readding the user as a new one. This wasn't possible with the new deletion script anymore.
- `addalias, delalias` was changed to reflect the correct implementation of multiple recipients for one alias (`,` as saparator only, actually that was making it much easier for me, getting the sed commands do what I wanted them to do! ;) )