### PR TITLE
Add a hint to run make clean all

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ The development workflow is the following:
 - Run `git submodule init` and `git submodule update` to get the BATS submodules
 - Code :-)
 - Add integration tests in `test/tests.bats`
-- Use `make` to build image locally and run tests
+- Use `make clean all` to build image locally and run tests
   Note that tests work on Linux only; they hang on Mac and Windows.
 - Document your improvements in `README.md` or Wiki depending on content
 - [Commit](https://help.github.com/articles/closing-issues-via-commit-messages/), push and make a pull-request


### PR DESCRIPTION
If developers only run make when there is a test failure the clean may not run, so 'make clean all' should be the safe mode to run the tests.

I got several name conflicts for /mail before i discovered that i need to call `make clean` after a failed build / test.

This is one of the errors i got:
```
# Run containers
docker run --rm -d --name mail \
	-v "`pwd`/test/config":/tmp/docker-mailserver \
	-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
	-v "`pwd`/test/onedir":/var/mail-state \
	-e ENABLE_CLAMAV=1 \
	-e SPOOF_PROTECTION=1 \
	-e ENABLE_SPAMASSASSIN=1 \
	-e REPORT_RECIPIENT=user1@localhost.localdomain \
	-e REPORT_SENDER=report1@mail.my-domain.com \
	-e SA_TAG=-5.0 \
	-e SA_TAG2=2.0 \
	-e SA_KILL=3.0 \
	-e SA_SPAM_SUBJECT="SPAM: " \
	-e VIRUSMAILS_DELETE_DELAY=7 \
	-e ENABLE_SRS=1 \
	-e SASL_PASSWD="external-domain.com username:password" \
	-e ENABLE_MANAGESIEVE=1 \
	--cap-add=SYS_PTRACE \
	-e PERMIT_DOCKER=host \
	-e DMS_DEBUG=0 \
	-h mail.my-domain.com -t tvial/docker-mailserver:testing
docker: Error response from daemon: Conflict. The container name "/mail" is already in use by container "24d109c834e0ac1056cd3eba54e1a48f412a10019b59a7512fa15abbd5d1b98d". You have to remove (or rename) that container to be able to reuse that name.
```