### PR TITLE
add headers to postfix summary mail

### DIFF
--- a/target/bin/postfix-summary
+++ b/target/bin/postfix-summary
@@ -10,9 +10,17 @@ errex() {
 
 test -x /usr/sbin/pflogsumm || errex "Critical: /usr/sbin/pflogsumm not found"
 
-BODY="Subject: Postfix Summary for $HOSTNAME\n\n"
 # The case that the mail.log.1 file isn't readable shouldn't actually be possible with logrotate not rotating empty files.. But you never know!
 [ -r "/var/log/mail/mail.log.1" ] \
-  && BODY="$BODY"$(/usr/sbin/pflogsumm /var/log/mail/mail.log.1 --problems-first) \
-  || BODY="$BODY Error: Mail log not readable or not found: /var/log/mail/mail.log.1\n\nIn case of mail inactivity since the last report, this might be considered a nuisance warning.\n\nYours faithfully, The $HOSTNAME Mailserver"
-echo -e "$BODY" | sendmail -f "mailserver-report@$HOSTNAME" "$RECIPIENT"
+  && BODY=$(/usr/sbin/pflogsumm /var/log/mail/mail.log.1 --problems-first) \
+  || BODY="Error: Mail log not readable or not found: /var/log/mail/mail.log.1\n\nIn case of mail inactivity since the last report, this might be considered a nuisance warning.\n\nYours faithfully, The $HOSTNAME Mailserver"
+
+sendmail -t <<EOF
+From: mailserver-report@$HOSTNAME
+To: $RECIPIENT
+Subject: Postfix Summary for $HOSTNAME
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset=UTF-8
+
+$BODY
+EOF


### PR DESCRIPTION
this PR adds the `To`, `Content-Transfer-Encoding` and `Content-Type` headers to the postfix summary mails