### PR TITLE
Add PERMIT_DOCKER=connected-networks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ run:
 	# instead we need to use create, network connect and start (see https://success.docker.com/article/multiple-docker-networks)
 	docker create --name mail_smtponly_second_network \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
-		-v "`pwd`/test":/tmp/docker-mailserver-test \
+		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
 		-e SMTP_ONLY=1 \
 		-e PERMIT_DOCKER=connected-networks \
 		-e DMS_DEBUG=0 \
@@ -340,7 +340,7 @@ clean:
 		mail_with_default_relay \
 		mail_smtponly_second_network
 
-	docker network rm ${NON_DEFAULT_DOCKER_MAIL_NETWORK_NAME} ${NON_DEFAULT_DOCKER_MAIL_NETWORK_NAME}2
+	-docker network rm ${NON_DEFAULT_DOCKER_MAIL_NETWORK_NAME} ${NON_DEFAULT_DOCKER_MAIL_NETWORK_NAME}2
 	@if [ -d config.bak ]; then\
 		rm -rf config ;\
 		mv config.bak config ;\

--- a/README.md
+++ b/README.md
@@ -285,7 +285,8 @@ Enables the Sender Rewriting Scheme. SRS is needed if your mail server acts as f
 Set different options for mynetworks option (can be overwrite in postfix-main.cf)
   - **empty** => localhost only
   - host => Add docker host (ipv4 only)
-  - network => Add all docker containers (ipv4 only)
+  - network => Add the docker default bridge network (172.16.0.0/12); **WARNING**: `docker-compose` might use others (e.g. 192.168.0.0/16) use `PERMIT_DOCKER=connected-networks` in this case
+  - connected-networks => Add all connected docker networks (ipv4 only)
 
 ##### VIRUSMAILS_DELETE_DELAY
 

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1228,10 +1228,9 @@ function count_processed_changes() {
 }
 
 @test "checking PERMIT_DOCKER: connected-networks" {
-  run docker exec mail /bin/sh -c "postconf | grep '^mynetworks =' | egrep '[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.0\.0/16'"
-  assert_success
-  run docker exec mail_pop3 /bin/sh -c "postconf | grep '^mynetworks =' | egrep '[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}/32'"
-  assert_success
+  run docker exec mail_smtponly_second_network /bin/sh -c "postconf | grep '^mynetworks ='"
+  assert_output --regexp "192\.168\.13\.[0-9]{1,3}\/24"
+  assert_output --regexp '192.168.37.[0-9]{1,3}/24'
 }
 
 #

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1227,6 +1227,13 @@ function count_processed_changes() {
   assert_success
 }
 
+@test "checking PERMIT_DOCKER: connected-networks" {
+  run docker exec mail /bin/sh -c "postconf | grep '^mynetworks =' | egrep '[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.0\.0/16'"
+  assert_success
+  run docker exec mail_pop3 /bin/sh -c "postconf | grep '^mynetworks =' | egrep '[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}/32'"
+  assert_success
+}
+
 #
 # amavis
 #


### PR DESCRIPTION
This will add the networks of all eth* interfaces as trusted, which is necessary if the container is in networks that are outside of the old docker default network (172.16.0.0/12), e.g. 192.168.0.0/16

See https://github.com/tomav/docker-mailserver/issues/1079#issuecomment-499903541 for a more detailed description of the problem that is solved here.