### PR TITLE
Generalize clean to remove all matching containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ generate-accounts:
 
 run:
 	# Run containers
-	docker run -d --name mail \
+	docker run --rm -d --name mail \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
 		-v "`pwd`/test/onedir":/var/mail-state \
@@ -49,7 +49,7 @@ run:
 		-e DMS_DEBUG=0 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
-	docker run -d --name mail_privacy \
+	docker run --rm -d --name mail_privacy \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
 		-e ENABLE_CLAMAV=1 \
@@ -66,7 +66,7 @@ run:
 		-e DMS_DEBUG=0 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
-	docker run -d --name mail_pop3 \
+	docker run --rm -d --name mail_pop3 \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
 		-v "`pwd`/test/config/letsencrypt":/etc/letsencrypt/live \
@@ -75,7 +75,7 @@ run:
 		-e SSL_TYPE=letsencrypt \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
-	docker run -d --name mail_smtponly \
+	docker run --rm -d --name mail_smtponly \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
 		-e SMTP_ONLY=1 \
@@ -84,14 +84,14 @@ run:
 		-e OVERRIDE_HOSTNAME=mail.my-domain.com \
 		-t $(NAME)
 	sleep 15
-	docker run -d --name mail_smtponly_without_config \
+	docker run --rm -d --name mail_smtponly_without_config \
 		-e SMTP_ONLY=1 \
 		-e ENABLE_LDAP=1 \
 		-e PERMIT_DOCKER=network \
 		-e OVERRIDE_HOSTNAME=mail.mydomain.com \
 		-t $(NAME)
 	sleep 15
-	docker run -d --name mail_override_hostname \
+	docker run --rm -d --name mail_override_hostname \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
 		-e PERMIT_DOCKER=network \
@@ -101,7 +101,7 @@ run:
 		-h unknown.domain.tld \
 		-t $(NAME)
 	sleep 15
-	docker run -d --name mail_domainname \
+	docker run --rm -d --name mail_domainname \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
 		-e PERMIT_DOCKER=network \
@@ -111,7 +111,7 @@ run:
 		-h unknown.domain.tld \
 		-t $(NAME)
 	sleep 15
-	docker run -d --name mail_srs_domainname \
+	docker run --rm -d --name mail_srs_domainname \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
 		-e PERMIT_DOCKER=network \
@@ -122,7 +122,7 @@ run:
 		-h unknown.domain.tld \
 		-t $(NAME)
 	sleep 15
-	docker run -d --name mail_fail2ban \
+	docker run --rm -d --name mail_fail2ban \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
 		-e ENABLE_FAIL2BAN=1 \
@@ -130,7 +130,7 @@ run:
 		--cap-add=NET_ADMIN \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
-	docker run -d --name mail_fetchmail \
+	docker run --rm -d --name mail_fetchmail \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
 		-e ENABLE_FETCHMAIL=1 \
@@ -138,7 +138,7 @@ run:
 		-e DMS_DEBUG=0 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
-	docker run -d --name mail_disabled_clamav_spamassassin \
+	docker run --rm -d --name mail_disabled_clamav_spamassassin \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
 		-e ENABLE_CLAMAV=0 \
@@ -146,7 +146,7 @@ run:
 		-e DMS_DEBUG=0 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
-	docker run -d --name mail_manual_ssl \
+	docker run --rm -d --name mail_manual_ssl \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
 		-e SSL_TYPE=manual \
@@ -155,11 +155,11 @@ run:
 		-e DMS_DEBUG=0 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
-	docker run -d --name ldap_for_mail \
+	docker run --rm -d --name ldap_for_mail \
 		-e LDAP_DOMAIN="localhost.localdomain" \
 		-h ldap.my-domain.com -t ldap
 	sleep 15
-	docker run -d --name mail_with_ldap \
+	docker run --rm -d --name mail_with_ldap \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
 		-e ENABLE_LDAP=1 \
@@ -240,23 +240,8 @@ lint:
 	git ls-files --exclude='Dockerfile*' --ignored | xargs --max-lines=1 hadolint
 
 clean:
-	# Remove running test containers
-	-docker rm -f \
-		mail \
-		mail_privacy \
-		mail_pop3 \
-		mail_smtponly \
-		mail_smtponly_without_config \
-		mail_fail2ban \
-		mail_fetchmail \
-		fail-auth-mailer \
-		mail_disabled_clamav_spamassassin \
-		mail_manual_ssl \
-		ldap_for_mail \
-		mail_with_ldap \
-		mail_override_hostname \
-		mail_domainname \
-		mail_srs_domainname
+	# Remove running and stopped test containers
+	-docker ps -a | grep -E "docker-mailserver:testing|ldap_for_mail" | cut -f 1-1 -d ' ' | xargs --no-run-if-empty docker rm -f
 
 	@if [ -d config.bak ]; then\
 		rm -rf config ;\


### PR DESCRIPTION
Sometimes anonymous containers remain after cleanup, generalize to remove all docker-mailserver:testing and the ldap container.