### PR TITLE
Added optional file user-patches.sh for own patches without recompiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ run:
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
 		-v "`pwd`/test/onedir":/var/mail-state \
-		-v "`pwd`/test/config/user-patches/user-patches.sh":/tmp/docker-mailserver/user-patches.sh:ro \
+		-v "`pwd`/test/config/user-patches/user-patches.sh":/tmp/docker-mailserver/user-patches.sh \
 		-e ENABLE_CLAMAV=1 \
 		-e SPOOF_PROTECTION=1 \
 		-e ENABLE_SPAMASSASSIN=1 \

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ run:
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
 		-v "`pwd`/test/onedir":/var/mail-state \
+		-v "`pwd`/test/config/user-patches/user-patches.sh:/tmp/docker-mailserver/user-patches.sh:ro \
 		-e ENABLE_CLAMAV=1 \
 		-e SPOOF_PROTECTION=1 \
 		-e ENABLE_SPAMASSASSIN=1 \

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ run:
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
 		-v "`pwd`/test/onedir":/var/mail-state \
-		-v "`pwd`/test/config/user-patches/user-patches.sh:/tmp/docker-mailserver/user-patches.sh:ro \
+		-v "`pwd`/test/config/user-patches/user-patches.sh":/tmp/docker-mailserver/user-patches.sh:ro \
 		-e ENABLE_CLAMAV=1 \
 		-e SPOOF_PROTECTION=1 \
 		-e ENABLE_SPAMASSASSIN=1 \

--- a/config/user-patches.sh
+++ b/config/user-patches.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo "Default user-patches.sh successfully executed!"

--- a/config/user-patches.sh
+++ b/config/user-patches.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+##
+# This user script will be executed between configuration and starting daemons
+##
+

--- a/config/user-patches.sh.dist
+++ b/config/user-patches.sh.dist
@@ -3,4 +3,4 @@
 # This user script will be executed between configuration and starting daemons
 # To enable it you must save it in your config directory as "user-patches.sh"
 ##
-echo "Default user-patches.sh successfully executed!"
+echo "Default user-patches.sh successfully executed"

