### PR TITLE
fixed depricated settings

### DIFF
--- a/target/dovecot/10-ssl.conf
+++ b/target/dovecot/10-ssl.conf
@@ -42,11 +42,8 @@ ssl_key = </etc/dovecot/ssl/dovecot.key
 # auth_ssl_username_from_cert=yes.
 #ssl_cert_username_field = commonName
 
-# DH parameters length to use.
-ssl_dh_parameters_length = 2048
-
 # SSL protocols to use
-ssl_protocols = !SSLv3,!TLSv1,!TLSv1.1
+ssl_min_protocol = TLSv1.2
 
 # SSL ciphers to use
 ssl_cipher_list = ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256


### PR DESCRIPTION
When you run "dovecot -a ", from within the container, it shows "ssl_dh_parameters_length" is depricated and "ssl_protocols" has been replaced by "ssl_min_protocol". I adjusted 10-ssl.conf accordingly and set ssl_min_protocol = TLSv1.2 . Now "dovecot -a" no longer gives the warnings.
 

