### PR TITLE
quotes needed to run multi-word command inside container

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -93,7 +93,7 @@ _docker_image() {
 
 _docker_container() {
   if [ -n "$CONTAINER_NAME" ]; then
-    docker exec -ti "$CONTAINER_NAME" $@
+    docker exec -ti "$CONTAINER_NAME" "$@"
   else
     echo "The docker-mailserver is not running!"
     exit 1


### PR DESCRIPTION
If the argument isn't quoted, then you can't run commands like

```
./setup.sh debug login "tail -f /var/log/mail/mail.log"
```