### PR TITLE
Added section "6.2.0+" to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.2.0+
+
+see https://github.com/tomav/docker-mailserver/releases
+
 ## 6.1.0
 
 * Deliver root mail (#952)


### PR DESCRIPTION
CHANGELOG.md was not updated with the last release. To avoid confusion I added 6.2.0+.