### PR TITLE
1175: specify user for cron.d freshclam file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ The development workflow is the following:
 - Code :-)
 - Add integration tests in `test/tests.bats`
 - Use `make` to build image locally and run tests
+  Note that tests work on Linux only; they hang on Mac and Windows.
 - Document your improvements in `README.md` or Wiki depending on content
 - [Commit](https://help.github.com/articles/closing-issues-via-commit-messages/), push and make a pull-request
 - Pull-request is automatically tested on Travis

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,8 @@ RUN sed -i -e 's/include_try \/usr\/share\/dovecot\/protocols\.d/include_try \/e
   cd /usr/share/dovecot && \
   ./mkcert.sh  && \
   mkdir -p /usr/lib/dovecot/sieve-pipe /usr/lib/dovecot/sieve-filter /usr/lib/dovecot/sieve-global && \
-  chmod 755 -R /usr/lib/dovecot/sieve-pipe /usr/lib/dovecot/sieve-filter /usr/lib/dovecot/sieve-global
+  chmod 755 -R /usr/lib/dovecot/sieve-pipe /usr/lib/dovecot/sieve-filter /usr/lib/dovecot/sieve-global && \
+  openssl dhparam -out /etc/dovecot/dh.pem 2048
 
 # Configures LDAP
 COPY target/dovecot/dovecot-ldap.conf.ext /etc/dovecot

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN apt-get update -q --fix-missing && \
   rm -f /etc/cron.weekly/fstrim && \
   rm -f /etc/postsrsd.secret
 
-RUN echo "0 0,6,12,18 * * * /usr/bin/freshclam --quiet" > /etc/cron.d/clamav-freshclam && \
+RUN echo "0 0,6,12,18 * * * root /usr/bin/freshclam --quiet" > /etc/cron.d/clamav-freshclam && \
   chmod 644 /etc/clamav/freshclam.conf && \
   freshclam && \
   sed -i 's/Foreground false/Foreground true/g' /etc/clamav/clamd.conf && \

--- a/target/dovecot/10-ssl.conf
+++ b/target/dovecot/10-ssl.conf
@@ -42,11 +42,15 @@ ssl_key = </etc/dovecot/ssl/dovecot.key
 # auth_ssl_username_from_cert=yes.
 #ssl_cert_username_field = commonName
 
-# DH parameters length to use.
-ssl_dh_parameters_length = 2048
+# SSL DH parameters
+# Generate new params with `openssl dhparam -out /etc/dovecot/dh.pem 4096`
+# Or migrate from old ssl-parameters.dat file with the command dovecot
+# gives on startup when ssl_dh is unset.
+ssl_dh = </etc/dovecot/dh.pem
 
-# SSL protocols to use
-ssl_protocols = !SSLv3,!TLSv1,!TLSv1.1
+# Minimum SSL protocol version to use. Potentially recognized values are SSLv3,
+# TLSv1, TLSv1.1, and TLSv1.2, depending on the OpenSSL version used.
+ssl_min_protocol = TLSv1.2
 
 # SSL ciphers to use
 ssl_cipher_list = ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -95,6 +95,7 @@ function register_functions() {
 
 	if [ "$SMTP_ONLY" != 1 ]; then
 		_register_setup_function "_setup_dovecot"
+                _register_setup_function "_setup_dovecot_dhparam"
 		_register_setup_function "_setup_dovecot_local_user"
 	fi
 
@@ -1189,11 +1190,30 @@ function _setup_postfix_dhparam() {
 			notify 'inf' "Use dhparams that was generated previously"
 		fi
 
-		# Copy from the state directpry to the working location
+		# Copy from the state directory to the working location
 		rm /etc/postfix/dhparams.pem && cp $DHPARAMS_FILE /etc/postfix/dhparams.pem
 	else
 		notify 'inf' "No state dir, we use the dhparams generated on image creation"
 	fi
+}
+
+function _setup_dovecot_dhparam() {
+        notify 'task' 'Setting up Dovecot dhparam'
+        if [ "$ONE_DIR" = 1 ];then
+                DHPARAMS_FILE=/var/mail-state/lib-dovecot/dh.pem
+                if [ ! -f $DHPARAMS_FILE ]; then
+                        notify 'inf' "Generate new dhparams for dovecot"
+                        mkdir -p $(dirname "$DHPARAMS_FILE")
+                        openssl dhparam -out $DHPARAMS_FILE 2048
+                else
+                        notify 'inf' "Use dovecot dhparams that was generated previously"
+                fi
+
+                # Copy from the state directory to the working location
+                rm /etc/dovecot/dh.pem && cp $DHPARAMS_FILE /etc/dovecot/dh.pem
+        else
+                notify 'inf' "No state dir, we use the dovecot dhparams generated on image creation"
+        fi
 }
 
 function _setup_security_stack() {


### PR DESCRIPTION
See issue 1175, cron complains that the freshclam entry in cron.d is invalid as it lacks a user. Fixed by adding root as user.

Note that the unit tests were failing before this, they are still failing after this and I don't really know how to test this with a unit test. A good manual test is to let the cron job run once with and without the fix. Without it there are errors in the logs and the cron job does not run.