### PR TITLE
check-for-updates monitors SSL files

### DIFF
--- a/target/check-for-changes.sh
+++ b/target/check-for-changes.sh
@@ -4,177 +4,201 @@
 log_date=$(date +"%Y-%m-%d %H:%M:%S ")
 # Prevent a start too early
 sleep 5
-echo "${log_date} Start check-for-changes script."
+echo "${log_date} Starting check-for-changes script."
 
 # change directory
 cd /tmp/docker-mailserver
 
 # Check postfix-accounts.cf exist else break
 if [ ! -f postfix-accounts.cf ]; then
-   echo "${log_date} postfix-accounts.cf is missing! This should not run! Exit!"
-   exit
+  echo "${log_date} postfix-accounts.cf is missing! This should not run! Exit!"
+  exit
 fi 
 
+function _update_checksums {
+  echo "${log_date} Making new checksum file"    
+  SSL_FILES=$(cat /etc/dovecot/conf.d/10-ssl.conf /etc/postfix/main.cf \
+                | egrep '^(smtpd_tls|ssl)_(key|cert)' \
+                | sed 's/[^\/]*//' \
+                | sort \
+                | uniq)
+  if [ -f postfix-virtual.cf ]; then
+    sha512sum --tag postfix-accounts.cf postfix-virtual.cf $SSL_FILES > chksum
+    sslstart=2
+  else
+    sha512sum --tag postfix-accounts.cf $SSL_FILES > chksum
+    sslstart=1    
+  fi
+}
+
+function _check_checksums {
+  chksum=($(sha512sum -c --ignore-missing chksum | rev | cut -d' ' -f1 | rev))
+  resu_acc=$chksum
+  if [ -f postfix-virtual.cf ]; then
+    resu_vir=${chksum[1]}
+  else
+    resu_vir="OK"
+  fi
+  resu_ssl="OK"
+  for x in ${chksum[@]:$sslstart}; do
+    if [ "$x" != "OK" ]; then resu_ssl="FAILED"; fi
+  done
+}
+
 # Update / generate after start
-echo "${log_date} Makeing new checksum file."
-if [ -f postfix-virtual.cf ]; then
-	sha512sum --tag postfix-accounts.cf --tag postfix-virtual.cf > chksum
-else
-	sha512sum --tag postfix-accounts.cf > chksum
-fi
+_update_checksums
+
 # Run forever
 while true; do
+  # check files: resu_acc resu_vir and resu_ssl set to OK if no change
+  _check_checksums
 
-# recreate logdate
-log_date=$(date +"%Y-%m-%d %H:%M:%S ")
+  # recreate logdate
+  log_date=$(date +"%Y-%m-%d %H:%M:%S ")
 
-# Get chksum and check it.
-chksum=$(sha512sum -c --ignore-missing chksum)
-resu_acc=${chksum:21:2}
-if [ -f postfix-virtual.cf ]; then
-	resu_vir=${chksum:44:2}
-else
-	resu_vir="OK"
-fi
-
-if ! [ $resu_acc = "OK" ] || ! [ $resu_vir = "OK" ]; then
-   echo "${log_date} Change detected"
+  if ! [ $resu_acc = "OK" ] || ! [ $resu_vir = "OK" ]; then
+    echo "${log_date} Change detected"
     #regen postfix accounts.
-	echo -n > /etc/postfix/vmailbox
-	echo -n > /etc/dovecot/userdb
-	if [ -f /tmp/docker-mailserver/postfix-accounts.cf -a "$ENABLE_LDAP" != 1 ]; then
-		sed -i 's/\r//g' /tmp/docker-mailserver/postfix-accounts.cf
-		echo "# WARNING: this file is auto-generated. Modify config/postfix-accounts.cf to edit user list." > /etc/postfix/vmailbox
-		# Checking that /tmp/docker-mailserver/postfix-accounts.cf ends with a newline
-		sed -i -e '$a\' /tmp/docker-mailserver/postfix-accounts.cf
-		chown dovecot:dovecot /etc/dovecot/userdb
-		chmod 640 /etc/dovecot/userdb
-		sed -i -e '/\!include auth-ldap\.conf\.ext/s/^/#/' /etc/dovecot/conf.d/10-auth.conf
-		sed -i -e '/\!include auth-passwdfile\.inc/s/^#//' /etc/dovecot/conf.d/10-auth.conf
+    echo -n > /etc/postfix/vmailbox
+    echo -n > /etc/dovecot/userdb
+    if [ -f /tmp/docker-mailserver/postfix-accounts.cf -a "$ENABLE_LDAP" != 1 ]; then
+      sed -i 's/\r//g' /tmp/docker-mailserver/postfix-accounts.cf
+      echo "# WARNING: this file is auto-generated. Modify config/postfix-accounts.cf to edit user list." > /etc/postfix/vmailbox
+      # Checking that /tmp/docker-mailserver/postfix-accounts.cf ends with a newline
+      sed -i -e '$a\' /tmp/docker-mailserver/postfix-accounts.cf
+      chown dovecot:dovecot /etc/dovecot/userdb
+      chmod 640 /etc/dovecot/userdb
+      sed -i -e '/\!include auth-ldap\.conf\.ext/s/^/#/' /etc/dovecot/conf.d/10-auth.conf
+      sed -i -e '/\!include auth-passwdfile\.inc/s/^#//' /etc/dovecot/conf.d/10-auth.conf
 
