### PR TITLE
Fix missing error output from timeout

### DIFF
--- a/test/test_helper/common.bash
+++ b/test/test_helper/common.bash
@@ -9,7 +9,7 @@ TEST_TIMEOUT_IN_SECONDS=${TEST_TIMEOUT_IN_SECONDS-60}
 function repeat_until_success_or_timeout {
     if ! [[ "$1" =~ ^[0-9]+$ ]]; then
         echo "First parameter for timeout must be an integer, recieved \"$1\""
-        exit 1
+        return 1
     fi
     TIMEOUT=$1
     STARTTIME=$SECONDS
@@ -19,7 +19,7 @@ function repeat_until_success_or_timeout {
         sleep 5
         if [[ $(($SECONDS - $STARTTIME )) -gt $TIMEOUT ]]; then
             echo "Timed out on command: $@"
-            exit 1
+            return 1
         fi
     done
 }

--- a/test/test_helper/common.bash
+++ b/test/test_helper/common.bash
@@ -34,16 +34,26 @@ function wait_for_finished_setup_in_container() {
     repeat_until_success_or_timeout $TEST_TIMEOUT_IN_SECONDS sh -c "docker logs $1 | grep 'Starting mail server'"
 }
 
+SETUP_FILE_MARKER="$BATS_TMPDIR/`basename \"$BATS_TEST_FILENAME\".setup_file`"
+
 # use in setup() in conjunction with a `@test "first" {}` to trigger setup_file reliably
 function run_setup_file_if_necessary() {
     if [ "$BATS_TEST_NAME" == 'test_first' ]; then
+        rm -f "$SETUP_FILE_MARKE"
         setup_file
+        touch "$SETUP_FILE_MARKER"
+    else
+        if [ ! -f "$SETUP_FILE_MARKER" ]; then
+            skip "setup_file failed"
+            return 1
+        fi
     fi
 }
 
 # use in teardown() in conjunction with a `@test "last" {}` to trigger teardown_file reliably
 function run_teardown_file_if_necessary() {
     if [ "$BATS_TEST_NAME" == 'test_last' ]; then
+        rm -f "$SETUP_FILE_MARKE"
         teardown_file
     fi
 }


### PR DESCRIPTION
The exits would prevent the printing code from running. Thus we would get a failed test but no error message.