### PR TITLE
Restart Postfix and Dovecot when SSL files change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -209,7 +209,7 @@ RUN curl -s https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > /et
 
 COPY ./target/bin /usr/local/bin
 # Start-mailserver script
-COPY ./target/check-for-changes.sh ./target/start-mailserver.sh ./target/fail2ban-wrapper.sh ./target/postfix-wrapper.sh ./target/postsrsd-wrapper.sh ./target/docker-configomat/configomat.sh /usr/local/bin/
+COPY ./target/watch-ssl-files.sh ./target/check-for-changes.sh ./target/start-mailserver.sh ./target/fail2ban-wrapper.sh ./target/postfix-wrapper.sh ./target/postsrsd-wrapper.sh ./target/docker-configomat/configomat.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/*
 
 # Configure supervisor

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -212,10 +212,16 @@ function register_functions() {
 	if [ "$ENABLE_CLAMAV" = 1 ]; then
 		_register_start_daemon "_start_daemons_clamav"
 	fi
-    # Change detector
-    if [ "$ENABLE_LDAP" = 0 ]; then
-	    _register_start_daemon "_start_changedetector"
-    fi
+
+  # Change detector
+  if [ "$ENABLE_LDAP" = 0 ]; then
+    _register_start_daemon "_start_changedetector"
+  fi
+
+	# Watch SSL files -- but only if SSL is enabled!
+	if [ ! -z "$SSL_TYPE" ]; then
+    _register_start_daemon "_start_watchsslfiles"
+  fi
 
 	_register_start_daemon "_start_daemons_amavis"
 	################### << daemon funcs
@@ -501,8 +507,8 @@ function _setup_dovecot() {
 		sed -i "s/#sieve_after =/sieve_after =/" /etc/dovecot/conf.d/90-sieve.conf
 		cp /tmp/docker-mailserver/after.dovecot.sieve /usr/lib/dovecot/sieve-global/
 		sievec /usr/lib/dovecot/sieve-global/after.dovecot.sieve
-	else 
-		sed -i "s/  sieve_after =/  #sieve_after =/" /etc/dovecot/conf.d/90-sieve.conf	
+	else
+		sed -i "s/  sieve_after =/  #sieve_after =/" /etc/dovecot/conf.d/90-sieve.conf
 	fi
 	chown docker:docker -R /usr/lib/dovecot/sieve*
 	chmod 550 -R /usr/lib/dovecot/sieve*
@@ -1495,6 +1501,10 @@ function _start_changedetector() {
     supervisorctl start changedetector
 }
 
+function _start_watchsslfiles() {
+	notify 'task' 'Starting watchsslfiles' 'n'
+		supervisorctl start watchsslfiles
+}
 
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # !  CARE --> DON'T CHANGE, unless you exactly know what you are doing

--- a/target/supervisor/conf.d/supervisor-app.conf
+++ b/target/supervisor/conf.d/supervisor-app.conf
@@ -129,3 +129,11 @@ autorestart=unexpected
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 command=/usr/local/bin/postsrsd-wrapper.sh
+
+[program:watchsslfiles]
+startsecs=0
+autostart=false
+autorestart=true
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+command=/usr/local/bin/watch-ssl-files.sh

--- a/target/watch-ssl-files.sh
+++ b/target/watch-ssl-files.sh
@@ -17,7 +17,7 @@ function gensum {
       sslmap[${var}]=$(sha512sum ${var})
     else
       log No such file at ${var}!
-      exit
+      exit -1
     fi
   done
 }
@@ -25,24 +25,89 @@ function gensum {
 # testsum checks each file for changes.
 # If a file is not found, the script exits with a log message.
 # The return value of the function is equal to the number of changed files.
-# NB: the array is not updated!
+# NB: the array is updated!
 function testsum {
   changed=0
   for var in "${!sslmap[@]}"; do
     if [ -f ${var} ]; then
-      if [ "$(sha512sum ${var})" != "${sslmap[${var}]}" ]; then
+      newsum=$(sha512sum ${var})
+      if [ "$newsum" != "${sslmap[${var}]}" ]; then
         # log File changed: ${var}
         changed=$((changed+1))
+        sslmap[${var}]=$newsum
       fi
     else
       log No such file at ${var}!
-      exit
+      exit -1
     fi
   done
   return ${changed}
 }
 
+# This function tests gensum and testsum.
+function test_script {
+  failed=""
+  passed=""
+
+  # 1. No test file, so gensum should exit.
+  rm -f testme
+  (gensum testme >/dev/null && failed+=" 1") || passed+=" 1"
+
+  # Create test file.
+  ls > testme
+  gensum testme
+
+  # 2. Unchanged file, testsum should return 0.
+  testsum
+  testsumresult=$?
+  if [ $testsumresult -ne 0 ]; then
+    failed+=" 2"
+  else
+    passed+=" 2"
+  fi
+
+  # Change file.
+  ls >> testme
+
+  # 3. Changed file should not return 0.
+  testsum
+  testsumresult=$?
+  if [ $testsumresult -eq 0 ]; then
+    failed+=" 3"
+  else
+    passed+=" 3"
+  fi
+
+  # 4. Array should have been updated in previous run, so should return 0.
+  testsum
+  testsumresult=$?
+  if [ $testsumresult -ne 0 ]; then
+    failed+=" 4"
+  else
+    passed+=" 4"
+  fi
+
+  # Remove test file.
+  rm testme
+
+  # 5. No file found should exit.
+  (testsum >/dev/null && failed+=" 5") || passed+=" 5"
+
+  # All tests must pass!
+  if [[ "$failed" = "" && "$passed" = " 1 2 3 4 5" ]]; then
+    exit 0
+  else
+    echo "Tests passed: $passed, failed: $failed"
+    exit 1
+  fi
+}
+
 # ---
+
+# Test by passing "test" as first argument.
+if [[ ! -z "$1" && "$1" = "test" ]]; then
+  test_script
+fi
 
 # Populate array with SSL files.
 gensum ${SSL_CERT_PATH} ${SSL_KEY_PATH}

--- a/target/watch-ssl-files.sh
+++ b/target/watch-ssl-files.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+function log {
+  echo "[$(date --rfc-3339=seconds)] $*"
+}
+
+# sslmap is an associative array.
+# Keys are filenames, values are checksums.
+declare -A sslmap
+
+# gensum takes a list of filenames as arguments.
+# The function populates the associative array with checksums.
+# If any file is not found, the script exits with a log message.
+function gensum {
+  for var in "$@"; do
+    if [ -f ${var} ]; then
+      sslmap[${var}]=$(sha512sum ${var})
+    else
+      log No such file at ${var}!
+      exit
+    fi
+  done
+}
+
+# testsum checks each file for changes.
+# If a file is not found, the script exits with a log message.
+# The return value of the function is equal to the number of changed files.
+# NB: the array is not updated!
+function testsum {
+  changed=0
+  for var in "${!sslmap[@]}"; do
+    if [ -f ${var} ]; then
+      if [ "$(sha512sum ${var})" != "${sslmap[${var}]}" ]; then
+        # log File changed: ${var}
+        changed=$((changed+1))
+      fi
+    else
+      log No such file at ${var}!
+      exit
+    fi
+  done
+  return ${changed}
+}
+
+# ---
+
+# Populate array with SSL files.
+gensum ${SSL_CERT_PATH} ${SSL_KEY_PATH}
+
+# Run forever.
+while true; do
+
+  # Test files for changes.
+  testsum
+  testsumresult=$?
+  if [ $testsumresult -ne 0 ]; then
+    log SSL files changed, restarting Postfix and Dovecot
+    supervisorctl restart postfix
+    supervisorctl restart dovecot
+  fi
+
+  # Try again soon!
+  sleep 1
+done

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -790,6 +790,11 @@ load 'test_helper/bats-assert/load'
   assert_success
 }
 
+@test "checking ssl: watch-ssl-files.sh test" {
+  run docker exec mail_manual_ssl /bin/sh -c "/usr/local/bin/watch-ssl-files.sh test"
+  assert_success
+}
+
 #
 # postsrsd
 #
@@ -1621,7 +1626,7 @@ load 'test_helper/bats-assert/load'
   # check sender is not the default one.
   run docker exec mail grep "From: mailserver-report@mail.my-domain.com" /var/mail/localhost.localdomain/user1/new/ -R
   assert_failure
-  
+
   # checking default sender is correctly set when env variable not defined
   run docker exec mail_with_ldap grep "mailserver-report@mail.my-domain.com" /etc/logrotate.d/maillog
   assert_success


### PR DESCRIPTION
This is a slightly different approach to the problem for which #976 is intended to solve.

The major differences:
* A new script `target/watch-ssl-files.sh` was created to handle the situation, instead of extending `target/check-for-updates.sh`.
* Tests for the script's functions are included in the script, and are called by a test in the `test./tests.bats` file.

The primary benefit of a second script is that `target/check-for-updates.sh` currently runs when LDAP is not in use, so LDAP users who use SSL cannot take advantage of functionality added to this script.  The largest risk of a second script is "battling restarts", where one script restarts Postfix while another is attempting to do the same.

The tests are for the script's functions -- to generate a set of checksums for files and test those files for changes -- and not on the script's actual behavior (to restart the services when those files change), for simplicity's sake.  

If desired, I am 100% willing to merge the new script into the existing script.  It will require some general cleanup of the original script, but the end result would be a single task -- with tests -- checking on whether certain files have changed and taking the appropriate action.  Just ask, and I'll take care of it!

There are some additional inadvertent changes in this pull request as a result of Atom's efforts to remove trailing white space and white space from blank lines.  As this brings the code further into compliance with the style guide in the documentation, I decided to leave them in.  I can revert those changes if desired.