### PR TITLE
Clear up env format and hostname value

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Download the docker-compose.yml, the .env and the setup.sh files:
 #### Create a docker-compose environment
 
 - Edit the `.env` to your liking. Adapt this file with your FQDN.
+  - This file supports only simple `VAR=VAL` lines (see [Documentation](https://docs.docker.com/compose/env-file/)).
+  - Don't quote your values.
+  - Variable substitution is *not* supported (e.g. `OVERRIDE_HOSTNAME=$HOSTNAME.$DOMAINNAME`).
 - Install [docker-compose](https://docs.docker.com/compose/) in the version `1.6` or higher.
 
 #### Start Container

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -387,12 +387,13 @@ function _check_hostname() {
 		export DOMAINNAME=$(echo $HOSTNAME | sed s/[^.]*.//)
 	fi
 
+	notify 'inf' "Domain has been set to $DOMAINNAME"
+	notify 'inf' "Hostname has been set to $HOSTNAME"
+
 	if ( ! echo $HOSTNAME | grep -E '^(\S+[.]\S+)$' > /dev/null ); then
 		notify 'err' "Setting hostname/domainname is required"
 		kill `cat /var/run/supervisord.pid` && return 1
 	else
-		notify 'inf' "Domain has been set to $DOMAINNAME"
-		notify 'inf' "Hostname has been set to $HOSTNAME"
 		return 0
 	fi
 }


### PR DESCRIPTION
This should fix #1075.

- Added a section to README describing the .env-file format.
- Show hostname / domain before aborting, so it is easier to understand misconfiguration
