### PR TITLE
Fix freshclam cron name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ RUN apt-get update -q --fix-missing && \
   rm -f /etc/cron.weekly/fstrim && \
   rm -f /etc/postsrsd.secret
 
-RUN echo "0 0,6,12,18 * * * /usr/bin/freshclam --quiet" > /etc/cron.d/freshclam && \
+RUN echo "0 0,6,12,18 * * * /usr/bin/freshclam --quiet" > /etc/cron.d/clamav-freshclam && \
   chmod 644 /etc/clamav/freshclam.conf && \
   freshclam && \
   sed -i 's/Foreground false/Foreground true/g' /etc/clamav/clamd.conf && \


### PR DESCRIPTION
This fixes the daily mail error when logrotate tries to restart a non existing freshclam daemon because cron name doesn't fit freshclam init script invoked by logrotate
Fix second part of #792 