--- a/config/user-patches.sh.dist
+++ b/config/user-patches.sh.dist
@@ -1,0 +1,6 @@
+#!/bin/bash
+##
+# This user script will be executed between configuration and starting daemons
+# To enable it you must save it in your config directory as "user-patches.sh"
+##
+echo "Default user-patches.sh successfully executed!"

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1601,6 +1601,7 @@ function _misc_user_patches() {
 
 	if [ -f /tmp/docker-mailserver/user-patches.sh ]; then
 		chmod +x /tmp/docker-mailserver/user-patches.sh
+		chown -R docker:docker /tmp/docker-mailserver/user-patches.sh
 		/tmp/docker-mailserver/user-patches.sh
 		notify 'inf' "user-patches.sh executed"
 	else

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -172,7 +172,8 @@ function register_functions() {
 	if [ "$LOGWATCH_TRIGGER" != "none" ]; then
 		_register_setup_function "_setup_logwatch"
 	fi
-
+	
+	_register_setup_function "_setup_user_patches"
 
         # Compute last as the config files are modified in-place
         _register_setup_function "_setup_chksum_file"
@@ -195,7 +196,6 @@ function register_functions() {
 	################### >> misc funcs
 
 	_register_misc_function "_misc_save_states"
-	_register_misc_function "_misc_user_patches"
 
 	################### << misc funcs
 
@@ -1466,6 +1466,18 @@ function _setup_logwatch() {
 	esac
 }
 
+function _setup_user_patches() {
+	notify 'inf' 'Executing user-patches.sh'
+
+	if [ -f /tmp/docker-mailserver/user-patches.sh ]; then
+		chmod +x /tmp/docker-mailserver/user-patches.sh
+		/tmp/docker-mailserver/user-patches.sh
+		notify 'inf' "Executed 'config/user-patches.sh'"
+	else
+		notify 'inf' "No user patches executed because optional '/tmp/docker-mailserver/user-patches.sh' is not provided."
+	fi
+}
+
 function _setup_environment() {
     notify 'task' 'Setting up /etc/environment'
 
@@ -1593,18 +1605,6 @@ function _misc_save_states() {
 		chown -R debian-spamd /var/mail-state/lib-spamassassin
 		chown -R postfix /var/mail-state/spool-postfix
 
-	fi
-}
-
-function _misc_user_patches() {
-	notify 'inf' 'Executing user-patches.sh'
-
-	if [ -f /tmp/docker-mailserver/user-patches.sh ]; then
-		chmod +x /tmp/docker-mailserver/user-patches.sh
-		/tmp/docker-mailserver/user-patches.sh
-		notify 'inf' "Executed 'config/user-patches.sh'"
-	else
-		notify 'inf' "No user patches executed because optional '/tmp/docker-mailserver/user-patches.sh' is not provided."
 	fi
 }
 

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -195,6 +195,7 @@ function register_functions() {
 	################### >> misc funcs
 
 	_register_misc_function "_misc_save_states"
+	_register_misc_function "_misc_user_patches"
 
 	################### << misc funcs
 
@@ -1592,6 +1593,18 @@ function _misc_save_states() {
 		chown -R debian-spamd /var/mail-state/lib-spamassassin
 		chown -R postfix /var/mail-state/spool-postfix
 
+	fi
+}
+
+function _misc_user_patches() {
+	notify 'inf' 'Executing user-patches.sh'
+
+	if [ -f /tmp/docker-mailserver/user-patches.sh ]; then
+		chmod +x /tmp/docker-mailserver/user-patches.sh
+		bash /tmp/docker-mailserver/user-patches.sh
+		notify 'inf' "user-patches.sh executed"
+	else
+		notify 'inf' "user-patches.sh not executed because optional '/tmp/docker-mailserver/user-patches.sh' is not provided."
 	fi
 }
 

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1601,7 +1601,7 @@ function _misc_user_patches() {
 
 	if [ -f /tmp/docker-mailserver/user-patches.sh ]; then
 		chmod +x /tmp/docker-mailserver/user-patches.sh
-		bash /tmp/docker-mailserver/user-patches.sh
+		/tmp/docker-mailserver/user-patches.sh
 		notify 'inf' "user-patches.sh executed"
 	else
 		notify 'inf' "user-patches.sh not executed because optional '/tmp/docker-mailserver/user-patches.sh' is not provided."

--- a/test/config/user-patches/user-patches.sh
+++ b/test/config/user-patches/user-patches.sh
@@ -3,4 +3,4 @@
 # This user script will be executed between configuration and starting daemons
 # To enable it you must save it in your config directory as "user-patches.sh"
 ##
-echo "Default user-patches.sh successfully executed!"
+echo "Default user-patches.sh successfully executed"

--- a/test/config/user-patches/user-patches.sh
+++ b/test/config/user-patches/user-patches.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+##
+# This user script will be executed between configuration and starting daemons
+# To enable it you must save it in your config directory as "user-patches.sh"
+##
+echo "Default user-patches.sh successfully executed!"

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -28,8 +28,8 @@ function count_processed_changes() {
 #
 
 @test "checking configuration: user-patches.sh executed" {
-  run docker logs mail | grep "Default user-patches.sh successfully executed!"
-  assert_success
+  run echo -n "`docker logs mail | grep 'user\-patches\.sh'`"
+  assert_output --partial "Default user-patches.sh successfully executed"
 }
 
 @test "checking configuration: hostname/domainname" {

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -29,7 +29,7 @@ function count_processed_changes() {
 
 @test "checking configuration: user-patches.sh executed" {
   run docker logs mail | grep "Default user-patches.sh successfully executed!"
-  assert_output "Default user-patches.sh successfully executed!"
+  assert_success
 }
 
 @test "checking configuration: hostname/domainname" {

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -27,6 +27,11 @@ function count_processed_changes() {
 # configuration checks
 #
 
+@test "checking configuration: user-patches.sh executed" {
+  run docker logs mail | grep "Default user-patches.sh successfully executed!"
+  assert_output "Default user-patches.sh successfully executed!"
+}
+
 @test "checking configuration: hostname/domainname" {
   run docker run `docker inspect --format '{{ .Config.Image }}' mail`
   assert_success


### PR DESCRIPTION
As @erik-wramner suggested in https://github.com/tomav/docker-mailserver/issues/1281 I created this pull request.

Sadly I wasn't able to test with the current tip of master. Error while starting:
`2019-10-07 20:45:23,793 INFO spawned: 'mailserver' with pid 8`
`supervisor: couldn't exec /usr/local/bin/start-mailserver.sh: ENOENT`
`supervisor: child process was not spawned`

This is my first pull request. Feel free to inform me whenever I was doing domething wrong.