### PR TITLE
Configuration support for /etc/aliases, see issue #988

### DIFF
--- a/target/check-for-changes.sh
+++ b/target/check-for-changes.sh
@@ -35,16 +35,16 @@ log_date=$(date +"%Y-%m-%d %H:%M:%S ")
 chksum=$(sha512sum -c --ignore-missing chksum)
 
 if [[ $chksum == *"FAIL"* ]]; then
-    echo "${log_date} Change detected"
+	echo "${log_date} Change detected"
 
-    #regen postix aliases.
+	#regen postix aliases.
 	echo "root: ${POSTMASTER_ADDRESS}" > /etc/aliases
 	if [ -f /tmp/docker-mailserver/postfix-aliases.cf ]; then
-        cat /tmp/docker-mailserver/postfix-aliases.cf>>/etc/aliases
-    fi
+		cat /tmp/docker-mailserver/postfix-aliases.cf>>/etc/aliases
+	fi
 	postalias /etc/aliases
 
-    #regen postfix accounts.
+	#regen postfix accounts.
 	echo -n > /etc/postfix/vmailbox
 	echo -n > /etc/dovecot/userdb
 	if [ -f /tmp/docker-mailserver/postfix-accounts.cf -a "$ENABLE_LDAP" != 1 ]; then
@@ -131,8 +131,8 @@ if [[ $chksum == *"FAIL"* ]]; then
 		chmod 0600 /etc/postfix/relayhost_map
 	fi
 	if [ -f postfix-virtual.cf ]; then
-    # regen postfix aliases
-    echo -n > /etc/postfix/virtual
+	# regen postfix aliases
+	echo -n > /etc/postfix/virtual
 	echo -n > /etc/postfix/regexp
 	if [ -f /tmp/docker-mailserver/postfix-virtual.cf ]; then
 		# Copying virtual file
@@ -142,7 +142,7 @@ if [[ $chksum == *"FAIL"* ]]; then
 			# Setting variables for better readability
 			uname=$(echo ${from} | cut -d @ -f1)
 			domain=$(echo ${from} | cut -d @ -f2)
-			# if they are equal it means the line looks like: "user1     other@domain.tld"
+			# if they are equal it means the line looks like: "user1	 other@domain.tld"
 			test "$uname" != "$domain" && echo ${domain} >> /tmp/vhost.tmp
 		done < /tmp/docker-mailserver/postfix-virtual.cf
 	fi
@@ -155,26 +155,26 @@ if [[ $chksum == *"FAIL"* ]]; then
 		}' /etc/postfix/main.cf
 	fi
 	fi
-    # Set vhost 
+	# Set vhost 
 	if [ -f /tmp/vhost.tmp ]; then
 		cat /tmp/vhost.tmp | sort | uniq > /etc/postfix/vhost && rm /tmp/vhost.tmp
 	fi
-    
-    # Set right new if needed
+	
+	# Set right new if needed
 	if [ `find /var/mail -maxdepth 3 -a \( \! -user 5000 -o \! -group 5000 \) | grep -c .` != 0 ]; then
 		chown -R 5000:5000 /var/mail
 	fi
-    
-    # Restart of the postfix
-    supervisorctl restart postfix
-    
-    # Prevent restart of dovecot when smtp_only=1
-    if [ ! $SMTP_ONLY = 1 ]; then
-        supervisorctl restart dovecot
-    fi 
+	
+	# Restart of the postfix
+	supervisorctl restart postfix
+	
+	# Prevent restart of dovecot when smtp_only=1
+	if [ ! $SMTP_ONLY = 1 ]; then
+		supervisorctl restart dovecot
+	fi 
 
-    echo "${log_date} Update checksum"
-    sha512sum ${cf_files[@]/#/--tag } > chksum
+	echo "${log_date} Update checksum"
+	sha512sum ${cf_files[@]/#/--tag } > chksum
 fi
 
 sleep 1

--- a/target/check-for-changes.sh
+++ b/target/check-for-changes.sh
@@ -37,6 +37,7 @@ else
 	resu_vir="OK"
 fi
 
+
 if ! [ $resu_acc = "OK" ] || ! [ $resu_vir = "OK" ]; then
    echo "${log_date} Change detected"
     #regen postfix accounts.

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -747,7 +747,7 @@ function _setup_postfix_aliases() {
 	echo -n > /etc/postfix/virtual
 	echo -n > /etc/postfix/regexp
 	if [ -f /tmp/docker-mailserver/postfix-virtual.cf ]; then
-    # fixing old virtual user file
+	# fixing old virtual user file
 	  [[ $(grep ",$" /tmp/docker-mailserver/postfix-virtual.cf) ]] && sed -i -e "s/, /,/g" -e "s/,$//g" /tmp/docker-mailserver/postfix-virtual.cf
 		# Copying virtual file
 		cp -f /tmp/docker-mailserver/postfix-virtual.cf /etc/postfix/virtual
@@ -775,11 +775,11 @@ function _setup_postfix_aliases() {
 	notify 'inf' "Configuring root alias"
 	echo "root: ${POSTMASTER_ADDRESS}" > /etc/aliases
 	if [ -f /tmp/docker-mailserver/postfix-aliases.cf ]; then
-        cat /tmp/docker-mailserver/postfix-aliases.cf>>/etc/aliases
-    else
+		cat /tmp/docker-mailserver/postfix-aliases.cf>>/etc/aliases
+	else
 		notify 'inf' "'config/postfix-aliases.cf' is not provided and will be auto created."
-        echo -n >/tmp/docker-mailserver/postfix-aliases.cf
-    fi
+		echo -n >/tmp/docker-mailserver/postfix-aliases.cf
+	fi
 	postalias /etc/aliases
 }
 
@@ -807,8 +807,8 @@ function _setup_dkim() {
 	else
 		notify 'warn' "No DKIM key provided. Check the documentation to find how to get your keys."
 
-                local _f_keytable="/etc/opendkim/KeyTable"
-                [ ! -f "$_f_keytable" ] && touch "$_f_keytable"
+		local _f_keytable="/etc/opendkim/KeyTable"
+		[ ! -f "$_f_keytable" ] && touch "$_f_keytable"
 	fi
 }
 

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -774,6 +774,12 @@ function _setup_postfix_aliases() {
 
 	notify 'inf' "Configuring root alias"
 	echo "root: ${POSTMASTER_ADDRESS}" > /etc/aliases
+	if [ -f /tmp/docker-mailserver/postfix-aliases.cf ]; then
+        cat /tmp/docker-mailserver/postfix-aliases.cf>>/etc/aliases
+    else
+		notify 'inf' "'config/postfix-aliases.cf' is not provided and will be auto created."
+        echo -n >/tmp/docker-mailserver/postfix-aliases.cf
+    fi
 	postalias /etc/aliases
 }
 


### PR DESCRIPTION
This is work in progress (sorry perhaps I should create this when done, still learning a bit here)
[x] add postfix-aliases.cf to ./config (/tmp/docker-mailserver)
[x] in check-for-changes.sh monitor postfix-aliases.cf in and apply changes to /etc/aliases
[x] in start-mailserver.sh apply postfix-aliases.cf to /etc/aliases
This solution addresses issue #988 .