### PR TITLE
Issue 1083

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Otherwise, `iptables` won't be able to ban IPs.
   - custom => Enables custom certificates
   - manual => Let's you manually specify locations of your SSL certificates for non-standard cases
   - self-signed => Enables self-signed certificates
+  - _any other value_ => SSL required, settings by default
 
 Please read [the SSL page in the wiki](https://github.com/tomav/docker-mailserver/wiki/Configure-SSL) for more information.
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Otherwise, `iptables` won't be able to ban IPs.
   - **empty** => SSL disabled
   - letsencrypt => Enables Let's Encrypt certificates
   - custom => Enables custom certificates
-  - manual => Let's you manually specify locations of your SSL certificates for non-standard cases
+  - manual => Let you manually specify locations of your SSL certificates for non-standard cases
   - self-signed => Enables self-signed certificates
   - _any other value_ => SSL required, settings by default
 

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -953,6 +953,20 @@ function _setup_ssl() {
 		notify 'inf' "SSL configured with 'self-signed' certificates"
 	fi
 	;;
+    '' )
+        # $SSL_TYPE=empty, no SSL certificate, plain text access
+
+        # Dovecot configuration
+        sed -i -e 's~#disable_plaintext_auth = yes~disable_plaintext_auth = no~g' /etc/dovecot/conf.d/10-auth.conf
+        sed -i -e 's~ssl = required~ssl = yes~g' /etc/dovecot/conf.d/10-ssl.conf
+
+        notify 'inf' "SSL configured with plain text access"
+        ;;
+    * )
+        # Unknown option, default behavior, no action is required
+
+        notify 'warn' "SSL configured by default"
+        ;;
 	esac
 }
 


### PR DESCRIPTION
- Setting SSL_TYPE to empty string will allow to use [plain text access](https://github.com/tomav/docker-mailserver/wiki/Configure-SSL#plain-text-access).
- Setting SSL_TYPE to unknown value will give a warning about setting SSL by default.
- Updated [README.md SSL_TYPE section](https://github.com/green-anger/docker-mailserver/tree/issue-1083#ssl_type).
- Fixed a small typo in the same section.