### PR TITLE
Set REPORT_RECIPIENT to postmaster when 0

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -451,14 +451,14 @@ function _setup_default_vars() {
 
 	# set PFLOGSUMM_TRIGGER here for backwards compatibility
 	# when REPORT_RECIPIENT is on the old method should be used
-	if [ "$REPORT_RECIPIENT" != "0" ]; then
-		DEFAULT_VARS["PFLOGSUMM_TRIGGER"]="${PFLOGSUMM_TRIGGER:="logrotate"}"
-	else
+	if [ "$REPORT_RECIPIENT" == "0" ]; then
 		DEFAULT_VARS["PFLOGSUMM_TRIGGER"]="${PFLOGSUMM_TRIGGER:="none"}"
+	else
+		DEFAULT_VARS["PFLOGSUMM_TRIGGER"]="${PFLOGSUMM_TRIGGER:="logrotate"}"
 	fi
 
 	# Expand address to simplify the rest of the script
-	if [ "$REPORT_RECIPIENT" == "1" ]; then
+	if [ "$REPORT_RECIPIENT" == "0" ] || [ "$REPORT_RECIPIENT" == "1" ]; then
 		REPORT_RECIPIENT="$POSTMASTER_ADDRESS"
 		DEFAULT_VARS["REPORT_RECIPIENT"]="${REPORT_RECIPIENT}"
 	fi


### PR DESCRIPTION
Second attempt, set REPORT_RECIPIENT to postmaster for use later. Skipped that before as REPORT_RECIPIENT was intended only for backwards compatibility, but it broke down when combined with the new options.