### PR TITLE
 Introducing global filters.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,10 +117,8 @@ RUN sed -i -e 's/include_try \/usr\/share\/dovecot\/protocols\.d/include_try \/e
   chmod 755 /etc/dovecot/ssl  && \
   cd /usr/share/dovecot && \
   ./mkcert.sh  && \
-  mkdir /usr/lib/dovecot/sieve-pipe && \
-  chmod 755 /usr/lib/dovecot/sieve-pipe  && \
-  mkdir /usr/lib/dovecot/sieve-filter && \
-  chmod 755 /usr/lib/dovecot/sieve-filter
+  mkdir -p /usr/lib/dovecot/sieve-pipe /usr/lib/dovecot/sieve-filter /usr/lib/dovecot/sieve-global && \
+  chmod 755 -R /usr/lib/dovecot/sieve-pipe /usr/lib/dovecot/sieve-filter /usr/lib/dovecot/sieve-global
 
 # Configures LDAP
 COPY target/dovecot/dovecot-ldap.conf.ext /etc/dovecot

--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,8 @@ clean:
 		mail_with_postgrey \
 		mail_undef_spam_subject \
 		mail_postscreen \
-		mail_override_hostname
+		mail_override_hostname \
+		mail_with_relays
 
 	@if [ -d config.bak ]; then\
 		rm -rf config ;\

