### PR TITLE
Fixed bug when dh.pem/dhparam.pem exists with ONE_DIR

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1261,7 +1261,7 @@ function _setup_postfix_dhparam() {
 		fi
 
 		# Copy from the state directory to the working location
-		rm /etc/postfix/dhparams.pem && cp $DHPARAMS_FILE /etc/postfix/dhparams.pem
+		rm -f /etc/postfix/dhparams.pem && cp $DHPARAMS_FILE /etc/postfix/dhparams.pem
 	else
                 if [ ! -f /etc/postfix/dhparams.pem ]; then
                         if [ -f /etc/dovecot/dh.pem ]; then
@@ -1293,7 +1293,7 @@ function _setup_dovecot_dhparam() {
                 fi
 
                 # Copy from the state directory to the working location
-                rm /etc/dovecot/dh.pem && cp $DHPARAMS_FILE /etc/dovecot/dh.pem
+                rm -f /etc/dovecot/dh.pem && cp $DHPARAMS_FILE /etc/dovecot/dh.pem
         else
                 if [ ! -f /etc/dovecot/dh.pem ]; then
                         if [ -f /etc/postfix/dhparams.pem ]; then


### PR DESCRIPTION
Added `-f` to force `rm` to succeed if there is no file to delete (normal case) with one dir. Minimal change, would have been cleaner to remove the `rm` but as it is I prefer to keep it if I have missed something.