### PR TITLE
set Nameservers in opendkim.conf at start-up

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -850,6 +850,12 @@ function _setup_dkim() {
 		local _f_keytable="/etc/opendkim/KeyTable"
 		[ ! -f "$_f_keytable" ] && touch "$_f_keytable"
 	fi
+
+	# Setup nameservers paramater from /etc/resolv.conf if not defined
+	if ! grep '^Nameservers' /etc/opendkim.conf; then
+		echo "Nameservers $(grep '^nameserver' /etc/resolv.conf | awk -F " " '{print $2}')" >> /etc/opendkim.conf
+		notify 'inf' "Nameservers added to /etc/opendkim.conf"
+	fi
 }
 
 function _setup_ssl() {

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -563,6 +563,11 @@ function count_processed_changes() {
   assert_output 2
 }
 
+@test "checking opendkim: /etc/opendkim.conf contains nameservers copied from /etc/resolv.conf" {
+  run docker exec mail /bin/bash -c "grep -E '^Nameservers ((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)' /etc/opendkim.conf"
+  assert_success
+}
+
 
 # this set of tests is of low quality. It does not test the RSA-Key size properly via openssl or similar
 # Instead it tests the file-size (here 511) - which may differ with a different domain names


### PR DESCRIPTION
Fix for https://github.com/tomav/docker-mailserver/issues/1204 