-		# rebuild relay host
-		if [ ! -z "$RELAY_HOST" ]; then
-			# keep old config
-			echo -n > /etc/postfix/sasl_passwd
-			echo -n > /etc/postfix/relayhost_map
-			if [ ! -z "$SASL_PASSWD" ]; then
-				echo "$SASL_PASSWD" >> /etc/postfix/sasl_passwd
-			fi
-			# add domain-specific auth from config file
-			if [ -f /tmp/docker-mailserver/postfix-sasl-password.cf ]; then
-				while read line; do
-					if ! echo "$line" | grep -q -e "\s*#"; then
-						echo "$line" >> /etc/postfix/sasl_passwd
-					fi
-				done < /tmp/docker-mailserver/postfix-sasl-password.cf
-			fi
-			# add default relay
-			if [ ! -z "$RELAY_USER" ] && [ ! -z "$RELAY_PASSWORD" ]; then
-				echo "[$RELAY_HOST]:$RELAY_PORT		$RELAY_USER:$RELAY_PASSWORD" >> /etc/postfix/sasl_passwd
-			fi
-			# add relay maps from file
-			if [ -f /tmp/docker-mailserver/postfix-relaymap.cf ]; then
-				while read line; do
-					if ! echo "$line" | grep -q -e "\s*#"; then
-						echo "$line" >> /etc/postfix/relayhost_map
-					fi
-				done < /tmp/docker-mailserver/postfix-relaymap.cf
-			fi
-		fi
+      # rebuild relay host
+      if [ ! -z "$RELAY_HOST" ]; then
+        # keep old config
+        echo -n > /etc/postfix/sasl_passwd
+        echo -n > /etc/postfix/relayhost_map
+        if [ ! -z "$SASL_PASSWD" ]; then
+          echo "$SASL_PASSWD" >> /etc/postfix/sasl_passwd
+        fi
+        # add domain-specific auth from config file
+        if [ -f /tmp/docker-mailserver/postfix-sasl-password.cf ]; then
+          while read line; do
+            if ! echo "$line" | grep -q -e "\s*#"; then
+              echo "$line" >> /etc/postfix/sasl_passwd
+            fi
+          done < /tmp/docker-mailserver/postfix-sasl-password.cf
+        fi
+        # add default relay
+        if [ ! -z "$RELAY_USER" ] && [ ! -z "$RELAY_PASSWORD" ]; then
+          echo "[$RELAY_HOST]:$RELAY_PORT		$RELAY_USER:$RELAY_PASSWORD" >> /etc/postfix/sasl_passwd
+        fi
+        # add relay maps from file
+        if [ -f /tmp/docker-mailserver/postfix-relaymap.cf ]; then
+          while read line; do
+            if ! echo "$line" | grep -q -e "\s*#"; then
+              echo "$line" >> /etc/postfix/relayhost_map
+            fi
+          done < /tmp/docker-mailserver/postfix-relaymap.cf
+        fi
+      fi
 
