### PR TITLE
Calling supervisord directly instead of via shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -219,6 +219,6 @@ COPY target/supervisor/conf.d/* /etc/supervisor/conf.d/
 
 EXPOSE 25 587 143 465 993 110 995 4190
 
-CMD supervisord -c /etc/supervisor/supervisord.conf
+CMD ["supervisord", "-c", "/etc/supervisor/supervisord.conf"]
 
 ADD target/filebeat.yml.tmpl /etc/filebeat/filebeat.yml.tmpl

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,7 @@
 INFO=$(docker ps \
   --no-trunc \
   --format="{{.Image}}\t{{.Names}}\t{{.Command}}" | \
-  grep "/bin/sh -c 'supervisord -c /etc/supervisor/supervisord.conf'")
+  grep "supervisord -c /etc/supervisor/supervisord.conf")
 
 IMAGE_NAME=$(echo $INFO | awk '{print $1}')
 CONTAINER_NAME=$(echo $INFO | awk '{print $2}')

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -387,7 +387,7 @@ function _check_hostname() {
 
 	if ( ! echo $HOSTNAME | grep -E '^(\S+[.]\S+)$' > /dev/null ); then
 		notify 'err' "Setting hostname/domainname is required"
-		kill -6 `cat /var/run/supervisord.pid` && return 1
+		kill `cat /var/run/supervisord.pid` && return 1
 	else
 		notify 'inf' "Domain has been set to $DOMAINNAME"
 		notify 'inf' "Hostname has been set to $HOSTNAME"

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -6,7 +6,7 @@ load 'test_helper/bats-assert/load'
 
 @test "checking configuration: hostname/domainname" {
   run docker run `docker inspect --format '{{ .Config.Image }}' mail`
-  assert_failure
+  assert_success
 }
 
 @test "checking configuration: hostname/domainname override" {
@@ -1783,5 +1783,14 @@ load 'test_helper/bats-assert/load'
 
 @test "checking that mail for root was delivered" {
   run docker exec mail grep "Subject: Root Test Message" /var/mail/localhost.localdomain/user1/new/ -R
+  assert_success
+}
+
+#
+# clean exit
+#
+
+@test "checking that the container stops cleanly" {
+  run docker stop -t 60 mail
   assert_success
 }


### PR DESCRIPTION
This fixes #1047 by calling supervisor directly. The container won't fail now anymore, because there is no way to tell supervisor to exit with an error, so I had to change the test that expects the container to fail.

I recommend increasing the stopping time, though. Since the container can take longer than 10 seconds to stop gracefully. This can be done using "stop_grace_period" in docker-compose.yml or "--stop-timeout" using "docker run" (also docker stop -t)
