### PR TITLE
Make check for connected-networks more dynamic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ generate-accounts:
 	docker run --rm -e MAIL_USER=user2@otherdomain.tld -e MAIL_PASS=mypassword -t $(NAME) /bin/sh -c 'echo "$$MAIL_USER|$$(doveadm pw -s SHA512-CRYPT -u $$MAIL_USER -p $$MAIL_PASS)"' >> test/config/postfix-accounts.cf
 
 run:
-	docker network create --driver bridge --subnet 192.168.13.0/24 $(NON_DEFAULT_DOCKER_MAIL_NETWORK_NAME)
-	docker network create --driver bridge --subnet 192.168.37.0/24 $(NON_DEFAULT_DOCKER_MAIL_NETWORK_NAME)2
+	docker network create --driver bridge $(NON_DEFAULT_DOCKER_MAIL_NETWORK_NAME)
+	docker network create --driver bridge $(NON_DEFAULT_DOCKER_MAIL_NETWORK_NAME)2
 	# use two networks (default ("bridge") and our custom network) to recreate problematic test case where PERMIT_DOCKER=host would not help
 	# currently we cannot use --network in `docker run` multiple times, it will just use the last one
 	# instead we need to use create, network connect and start (see https://success.docker.com/article/multiple-docker-networks)

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1233,9 +1233,11 @@ function count_processed_changes() {
 }
 
 @test "checking PERMIT_DOCKER: connected-networks" {
+  ipnet1=$(docker network inspect --format '{{range .Containers}}{{.IPv4Address}}{{end}}' non-default-docker-mail-network)
+  ipnet2=$(docker network inspect --format '{{range .Containers}}{{.IPv4Address}}{{end}}' non-default-docker-mail-network2)
   run docker exec mail_smtponly_second_network /bin/sh -c "postconf | grep '^mynetworks ='"
-  assert_output --regexp "192\.168\.13\.[0-9]{1,3}\/24"
-  assert_output --regexp '192.168.37.[0-9]{1,3}/24'
+  assert_output --partial $ipnet1
+  assert_output --partial $ipnet2
 }
 
 #


### PR DESCRIPTION
On my system the creation of the bridge failed since there was an overlap in the address space

continuation of https://github.com/tomav/docker-mailserver/pull/1194

Signed-off-by: Felix Bartels <felix@host-consultants.de>