-		# Creating users
-		# 'pass' is encrypted
-		# comments and empty lines are ignored
-		grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-accounts.cf | while IFS=$'|' read login pass
-		do
-			# Setting variables for better readability
-			user=$(echo ${login} | cut -d @ -f1)
-			domain=$(echo ${login} | cut -d @ -f2)
-			# Let's go!
-			echo "${login} ${domain}/${user}/" >> /etc/postfix/vmailbox
-			# User database for dovecot has the following format:
-			# user:password:uid:gid:(gecos):home:(shell):extra_fields
-			# Example :
-			# ${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::userdb_mail=maildir:/var/mail/${domain}/${user}
-			echo "${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::" >> /etc/dovecot/userdb
-			mkdir -p /var/mail/${domain}
-			if [ ! -d "/var/mail/${domain}/${user}" ]; then
-				maildirmake.dovecot "/var/mail/${domain}/${user}"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Sent"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Trash"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Drafts"
-				echo -e "INBOX\nSent\nTrash\nDrafts" >> "/var/mail/${domain}/${user}/subscriptions"
-				touch "/var/mail/${domain}/${user}/.Sent/maildirfolder"
-			fi
-			# Copy user provided sieve file, if present
-			test -e /tmp/docker-mailserver/${login}.dovecot.sieve && cp /tmp/docker-mailserver/${login}.dovecot.sieve /var/mail/${domain}/${user}/.dovecot.sieve
-			echo ${domain} >> /tmp/vhost.tmp
-			# add domains to relayhost_map
-			if [ ! -z "$RELAY_HOST" ]; then
-				if ! grep -q -e "^@${domain}\s" /etc/postfix/relayhost_map; then
-					echo "@${domain}		[$RELAY_HOST]:$RELAY_PORT" >> /etc/postfix/relayhost_map
-				fi
-			fi
-		done
-	fi
-	if [ -f /etc/postfix/sasl_passwd ]; then
-		chown root:root /etc/postfix/sasl_passwd
-		chmod 0600 /etc/postfix/sasl_passwd
-	fi
-	if [ -f /etc/postfix/relayhost_map ]; then
-		chown root:root /etc/postfix/relayhost_map
-		chmod 0600 /etc/postfix/relayhost_map
-	fi
-	if [ -f postfix-virtual.cf ]; then
-    # regen postfix aliases
-    echo -n > /etc/postfix/virtual
-	echo -n > /etc/postfix/regexp
-	if [ -f /tmp/docker-mailserver/postfix-virtual.cf ]; then
-		# Copying virtual file
-		cp -f /tmp/docker-mailserver/postfix-virtual.cf /etc/postfix/virtual
-		while read from to
-		do
-			# Setting variables for better readability
-			uname=$(echo ${from} | cut -d @ -f1)
-			domain=$(echo ${from} | cut -d @ -f2)
-			# if they are equal it means the line looks like: "user1     other@domain.tld"
-			test "$uname" != "$domain" && echo ${domain} >> /tmp/vhost.tmp
-		done < /tmp/docker-mailserver/postfix-virtual.cf
-	fi
-	if [ -f /tmp/docker-mailserver/postfix-regexp.cf ]; then
-		# Copying regexp alias file
-		cp -f /tmp/docker-mailserver/postfix-regexp.cf /etc/postfix/regexp
-		sed -i -e '/^virtual_alias_maps/{
-		s/ regexp:.*//
-		s/$/ regexp:\/etc\/postfix\/regexp/
-		}' /etc/postfix/main.cf
-	fi
-	fi
+      # Creating users
+      # 'pass' is encrypted
+      # comments and empty lines are ignored
+      grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-accounts.cf | while IFS=$'|' read login pass
+      do
+        # Setting variables for better readability
+        user=$(echo ${login} | cut -d @ -f1)
+        domain=$(echo ${login} | cut -d @ -f2)
+        # Let's go!
+        echo "${login} ${domain}/${user}/" >> /etc/postfix/vmailbox
+        # User database for dovecot has the following format:
+        # user:password:uid:gid:(gecos):home:(shell):extra_fields
+        # Example :
+        # ${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::userdb_mail=maildir:/var/mail/${domain}/${user}
+        echo "${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::" >> /etc/dovecot/userdb
+        mkdir -p /var/mail/${domain}
+        if [ ! -d "/var/mail/${domain}/${user}" ]; then
+          maildirmake.dovecot "/var/mail/${domain}/${user}"
+          maildirmake.dovecot "/var/mail/${domain}/${user}/.Sent"
+          maildirmake.dovecot "/var/mail/${domain}/${user}/.Trash"
+          maildirmake.dovecot "/var/mail/${domain}/${user}/.Drafts"
+          echo -e "INBOX\nSent\nTrash\nDrafts" >> "/var/mail/${domain}/${user}/subscriptions"
+          touch "/var/mail/${domain}/${user}/.Sent/maildirfolder"
+        fi
+        # Copy user provided sieve file, if present
+        test -e /tmp/docker-mailserver/${login}.dovecot.sieve && cp /tmp/docker-mailserver/${login}.dovecot.sieve /var/mail/${domain}/${user}/.dovecot.sieve
+        echo ${domain} >> /tmp/vhost.tmp
+        # add domains to relayhost_map
+        if [ ! -z "$RELAY_HOST" ]; then
+          if ! grep -q -e "^@${domain}\s" /etc/postfix/relayhost_map; then
+            echo "@${domain}		[$RELAY_HOST]:$RELAY_PORT" >> /etc/postfix/relayhost_map
+          fi
+        fi
+      done
+    fi
+    if [ -f /etc/postfix/sasl_passwd ]; then
+      chown root:root /etc/postfix/sasl_passwd
+      chmod 0600 /etc/postfix/sasl_passwd
+    fi
+    if [ -f /etc/postfix/relayhost_map ]; then
+      chown root:root /etc/postfix/relayhost_map
+      chmod 0600 /etc/postfix/relayhost_map
+    fi
+    if [ -f postfix-virtual.cf ]; then
+      # regen postfix aliases
+      echo -n > /etc/postfix/virtual
+      echo -n > /etc/postfix/regexp
+      if [ -f /tmp/docker-mailserver/postfix-virtual.cf ]; then
+        # Copying virtual file
+        cp -f /tmp/docker-mailserver/postfix-virtual.cf /etc/postfix/virtual
+        while read from to
+        do
+          # Setting variables for better readability
+          uname=$(echo ${from} | cut -d @ -f1)
+          domain=$(echo ${from} | cut -d @ -f2)
+          # if they are equal it means the line looks like: "user1     other@domain.tld"
+          test "$uname" != "$domain" && echo ${domain} >> /tmp/vhost.tmp
+        done < /tmp/docker-mailserver/postfix-virtual.cf
+      fi
+      if [ -f /tmp/docker-mailserver/postfix-regexp.cf ]; then
+        # Copying regexp alias file
+        cp -f /tmp/docker-mailserver/postfix-regexp.cf /etc/postfix/regexp
+        sed -i -e '/^virtual_alias_maps/{
+            s/ regexp:.*//
+            s/$/ regexp:\/etc\/postfix\/regexp/
+          }' /etc/postfix/main.cf
+      fi
+    fi
     # Set vhost 
