### PR TITLE
add test artifacts to gitignore and clean target of makefile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,1 @@
-test/onedir
+test/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,15 @@ test/config/postfix-accounts.cf
 test/config/letsencrypt/mail.my-domain.com/combined.pem
 test/onedir
 config/opendkim/
+test/config/dovecot-lmtp/userdb
+test/config/key*
+test/config/opendkim/keys/domain.tld/
+test/config/opendkim/keys/example.com/
+test/config/opendkim/keys/localdomain2.com/
+test/config/postfix-aliases.cf
+test/config/postfix-receive-access.cf
+test/config/postfix-receive-access.cfe
+test/config/postfix-send-access.cf
+test/config/postfix-send-access.cfe
+test/config/relay-hosts/chksum
+test/config/relay-hosts/postfix-aliases.cf

--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,4 @@ clean:
 		sudo rm -rf test/config ;\
 		mv testconfig.bak test/config ;\
 	fi
-	-sudo rm -rf test/onedir
-	-sudo rm -rf test/alias
-	-sudo rm -rf test/relay
-
+	-sudo rm -rf test/onedir test/alias test/relay test/config/dovecot-lmtp/userdb test/config/key* test/config/opendkim/keys/domain.tld/ test/config/opendkim/keys/example.com/ test/config/opendkim/keys/localdomain2.com/ test/config/postfix-aliases.cf test/config/postfix-receive-access.cf test/config/postfix-receive-access.cfe test/config/postfix-send-access.cf test/config/postfix-send-access.cfe test/config/relay-hosts/chksum test/config/relay-hosts/postfix-aliases.cf


### PR DESCRIPTION
Hi,

while working on https://github.com/tomav/docker-mailserver/pull/1194 I realised that there are quite a lot of files that are not proberly cleaned up when running the tests locally (and since they are not cleaned up will for example show up in `git status`). This PR attempts to fix this.