### PR TITLE
fix SASL domain fixes #892

### DIFF
--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -72,7 +72,7 @@ smtpd_sasl_path = /var/spool/postfix/private/auth
 smtpd_sasl_type = dovecot
 
 smtpd_sasl_security_options = noanonymous
-smtpd_sasl_local_domain = $myhostname
+smtpd_sasl_local_domain = $mydomain
 broken_sasl_auth_clients = yes
 
 # Mail directory


### PR DESCRIPTION
setting value as `$myhostname` will make sasl look for users `user@mail.domain.tld` instead of `user@domain.tld`