-	if [ -f /tmp/vhost.tmp ]; then
-		cat /tmp/vhost.tmp | sort | uniq > /etc/postfix/vhost && rm /tmp/vhost.tmp
-	fi
-    
+    if [ -f /tmp/vhost.tmp ]; then
+      cat /tmp/vhost.tmp | sort | uniq > /etc/postfix/vhost && rm /tmp/vhost.tmp
+    fi
+
     # Set right new if needed
-	if [ `find /var/mail -maxdepth 3 -a \( \! -user 5000 -o \! -group 5000 \) | grep -c .` != 0 ]; then
-		chown -R 5000:5000 /var/mail
-	fi
-    
+    if [ `find /var/mail -maxdepth 3 -a \( \! -user 5000 -o \! -group 5000 \) | grep -c .` != 0 ]; then
+      chown -R 5000:5000 /var/mail
+    fi
+
     # Restart of the postfix
     supervisorctl restart postfix
-    
+
     # Prevent restart of dovecot when smtp_only=1
     if [ ! $SMTP_ONLY = 1 ]; then
-        supervisorctl restart dovecot
+      supervisorctl restart dovecot
     fi 
 
     echo "${log_date} Update checksum"
-	if [ -f postfix-virtual.cf ]; then
-    sha512sum --tag postfix-accounts.cf --tag postfix-virtual.cf > chksum
-	else
-	sha512sum --tag postfix-accounts.cf > chksum
-	fi
-fi
+    _update_checksums        
+  fi
 
-sleep 1
+  if [ $resu_ssl != "OK" ]; then
+    echo "${log_date} SSL certificates changed"
+    supervisorctl restart postfix
+    supervisorctl restart dovecot
+    _update_checksums
+    echo "${log_date} Update checksum"
+  fi
+
+  sleep 1
 done
+


### PR DESCRIPTION
These changes to check-for-updates allow for the monitoring of the SSL certificates. The names of these files are extracted from the configuration files. If the SSL files change, both postfix and dovecot are restarted.

The generation and checking of checksums has been moved to two functions. Also, the check function creates an array with the results from the sha512 check (last word of each line) rather than indexing the result string with character offsets. This seems more portable and robust to me.
 