### PR TITLE
fix line breaks in postfix-summary mail error case

### DIFF
--- a/target/bin/postfix-summary
+++ b/target/bin/postfix-summary
@@ -11,9 +11,16 @@ errex() {
 test -x /usr/sbin/pflogsumm || errex "Critical: /usr/sbin/pflogsumm not found"
 
 # The case that the mail.log.1 file isn't readable shouldn't actually be possible with logrotate not rotating empty files.. But you never know!
-[ -r "/var/log/mail/mail.log.1" ] \
-  && BODY=$(/usr/sbin/pflogsumm /var/log/mail/mail.log.1 --problems-first) \
-  || BODY="Error: Mail log not readable or not found: /var/log/mail/mail.log.1\n\nIn case of mail inactivity since the last report, this might be considered a nuisance warning.\n\nYours faithfully, The $HOSTNAME Mailserver"
+if [ -r "/var/log/mail/mail.log.1" ]; then
+  BODY=$(/usr/sbin/pflogsumm /var/log/mail/mail.log.1 --problems-first)
+else
+  BODY="Error: Mail log not readable or not found: /var/log/mail/mail.log.1
+
+In case of mail inactivity since the last report, this might be considered a nuisance warning.
+
+Yours faithfully,
+The $HOSTNAME Mailserver"
+fi
 
 sendmail -t <<EOF
 From: mailserver-report@$HOSTNAME


### PR DESCRIPTION
my last PR #919 unfortunately broke the line breaks in the error case of the postfix summary mail (sorry about that), this commit fixes them

(the `echo -e` interpreted the `\n` as a line break before, but the heredoc doesn't)