### PR TITLE
Provide version information through labels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 - sudo chmod +rx /usr/local/bin/hadolint
 install:
 - make lint
-- travis_retry travis_wait make build-no-cache
+- travis_retry travis_wait make build
 script:
 - make generate-accounts run generate-accounts-after-run fixtures tests
 after_script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
 FROM debian:stretch-slim
-LABEL maintainer="Thomas VIAL"
+
+ARG VCS_REF
+ARG VCS_VERSION
+
+LABEL maintainer="Thomas VIAL"  \
+    org.label-schema.name="docker-mailserver" \
+    org.label-schema.description="A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...)" \
+    org.label-schema.url="https://github.com/tomav/docker-mailserver" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url="https://github.com/tomav/docker-mailserver" \
+    org.label-schema.version=$VCS_VERSION \
+    org.label-schema.schema-version="1.0"
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV VIRUSMAILS_DELETE_DELAY=7

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 NAME = tvial/docker-mailserver:testing
+VCS_REF := $(shell git rev-parse --short HEAD)
+VCS_VERSION := $(shell git describe)
 
 all: build-no-cache backup generate-accounts run generate-accounts-after-run fixtures tests clean
 all-fast: build backup generate-accounts run generate-accounts-after-run fixtures tests clean
@@ -6,10 +8,16 @@ no-build: backup generate-accounts run generate-accounts-after-run fixtures test
 
 build-no-cache:
 	export DOCKER_MAIL_DOCKER_BUILD_NO_CACHE=--no-cache
-	docker build --no-cache -t $(NAME) .
+	docker build --no-cache \
+		--build-arg VCS_REF=$(VCS_REF) \
+		--build-arg VCS_VERSION=$(VCS_VERSION) \
+		-t $(NAME) .
 
 build:
-	docker build -t $(NAME) .
+	docker build \
+		--build-arg VCS_REF=$(VCS_REF) \
+		--build-arg VCS_VERSION=$(VCS_VERSION) \
+		-t $(NAME) .
 
 backup:
 	# if backup directories exist, clean hasn't been called, therefore we shouldn't overwrite it. It still contains the original content.

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,8 @@ NAME = tvial/docker-mailserver:testing
 VCS_REF := $(shell git rev-parse --short HEAD)
 VCS_VERSION := $(shell git describe)
 
-all: build-no-cache backup generate-accounts run generate-accounts-after-run fixtures tests clean
-all-fast: build backup generate-accounts run generate-accounts-after-run fixtures tests clean
+all: build backup generate-accounts run generate-accounts-after-run fixtures tests clean
 no-build: backup generate-accounts run generate-accounts-after-run fixtures tests clean
-
-build-no-cache:
-	export DOCKER_MAIL_DOCKER_BUILD_NO_CACHE=--no-cache
-	docker build --no-cache \
-		--build-arg VCS_REF=$(VCS_REF) \
-		--build-arg VCS_VERSION=$(VCS_VERSION) \
-		-t $(NAME) .
 
 build:
 	docker build \

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,8 @@
+VCS_REF=$(git rev-parse --short HEAD)
+VCS_VERSION=$(git describe)
+
+docker build \
+	--build-arg VCS_REF=$VCS_REF \
+	--build-arg VCS_VERSION=$VCS_VERSION \
+	-f $DOCKERFILE_PATH -t $IMAGE_NAME .
+

--- a/hooks/build
+++ b/hooks/build
@@ -1,8 +1,8 @@
+#!/bin/sh
 VCS_REF=$(git rev-parse --short HEAD)
 VCS_VERSION=$(git describe)
 
 docker build \
-	--build-arg VCS_REF=$VCS_REF \
-	--build-arg VCS_VERSION=$VCS_VERSION \
-	-f $DOCKERFILE_PATH -t $IMAGE_NAME .
-
+	--build-arg VCS_REF="$VCS_REF" \
+	--build-arg VCS_VERSION="$VCS_VERSION" \
+	-f "$DOCKERFILE_PATH" -t "$IMAGE_NAME" .

--- a/test/mail_with_ldap.bats
+++ b/test/mail_with_ldap.bats
@@ -10,7 +10,7 @@ function teardown() {
 
 function setup_file() {
     pushd test/docker-openldap/
-    docker build -f Dockerfile -t ldap $DOCKER_MAIL_DOCKER_BUILD_NO_CACHE .
+    docker build -f Dockerfile -t ldap --no-cache .
     popd
 
     docker run -d --name ldap_for_mail \


### PR DESCRIPTION
Can be retrieved by calling e.g. `docker inspect tvial/docker-mailserver:testing`

Sample output:

```
$ docker inspect -f '{{ range $k, $v := .ContainerConfig.Labels -}}
> {{ $k }}={{ $v }}
> {{ end -}}' tvial/docker-mailserver:testing
maintainer=Thomas VIAL
org.label-schema.description=A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...)
org.label-schema.name=docker-mailserver
org.label-schema.schema-version=1.0
org.label-schema.url=https://github.com/tomav/docker-mailserver
org.label-schema.vcs-ref=7580aec
org.label-schema.vcs-url=https://github.com/tomav/docker-mailserver
org.label-schema.version=v6.1.0-111-g7580aec
```