### PR TITLE
fix: /var/mail permissions are hardcoded to 5000 #964

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1284,10 +1284,11 @@ function fix() {
 function _fix_var_mail_permissions() {
 	notify 'task' 'Checking /var/mail permissions'
 
+	MAIL_UID=`id -u mail`
 	# Fix permissions, but skip this if 3 levels deep the user id is already set
-	if [ `find /var/mail -maxdepth 3 -a \( \! -user 5000 -o \! -group 5000 \) | grep -c .` != 0 ]; then
+	if [ `find /var/mail -maxdepth 3 -a \( \! -user $MAIL_UID -o \! -group $MAIL_UID \) | grep -c .` != 0 ]; then
 		notify 'inf' "Fixing /var/mail permissions"
-		chown -R 5000:5000 /var/mail
+		chown -R $MAIL_UID:$MAIL_UID /var/mail
 	else
 		notify 'inf' "Permissions in /var/mail look OK"
 		return 0


### PR DESCRIPTION
On April 29th I've issued [a bug](https://github.com/tomav/docker-mailserver/issues/964) with file permissions in `/var/mail`, but no one paid attention to this. That's why I've created this PR. 