### PR TITLE
Removing unnecessary maildir folders creation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,6 @@ insert_final_newline = true
 
 [*.md]
 indent_style = space
-indent_size = 4
 trim_trailing_whitespace = false
 
 [*.{yaml,yml,yml.dist,yml.tmpl}]
@@ -27,6 +26,10 @@ indent_size = 2
 indent_style = space
 indent_size = 2
 
-[target/start-mailserver.sh]
-indent_style = tab
-indent_size = 4
+# directories created by git submodules
+[{test/bats/**,test/test_helper/bats-assert/**,test/test_helper/bats-support/**,target/docker-configomat/**}]
+insert_final_newline = none
+indent_style = none
+indent_size = none
+trim_trailing_whitespace = none
+end_of_line = none

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 - sudo chmod +rx /usr/local/bin/hadolint
 install:
 - make lint
-- travis_retry travis_wait make build-no-cache
+- travis_retry travis_wait make build
 script:
 - make generate-accounts run generate-accounts-after-run fixtures tests
 after_script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ The development workflow is the following:
 - Run `git submodule init` and `git submodule update` to get the BATS submodules
 - Code :-)
 - Add integration tests in `test/tests.bats`
-- Use `make` to build image locally and run tests
+- Use `make clean all` to build image locally and run tests
   Note that tests work on Linux only; they hang on Mac and Windows.
 - Document your improvements in `README.md` or Wiki depending on content
 - [Commit](https://help.github.com/articles/closing-issues-via-commit-messages/), push and make a pull-request

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
 FROM debian:stretch-slim
-LABEL maintainer="Thomas VIAL"
+
+ARG VCS_REF
+ARG VCS_VERSION
+
+LABEL maintainer="Thomas VIAL"  \
+    org.label-schema.name="docker-mailserver" \
+    org.label-schema.description="A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...)" \
+    org.label-schema.url="https://github.com/tomav/docker-mailserver" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url="https://github.com/tomav/docker-mailserver" \
+    org.label-schema.version=$VCS_VERSION \
+    org.label-schema.schema-version="1.0"
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV VIRUSMAILS_DELETE_DELAY=7

--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,6 @@ generate-accounts-after-run:
 fixtures:
 	# Setup sieve & create filtering folder (INBOX/spam)
 	docker cp "`pwd`/test/config/sieve/dovecot.sieve" mail:/var/mail/localhost.localdomain/user1/.dovecot.sieve
-	docker exec mail /bin/sh -c "maildirmake.dovecot /var/mail/localhost.localdomain/user1/.INBOX.spam"
-	docker exec mail /bin/sh -c "chown 5000:5000 -R /var/mail/localhost.localdomain/user1/.INBOX.spam"
 	sleep 30
 	# Sending test mails
 	docker exec mail /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/amavis-spam.txt"

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 NAME = tvial/docker-mailserver:testing
+VCS_REF := $(shell git rev-parse --short HEAD)
+VCS_VERSION := $(shell git describe)
 
-all: build-no-cache backup generate-accounts run generate-accounts-after-run fixtures tests clean
-all-fast: build backup generate-accounts run generate-accounts-after-run fixtures tests clean
+all: build backup generate-accounts run generate-accounts-after-run fixtures tests clean
 no-build: backup generate-accounts run generate-accounts-after-run fixtures tests clean
 
-build-no-cache:
-	export DOCKER_MAIL_DOCKER_BUILD_NO_CACHE=--no-cache
-	docker build --no-cache -t $(NAME) .
-
 build:
-	docker build -t $(NAME) .
+	docker build \
+		--build-arg VCS_REF=$(VCS_REF) \
+		--build-arg VCS_VERSION=$(VCS_VERSION) \
+		-t $(NAME) .
 
 backup:
 	# if backup directories exist, clean hasn't been called, therefore we shouldn't overwrite it. It still contains the original content.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Download the docker-compose.yml, the .env and the setup.sh files:
     curl -o docker-compose.yml https://raw.githubusercontent.com/tomav/docker-mailserver/master/docker-compose.yml.dist
 
     curl -o .env https://raw.githubusercontent.com/tomav/docker-mailserver/master/.env.dist
+    
+    curl -o env-mailserver https://raw.githubusercontent.com/tomav/docker-mailserver/master/env-mailserver.dist
 
 #### Create a docker-compose environment
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,14 @@ Before you open an issue, please have a look this `README`, the [Wiki](https://g
 
 Recommended:
 - 1 CPU
-- 1GB RAM
+- 1-2GB RAM
+- Swap enabled for the container
 
 Minimum:
 - 1 CPU
 - 512MB RAM
 
-**Note:** You'll need to deactivate some services like ClamAV to be able to run on a host with 512MB of RAM.
+**Note:** You'll need to deactivate some services like ClamAV to be able to run on a host with 512MB of RAM. Even with 1G RAM you may run into problems without swap, see FAQ.
 
 ## Usage
 

--- a/env-mailserver.dist
+++ b/env-mailserver.dist
@@ -34,7 +34,7 @@ TLS_LEVEL=
 
 # Configures the handling of creating mails with forged sender addresses.
 #
-# empty => (not recommended, but default for backwards compatability reasons)
+# empty => (not recommended, but default for backwards compatibility reasons)
 #           Mail address spoofing allowed. Any logged in user may create email messages with a forged sender address.
 #           See also https://en.wikipedia.org/wiki/Email_spoofing
 # 1 => (recommended) Mail spoofing denied. Each user may only send with his own or his alias addresses.

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,8 @@
+#!/bin/sh
+VCS_REF=$(git rev-parse --short HEAD)
+VCS_VERSION=$(git describe)
+
+docker build \
+	--build-arg VCS_REF="$VCS_REF" \
+	--build-arg VCS_VERSION="$VCS_VERSION" \
+	-f "$DOCKERFILE_PATH" -t "$IMAGE_NAME" .

--- a/target/check-for-changes.sh
+++ b/target/check-for-changes.sh
@@ -126,15 +126,7 @@ if [[ $chksum == *"FAIL"* ]]; then
 			# Example :
 			# ${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::userdb_mail=maildir:/var/mail/${domain}/${user}
 			echo "${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::" >> /etc/dovecot/userdb
-			mkdir -p /var/mail/${domain}
-			if [ ! -d "/var/mail/${domain}/${user}" ]; then
-				maildirmake.dovecot "/var/mail/${domain}/${user}"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Sent"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Trash"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Drafts"
-				echo -e "INBOX\nSent\nTrash\nDrafts" >> "/var/mail/${domain}/${user}/subscriptions"
-				touch "/var/mail/${domain}/${user}/.Sent/maildirfolder"
-			fi
+			mkdir -p /var/mail/${domain}/${user}
 			# Copy user provided sieve file, if present
 			test -e /tmp/docker-mailserver/${login}.dovecot.sieve && cp /tmp/docker-mailserver/${login}.dovecot.sieve /var/mail/${domain}/${user}/.dovecot.sieve
 			echo ${domain} >> /tmp/vhost.tmp

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -631,15 +631,7 @@ function _setup_dovecot_local_user() {
 			# Example :
 			# ${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::userdb_mail=maildir:/var/mail/${domain}/${user}
 			echo "${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::" >> /etc/dovecot/userdb
-			mkdir -p /var/mail/${domain}
-			if [ ! -d "/var/mail/${domain}/${user}" ]; then
-				maildirmake.dovecot "/var/mail/${domain}/${user}"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Sent"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Trash"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Drafts"
-				echo -e "INBOX\nSent\nTrash\nDrafts" >> "/var/mail/${domain}/${user}/subscriptions"
-				touch "/var/mail/${domain}/${user}/.Sent/maildirfolder"
-			fi
+			mkdir -p /var/mail/${domain}/${user}
 			# Copy user provided sieve file, if present
 			test -e /tmp/docker-mailserver/${login}.dovecot.sieve && cp /tmp/docker-mailserver/${login}.dovecot.sieve /var/mail/${domain}/${user}/.dovecot.sieve
 			echo ${domain} >> /tmp/vhost.tmp

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -90,6 +90,7 @@ function register_functions() {
 	################### >> setup funcs
 
 	_register_setup_function "_setup_default_vars"
+	_register_setup_function "_setup_file_permissions"
 
 	if [ "$ENABLE_ELK_FORWARDER" = 1 ]; then
 		_register_setup_function "_setup_elk_forwarder"
@@ -470,6 +471,26 @@ function _setup_default_vars() {
 		[ $? != 0 ] && notify 'err' "Unable to set $var=${DEFAULT_VARS[$var]}" && kill -15 `cat /var/run/supervisord.pid` && return 1
 		notify 'inf' "Set $var=${DEFAULT_VARS[$var]}"
 	done
+}
+
+# File/folder permissions are fine when using docker volumes, but may be wrong
+# when file system folders are mounted into the container.
+# Set the expected values and create missing folders/files just in case.
+function _setup_file_permissions() {
+	notify 'task' "Setting file/folder permissions"
+
+	mkdir -p /var/log/supervisor
+
+	mkdir -p /var/log/mail
+	chown syslog:root /var/log/mail
+
+	touch /var/log/mail/clamav.log
+	chown clamav:adm /var/log/mail/clamav.log
+	chmod 640 /var/log/mail/clamav.log
+
+	touch /var/log/mail/freshclam.log
+	chown clamav:adm /var/log/mail/freshclam.log
+	chmod 640 /var/log/mail/freshclam.log
 }
 
 function _setup_chksum_file() {

--- a/test/mail_special_use_folders.bats
+++ b/test/mail_special_use_folders.bats
@@ -1,0 +1,56 @@
+load 'test_helper/common'
+
+setup() {
+    run_setup_file_if_necessary
+}
+
+teardown() {
+    run_teardown_file_if_necessary
+}
+
+setup_file() {
+    docker run -d --name mail_special_use_folders \
+		-v "`pwd`/test/config":/tmp/docker-mailserver \
+		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
+                -e SASL_PASSWD="external-domain.com username:password" \
+                -e ENABLE_CLAMAV=0 \
+                -e ENABLE_SPAMASSASSIN=0 \
+                --cap-add=SYS_PTRACE \
+                -e PERMIT_DOCKER=host \
+                -e DMS_DEBUG=0 \
+                -h mail.my-domain.com -t ${NAME}
+    wait_for_smtp_port_in_container mail_special_use_folders
+}
+
+teardown_file() {
+    docker rm -f mail_special_use_folders
+}
+
+@test "first" {
+    skip 'only used to call setup_file from setup'
+}
+
+
+@test "checking normal delivery" {
+  run docker exec mail_special_use_folders /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user1.txt"
+  assert_success
+
+  repeat_until_success_or_timeout 30 docker exec mail_special_use_folders /bin/sh -c '[ $(ls /var/mail/localhost.localdomain/user1/new | wc -l) -eq 1 ]'
+}
+
+@test "checking special-use folders not yet created" {
+  run docker exec mail_special_use_folders /bin/bash -c "ls -A /var/mail/localhost.localdomain/user1 | grep -E '.Drafts|.Sent|.Trash' | wc -l"
+  assert_success
+  assert_output 0
+}
+
+@test "checking special-use folders available in IMAP" {
+  run docker exec mail_special_use_folders /bin/sh -c "nc -w 8 0.0.0.0 143 < /tmp/docker-mailserver-test/nc_templates/imap_special_use_folders.txt | grep -E 'Drafts|Junk|Trash|Sent' | wc -l"
+  assert_success
+  assert_output 4
+}
+
+
+@test "last" {
+    skip 'only used to call teardown_file from teardown'
+}

--- a/test/mail_with_ldap.bats
+++ b/test/mail_with_ldap.bats
@@ -10,7 +10,7 @@ function teardown() {
 
 function setup_file() {
     pushd test/docker-openldap/
-    docker build -f Dockerfile -t ldap $DOCKER_MAIL_DOCKER_BUILD_NO_CACHE .
+    docker build -f Dockerfile -t ldap --no-cache .
     popd
 
     docker run -d --name ldap_for_mail \

--- a/test/test-files/nc_templates/imap_special_use_folders.txt
+++ b/test/test-files/nc_templates/imap_special_use_folders.txt
@@ -1,0 +1,3 @@
+a1 LOGIN user1@localhost.localdomain mypassword
+a2 LIST "" "*"
+a3 LOGOUT

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -294,22 +294,19 @@ function count_processed_changes() {
   [ "${lines[2]}" = "added@localhost.localdomain" ]
 }
 
-@test "checking accounts: user mail folders for user1" {
-  run docker exec mail /bin/bash -c "ls -A /var/mail/localhost.localdomain/user1 | grep -E '.Drafts|.Sent|.Trash|cur|new|subscriptions|tmp' | wc -l"
+@test "checking accounts: user mail folder for user1" {
+  run docker exec mail /bin/bash -c "ls -d /var/mail/localhost.localdomain/user1"
   assert_success
-  assert_output 7
 }
 
-@test "checking accounts: user mail folders for user2" {
-  run docker exec mail /bin/bash -c "ls -A /var/mail/otherdomain.tld/user2 | grep -E '.Drafts|.Sent|.Trash|cur|new|subscriptions|tmp' | wc -l"
+@test "checking accounts: user mail folder for user2" {
+  run docker exec mail /bin/bash -c "ls -d /var/mail/otherdomain.tld/user2"
   assert_success
-  assert_output 7
 }
 
-@test "checking accounts: user mail folders for added user" {
-  run docker exec mail /bin/bash -c "ls -A /var/mail/localhost.localdomain/added | grep -E '.Drafts|.Sent|.Trash|cur|new|subscriptions|tmp' | wc -l"
+@test "checking accounts: user mail folder for added user" {
+  run docker exec mail /bin/bash -c "ls -d /var/mail/localhost.localdomain/added"
   assert_success
-  assert_output 7
 }
 
 @test "checking accounts: comments are not parsed" {


### PR DESCRIPTION
According to Dovecot configuration `/etc/dovecot/conf.d/15-mailboxes.conf`
`Drafts`, `Junk`, `Trash` and `Sent` folders will be created on the fly (reference documentation: https://wiki.dovecot.org/MailboxSettings)