### PR TITLE
install whois package for use with fail2ban

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ RUN apt-get update -q --fix-missing && \
     postgrey \
     unrar-free \
     unzip \
+    whois \
     xz-utils \
     zoo \
     && \


### PR DESCRIPTION
Required for `action_mwl` email notifications from fail2ban