### PR TITLE
Fixed opendkim config on multiple nameservers

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -853,7 +853,7 @@ function _setup_dkim() {
 
 	# Setup nameservers paramater from /etc/resolv.conf if not defined
 	if ! grep '^Nameservers' /etc/opendkim.conf; then
-		echo "Nameservers $(grep '^nameserver' /etc/resolv.conf | awk -F " " '{print $2}')" >> /etc/opendkim.conf
+		echo "Nameservers $(grep '^nameserver' /etc/resolv.conf | awk -F " " '{print $2}' | paste -sd ',' -)" >> /etc/opendkim.conf
 		notify 'inf' "Nameservers added to /etc/opendkim.conf"
 	fi
 }


### PR DESCRIPTION
Having multiple nameservers set in `/etc/resolv.conf` currently results in a malformed opendkim configuration and opendkim performing a crash loop.

Given the file `/etc/resolv.conf`:
```
nameserver 1.2.3.4
nameserver 2.3.4.5
nameserver 3.4.5.6
```

The following `/etc/opendkim.conf` configuration lines are created on startup (which are malformed):
```
Nameservers 1.2.3.4
2.3.4.5
3.4.5.6
```

This fix merges the multiple lines and delimits them using `,`, just as opendkim requires:
```
Nameservers 1.2.3.4,2.3.4.5,3.4.5.6
```