### PR TITLE
DOMAINNAME can fail to be set in postsrsd-wrapper.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,29 @@ run:
 		-v "`pwd`/test":/tmp/docker-mailserver-test \
 		-e PERMIT_DOCKER=network \
 		-e DMS_DEBUG=0 \
+		-e ENABLE_SRS=1 \
 		-e OVERRIDE_HOSTNAME=mail.my-domain.com \
+		-h unknown.domain.tld \
+		-t $(NAME)
+	sleep 15
+	docker run -d --name mail_domainname \
+		-v "`pwd`/test/config":/tmp/docker-mailserver \
+		-v "`pwd`/test":/tmp/docker-mailserver-test \
+		-e PERMIT_DOCKER=network \
+		-e DMS_DEBUG=0 \
+		-e ENABLE_SRS=1 \
+		-e DOMAINNAME=my-domain.com \
+		-h unknown.domain.tld \
+		-t $(NAME)
+	sleep 15
+	docker run -d --name mail_srs_domainname \
+		-v "`pwd`/test/config":/tmp/docker-mailserver \
+		-v "`pwd`/test":/tmp/docker-mailserver-test \
+		-e PERMIT_DOCKER=network \
+		-e DMS_DEBUG=0 \
+		-e ENABLE_SRS=1 \
+		-e SRS_DOMAINNAME=srs.my-domain.com \
+		-e DOMAINNAME=my-domain.com \
 		-h unknown.domain.tld \
 		-t $(NAME)
 	sleep 15
@@ -284,6 +306,8 @@ clean:
 		mail_undef_spam_subject \
 		mail_postscreen \
 		mail_override_hostname \
+		mail_domainname \
+		mail_srs_domainname \
 		mail_with_relays
 
 	@if [ -d config.bak ]; then\

--- a/README.md
+++ b/README.md
@@ -548,6 +548,11 @@ Note: This postgrey setting needs `ENABLE_POSTGREY=1`
   - if you have a cluster/swarm make sure the same keys are on all nodes
   - example command to generate a key: `dd if=/dev/urandom bs=24 count=1 2>/dev/null | base64`
 
+##### SRS_DOMAINNAME
+
+  - **empty** => Derived from OVERRIDE_HOSTNAME, DOMAINNAME, or the container's hostname
+  - Set this if auto-detection fails, isn't what you want, or you wish to have a separate container handle DSNs
+
 ## Multi-domain Relay Hosts
 
 #### RELAY_HOST

--- a/target/postsrsd-wrapper.sh
+++ b/target/postsrsd-wrapper.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
-# postsrsd-wrapper.sh, version 0.2.1
+# postsrsd-wrapper.sh, version 0.2.2
 
-DOMAINNAME="$(hostname -d)"
-sed -i -e "s/localdomain/$DOMAINNAME/g" /etc/default/postsrsd
+if [ -n "$SRS_DOMAINNAME" ]; then
+  domain_name="$SRS_DOMAINNAME"
+elif [ -n "$OVERRIDE_HOSTNAME" ]; then
+  domain_name="${OVERRIDE_HOSTNAME#*.}"
+elif [ -n "$DOMAINNAME" ]; then
+  domain_name="$DOMAINNAME"
+else
+  domain_name=$(hostname -d)
+fi
+
+sed -i -e "s/localdomain/${domain_name}/g" /etc/default/postsrsd
 
 postsrsd_secret_file='/etc/postsrsd.secret'
 postsrsd_state_dir='/var/mail-state/etc-postsrsd'

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -810,6 +810,25 @@ load 'test_helper/bats-assert/load'
   assert_success
 }
 
+@test "checking SRS: SRS_DOMAINNAME is used correctly" {
+  run docker exec mail_srs_domainname grep "SRS_DOMAIN=srs.my-domain.com" /etc/default/postsrsd
+  assert_success
+}
+
+@test "checking SRS: OVERRIDE_HOSTNAME is handled correctly" {
+  run docker exec mail_override_hostname grep "SRS_DOMAIN=my-domain.com" /etc/default/postsrsd
+  assert_success
+}
+
+@test "checking SRS: DOMAINNAME is handled correctly" {
+  run docker exec mail_domainname grep "SRS_DOMAIN=my-domain.com" /etc/default/postsrsd
+  assert_success
+}
+@test "checking SRS: fallback to hostname is handled correctly" {
+  run docker exec mail grep "SRS_DOMAIN=my-domain.com" /etc/default/postsrsd
+  assert_success
+}
+
 #
 # fail2ban
 #


### PR DESCRIPTION
if the container doesn’t have a proper hostname, postsrsd will fail to start
because SRS_DOMAIN is empty. Make a best effort to figure out the domain name
and provide a way to set one if needed.