### PR TITLE
fixed dovecot config for new version and generate dhparams in docker …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,8 @@ RUN sed -i -e 's/include_try \/usr\/share\/dovecot\/protocols\.d/include_try \/e
   cd /usr/share/dovecot && \
   ./mkcert.sh  && \
   mkdir -p /usr/lib/dovecot/sieve-pipe /usr/lib/dovecot/sieve-filter /usr/lib/dovecot/sieve-global && \
-  chmod 755 -R /usr/lib/dovecot/sieve-pipe /usr/lib/dovecot/sieve-filter /usr/lib/dovecot/sieve-global
+  chmod 755 -R /usr/lib/dovecot/sieve-pipe /usr/lib/dovecot/sieve-filter /usr/lib/dovecot/sieve-global && \
+  openssl dhparam -out /etc/dovecot/dh.pem 2048
 
 # Configures LDAP
 COPY target/dovecot/dovecot-ldap.conf.ext /etc/dovecot

--- a/target/dovecot/10-ssl.conf
+++ b/target/dovecot/10-ssl.conf
@@ -42,11 +42,15 @@ ssl_key = </etc/dovecot/ssl/dovecot.key
 # auth_ssl_username_from_cert=yes.
 #ssl_cert_username_field = commonName
 
-# DH parameters length to use.
-ssl_dh_parameters_length = 2048
+# SSL DH parameters
+# Generate new params with `openssl dhparam -out /etc/dovecot/dh.pem 4096`
+# Or migrate from old ssl-parameters.dat file with the command dovecot
+# gives on startup when ssl_dh is unset.
+ssl_dh = </etc/dovecot/dh.pem
 
-# SSL protocols to use
-ssl_protocols = !SSLv3,!TLSv1,!TLSv1.1
+# Minimum SSL protocol version to use. Potentially recognized values are SSLv3,
+# TLSv1, TLSv1.1, and TLSv1.2, depending on the OpenSSL version used.
+ssl_min_protocol = TLSv1.2
 
 # SSL ciphers to use
 ssl_cipher_list = ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256


### PR DESCRIPTION
…image

fixes #1147 

The tests are running again. The dhparams for dovecot are no longer generated by dovecot and must be generated beforehand. Not sure if we should regenerate that weekly since the dovecot wiki says it would not have much of a security gain (https://wiki.dovecot.org/SSL/DovecotConfiguration#SSL_security_settings). I don't know much about dhparams but I think on my server I will generate those outside of the container and mount them so I won't use a "public" version of the dhparams.

For the other change, you have to specify the minimum ssl protocol instead of the protocols to use (or in our case exclude).
