### PR TITLE
Replace ENV with ARG for DEBIAN_FRONTEND

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch-slim
 LABEL maintainer="Thomas VIAL"
 
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 ENV VIRUSMAILS_DELETE_DELAY=7
 ENV ONE_DIR=0
 ENV ENABLE_POSTGREY=0


### PR DESCRIPTION
Best practice suggests not using ENV for this setting as it persists after build. ARG is only set during build.