--- a/target/dovecot/90-sieve.conf
+++ b/target/dovecot/90-sieve.conf
@@ -71,7 +71,7 @@ plugin {
   # (http://pigeonhole.dovecot.org) for available plugins.
   # The sieve_extprograms plugin is included in this release.
   #sieve_plugins =
-  sieve_plugins = sieve_extprograms sieve_imapsieve
+  sieve_plugins = sieve_extprograms
 
   # The separator that is expected between the :user and :detail
   # address parts introduced by the subaddress extension. This may
@@ -108,18 +108,4 @@ plugin {
   # Locations of programs that can be called by the sieve_extprograms plugin
   sieve_pipe_bin_dir = /usr/lib/dovecot/sieve-pipe
   sieve_filter_bin_dir = /usr/lib/dovecot/sieve-filter
-
-  # AntispamWithSieve (Derived from: https://wiki2.dovecot.org/HowTo/AntispamWithSieve)
-
-  # From elsewhere to Spam folder
-  imapsieve_mailbox1_name = Junk
-  imapsieve_mailbox1_causes = COPY
-  imapsieve_mailbox1_before = file:/usr/lib/dovecot/antispam/report-spam.sieve
-
-  # From Spam folder to elsewhere
-  imapsieve_mailbox2_name = *
-  imapsieve_mailbox2_from = Junk
-  imapsieve_mailbox2_causes = COPY
-  imapsieve_mailbox2_before = file:/usr/lib/dovecot/antispam/report-ham.sieve
-
 }

--- a/target/dovecot/90-sieve.conf
+++ b/target/dovecot/90-sieve.conf
@@ -31,14 +31,14 @@ plugin {
   # executed. The order of execution within a directory is determined by the
   # file names, using a normal 8bit per-character comparison. Multiple script
   # file or directory paths can be specified by appending an increasing number.
-  sieve_before = /usr/lib/dovecot/sieve-global/before.dovecot.sieve
+  #sieve_before = /usr/lib/dovecot/sieve-global/before.dovecot.sieve
   #sieve_before2 =
   #sieve_before3 = (etc...)
 
   # Identical to sieve_before, only the specified scripts are executed after the
   # user's script (only when keep is still in effect!). Multiple script file or
   # directory paths can be specified by appending an increasing number.
-  sieve_after = /usr/lib/dovecot/sieve-global/after.dovecot.sieve
+  #sieve_after = /usr/lib/dovecot/sieve-global/after.dovecot.sieve
   #sieve_after2 =
   #sieve_after2 = (etc...)
 

--- a/target/dovecot/90-sieve.conf
+++ b/target/dovecot/90-sieve.conf
@@ -31,14 +31,14 @@ plugin {
   # executed. The order of execution within a directory is determined by the
   # file names, using a normal 8bit per-character comparison. Multiple script
   # file or directory paths can be specified by appending an increasing number.
-  #sieve_before =
+  sieve_before = /usr/lib/dovecot/sieve-global/before.dovecot.sieve
   #sieve_before2 =
   #sieve_before3 = (etc...)
 
   # Identical to sieve_before, only the specified scripts are executed after the
   # user's script (only when keep is still in effect!). Multiple script file or
   # directory paths can be specified by appending an increasing number.
-  #sieve_after =
+  sieve_after = /usr/lib/dovecot/sieve-global/after.dovecot.sieve
   #sieve_after2 =
   #sieve_after2 = (etc...)
 
@@ -71,7 +71,7 @@ plugin {
   # (http://pigeonhole.dovecot.org) for available plugins.
   # The sieve_extprograms plugin is included in this release.
   #sieve_plugins =
-  sieve_plugins = sieve_extprograms
+  sieve_plugins = sieve_extprograms sieve_imapsieve
 
   # The separator that is expected between the :user and :detail
   # address parts introduced by the subaddress extension. This may
@@ -108,4 +108,18 @@ plugin {
   # Locations of programs that can be called by the sieve_extprograms plugin
   sieve_pipe_bin_dir = /usr/lib/dovecot/sieve-pipe
   sieve_filter_bin_dir = /usr/lib/dovecot/sieve-filter
+
+  # AntispamWithSieve (Derived from: https://wiki2.dovecot.org/HowTo/AntispamWithSieve)
+
+  # From elsewhere to Spam folder
+  imapsieve_mailbox1_name = Junk
+  imapsieve_mailbox1_causes = COPY
+  imapsieve_mailbox1_before = file:/usr/lib/dovecot/antispam/report-spam.sieve
+
+  # From Spam folder to elsewhere
+  imapsieve_mailbox2_name = *
+  imapsieve_mailbox2_from = Junk
+  imapsieve_mailbox2_causes = COPY
+  imapsieve_mailbox2_before = file:/usr/lib/dovecot/antispam/report-ham.sieve
+
 }

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -481,16 +481,18 @@ function _setup_dovecot() {
 	# Copy pipe and filter programs, if any
 	rm -f /usr/lib/dovecot/sieve-filter/*
 	rm -f /usr/lib/dovecot/sieve-pipe/*
-	if [ -d /tmp/docker-mailserver/sieve-filter ]; then
-		cp /tmp/docker-mailserver/sieve-filter/* /usr/lib/dovecot/sieve-filter/
-		chown docker:docker /usr/lib/dovecot/sieve-filter/*
-		chmod 550 /usr/lib/dovecot/sieve-filter/*
+	[ -d /tmp/docker-mailserver/sieve-filter ] && cp /tmp/docker-mailserver/sieve-filter/* /usr/lib/dovecot/sieve-filter/
+	[ -d /tmp/docker-mailserver/sieve-pipe ] && cp /tmp/docker-mailserver/sieve-pipe/* /usr/lib/dovecot/sieve-pipe/
+	if [ -f /tmp/docker-mailserver/before.dovecot.sieve ]; then
+		cp /tmp/docker-mailserver/before.dovecot.sieve /usr/lib/dovecot/sieve-global/
+		sievec /usr/lib/dovecot/sieve-global/before.dovecot.sieve
 	fi
-	if [ -d /tmp/docker-mailserver/sieve-pipe ]; then
-		cp /tmp/docker-mailserver/sieve-pipe/* /usr/lib/dovecot/sieve-pipe/
-		chown docker:docker /usr/lib/dovecot/sieve-pipe/*
-		chmod 550 /usr/lib/dovecot/sieve-pipe/*
+	if [ -f /tmp/docker-mailserver/after.dovecot.sieve ]; then
+		cp /tmp/docker-mailserver/after.dovecot.sieve /usr/lib/dovecot/sieve-global/
+		sievec /usr/lib/dovecot/sieve-global/after.dovecot.sieve
 	fi
+	chown docker:docker -R /usr/lib/dovecot/sieve*
+	chmod 550 -R /usr/lib/dovecot/sieve*
 }
 
 function _setup_dovecot_local_user() {

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -484,12 +484,19 @@ function _setup_dovecot() {
 	[ -d /tmp/docker-mailserver/sieve-filter ] && cp /tmp/docker-mailserver/sieve-filter/* /usr/lib/dovecot/sieve-filter/
 	[ -d /tmp/docker-mailserver/sieve-pipe ] && cp /tmp/docker-mailserver/sieve-pipe/* /usr/lib/dovecot/sieve-pipe/
 	if [ -f /tmp/docker-mailserver/before.dovecot.sieve ]; then
+		sed -i "s/#sieve_before =/sieve_before =/" /etc/dovecot/conf.d/90-sieve.conf
 		cp /tmp/docker-mailserver/before.dovecot.sieve /usr/lib/dovecot/sieve-global/
 		sievec /usr/lib/dovecot/sieve-global/before.dovecot.sieve
+	else
+		sed -i "s/  sieve_before =/  #sieve_before =/" /etc/dovecot/conf.d/90-sieve.conf
 	fi
+
 	if [ -f /tmp/docker-mailserver/after.dovecot.sieve ]; then
+		sed -i "s/#sieve_after =/sieve_after =/" /etc/dovecot/conf.d/90-sieve.conf
 		cp /tmp/docker-mailserver/after.dovecot.sieve /usr/lib/dovecot/sieve-global/
 		sievec /usr/lib/dovecot/sieve-global/after.dovecot.sieve
+	else 
+		sed -i "s/  sieve_after =/  #sieve_after =/" /etc/dovecot/conf.d/90-sieve.conf	
 	fi
 	chown docker:docker -R /usr/lib/dovecot/sieve*
 	chmod 550 -R /usr/lib/dovecot/sieve*

--- a/test/config/before.dovecot.sieve
+++ b/test/config/before.dovecot.sieve
@@ -1,0 +1,6 @@
+require ["fileinto", "copy"];
+
+if address :contains ["From"] "spam@spam.com" {
+   fileinto :copy "INBOX";
+}
+

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -329,7 +329,7 @@ load 'test_helper/bats-assert/load'
 @test "checking smtp: user1 should have received 6 mails" {
   run docker exec mail /bin/sh -c "ls -A /var/mail/localhost.localdomain/user1/new | wc -l"
   assert_success
-  assert_output 6
+  assert_output 7
 }
 
 @test "checking smtp: rejects mail to unknown user" {
@@ -1047,6 +1047,10 @@ load 'test_helper/bats-assert/load'
   assert_output 1
 }
 
+@test "checking sieve global: user1 should have gotten a copy of his spam mail" {
+  run docker exec mail /bin/sh -c "grep 'Spambot <spam@spam.com>' -R /var/mail/localhost.localdomain/user1/new/"
+  assert_success
+}
 #
 # accounts
 #


### PR DESCRIPTION
On my way to getting spam handling done. This was part of PR #835 but should be handled as a separate PR I think. 
This introduces the optional global sieve files `after.dovecot.sieve`/`before.dovecot.sieve` which apply to **every** incoming email. They are executed before and after any user specific `{user}.dovecot.sieve` filter would be applied.

Wiki entry will follow once accepted.

- added optional after.dovecot.sieve/before.dovecot.sieve files
- added global filter test