### PR TITLE
Backup config folder while testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ generate-accounts-after-run:
 	sleep 10
 
 fixtures:
-	cp config/postfix-accounts.cf config/postfix-accounts.cf.bak
+	cp -r config config.bak
 	# Setup sieve & create filtering folder (INBOX/spam)
 	docker cp "`pwd`/test/config/sieve/dovecot.sieve" mail:/var/mail/localhost.localdomain/user1/.dovecot.sieve
 	docker exec mail /bin/sh -c "maildirmake.dovecot /var/mail/localhost.localdomain/user1/.INBOX.spam"
@@ -259,9 +259,9 @@ clean:
 		mail_postscreen \
 		mail_override_hostname
 
-	@if [ -f config/postfix-accounts.cf.bak ]; then\
-		rm -f config/postfix-accounts.cf ;\
-		mv config/postfix-accounts.cf.bak config/postfix-accounts.cf ;\
+	@if [ -d config.bak ]; then\
+		sudo rm -rf config ;\
+		mv config.bak config ;\
 	fi
 	-sudo rm -rf test/onedir \
 		test/config/empty \

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -788,6 +788,8 @@ function _setup_ssl() {
 					KEY="privkey"
 				elif [ -e "/etc/letsencrypt/live/$HOSTNAME/key.pem" ]; then
 					KEY="key"
+				else
+					notify 'err' "Cannot access '/etc/letsencrypt/live/"$HOSTNAME"/privkey.pem' nor 'key.pem'"
 				fi
 				if [ -n "$KEY" ]; then
 					notify 'inf' "Adding $HOSTNAME SSL certificate"
@@ -801,7 +803,11 @@ function _setup_ssl() {
 					sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/letsencrypt/live/'$HOSTNAME'/'"$KEY"'\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
 
 					notify 'inf' "SSL configured with 'letsencrypt' certificates"
+				else
+					notify 'err' "Key filename not set!"
 				fi
+			else
+				notify 'err' "Cannot access '/etc/letsencrypt/live/"$HOSTNAME"/fullchain.pem'"
 			fi
 		;;
 	"custom" )

--- a/test/config/dovecot-lmtp/userdb
+++ b/test/config/dovecot-lmtp/userdb
@@ -1,2 +1,0 @@
-user1@localhost.localdomain:{SHA512-CRYPT}$6$pnBf.UoYuOJ0EcxA$AY.2iRKsDftvCs5u2u72jgKcQHdN/tLguweV08YuBNaZGN4Xn9N8ES0NPxErqRR433vqBFUMmOiVNVF3JgMpB.:5000:5000::/var/mail/localhost.localdomain/user1::
-user2@otherdomain.tld:{SHA512-CRYPT}$6$xkJ0klS8NqpoGeVB$jKmC1YE03GeLtrcwgnQ14AG.nYm8Vj0l0BqUVM.VQ3MVBwYoooJL7JS7czR17gfwM9SRB/311OP8nF/GpNKr5.:5000:5000::/var/mail/otherdomain.tld/user2::


### PR DESCRIPTION
At the moment we only backup ./config/postfix-accounts.cf before testing the setup.sh functionality.
This PR creates a backup of the whole config folder and while cleaning restores it.

Also I removed the dovecot-lmtp/userdb file that is removed by make clean.