### PR TITLE
Allow regex aliases

### DIFF
--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -79,7 +79,7 @@ broken_sasl_auth_clients = yes
 virtual_transport = lmtp:unix:/var/run/dovecot/lmtp
 virtual_mailbox_domains = /etc/postfix/vhost
 virtual_mailbox_maps = texthash:/etc/postfix/vmailbox
-virtual_alias_maps = regexp:/etc/postfix/virtual_alias
+virtual_alias_maps = texthash:/etc/postfix/virtual, regexp:/etc/postfix/virtual_regex
 
 # Additional option for filtering
 content_filter = smtp-amavis:[127.0.0.1]:10024

--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -79,7 +79,7 @@ broken_sasl_auth_clients = yes
 virtual_transport = lmtp:unix:/var/run/dovecot/lmtp
 virtual_mailbox_domains = /etc/postfix/vhost
 virtual_mailbox_maps = texthash:/etc/postfix/vmailbox
-virtual_alias_maps = texthash:/etc/postfix/virtual
+virtual_alias_maps = regexp:/etc/postfix/virtual_alias
 
 # Additional option for filtering
 content_filter = smtp-amavis:[127.0.0.1]:10024


### PR DESCRIPTION
Since it like to use a unique email address for each service I use and I've got tiered on creating a new account each time I thought it would be a good idea to support regex aliases via postfix.