### PR TITLE
Fix port descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ Your config folder will be mounted in `/tmp/docker-mailserver/`. To understand h
 #### Exposed ports
 * 25 receiving email from other mailservers
 * 465 TLS/SSL Client email submission
-* 587 StartTLS Client email submission
-* 143 StartTLS IMAP client
+* 587 Plaintext / StartTLS Client email submission
+* 143 Plaintext / StartTLS IMAP client
 * 993 TLS/SSL IMAP client
-* 110 POP3 client
+* 110 Plaintext / StartTLS POP3 client
 * 995 TLS/SSL POP3 client
 
 `Note: Port 25 is only for receiving email from other mailservers and not for submitting email. You need to use port 465 or 587 for this.`

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Your config folder will be mounted in `/tmp/docker-mailserver/`. To understand h
 
 #### Exposed ports
 * 25 receiving email from other mailservers
-* 465 SSL Client email submission
-* 587 TLS Client email submission
+* 465 TLS/SSL Client email submission
+* 587 StartTLS Client email submission
 * 143 StartTLS IMAP client
 * 993 TLS/SSL IMAP client
 * 110 POP3 client


### PR DESCRIPTION
Port 465 is for implicit SSL/TLS connections, and port 587 is for StartTLS, so I fixed those descriptions.

Ports 110, 143, and 587 are actually plain text by default, with the option to upgrade to StartTLS, so I noted that as well.

(I haven't tested *all* of these myself to verify, but am taking this from what I know about email ports.  See e.g. [SSL vs TLS vs STARTTLS](https://www.fastmail.com/help/technical/ssltlsstarttls.html).)
