### PR TITLE
Removing unnecessary maildir folders creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,6 @@ generate-accounts-after-run:
 fixtures:
 	# Setup sieve & create filtering folder (INBOX/spam)
 	docker cp "`pwd`/test/config/sieve/dovecot.sieve" mail:/var/mail/localhost.localdomain/user1/.dovecot.sieve
-	docker exec mail /bin/sh -c "maildirmake.dovecot /var/mail/localhost.localdomain/user1/.INBOX.spam"
-	docker exec mail /bin/sh -c "chown 5000:5000 -R /var/mail/localhost.localdomain/user1/.INBOX.spam"
 	sleep 30
 	# Sending test mails
 	docker exec mail /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/amavis-spam.txt"

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ generate-accounts-after-run:
 	sleep 10
 
 fixtures:
-	# Setup sieve & create filtering folder (INBOX/spam)
+	# Setup sieve
 	docker cp "`pwd`/test/config/sieve/dovecot.sieve" mail:/var/mail/localhost.localdomain/user1/.dovecot.sieve
 	sleep 30
 	# Sending test mails

--- a/target/check-for-changes.sh
+++ b/target/check-for-changes.sh
@@ -126,15 +126,7 @@ if [[ $chksum == *"FAIL"* ]]; then
 			# Example :
 			# ${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::userdb_mail=maildir:/var/mail/${domain}/${user}
 			echo "${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::" >> /etc/dovecot/userdb
-			mkdir -p /var/mail/${domain}
-			if [ ! -d "/var/mail/${domain}/${user}" ]; then
-				maildirmake.dovecot "/var/mail/${domain}/${user}"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Sent"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Trash"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Drafts"
-				echo -e "INBOX\nSent\nTrash\nDrafts" >> "/var/mail/${domain}/${user}/subscriptions"
-				touch "/var/mail/${domain}/${user}/.Sent/maildirfolder"
-			fi
+			mkdir -p /var/mail/${domain}/${user}
 			# Copy user provided sieve file, if present
 			test -e /tmp/docker-mailserver/${login}.dovecot.sieve && cp /tmp/docker-mailserver/${login}.dovecot.sieve /var/mail/${domain}/${user}/.dovecot.sieve
 			echo ${domain} >> /tmp/vhost.tmp

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -652,15 +652,7 @@ function _setup_dovecot_local_user() {
 			# Example :
 			# ${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::userdb_mail=maildir:/var/mail/${domain}/${user}
 			echo "${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::" >> /etc/dovecot/userdb
-			mkdir -p /var/mail/${domain}
-			if [ ! -d "/var/mail/${domain}/${user}" ]; then
-				maildirmake.dovecot "/var/mail/${domain}/${user}"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Sent"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Trash"
-				maildirmake.dovecot "/var/mail/${domain}/${user}/.Drafts"
-				echo -e "INBOX\nSent\nTrash\nDrafts" >> "/var/mail/${domain}/${user}/subscriptions"
-				touch "/var/mail/${domain}/${user}/.Sent/maildirfolder"
-			fi
+			mkdir -p /var/mail/${domain}/${user}
 			# Copy user provided sieve file, if present
 			test -e /tmp/docker-mailserver/${login}.dovecot.sieve && cp /tmp/docker-mailserver/${login}.dovecot.sieve /var/mail/${domain}/${user}/.dovecot.sieve
 			echo ${domain} >> /tmp/vhost.tmp

--- a/test/mail_special_use_folders.bats
+++ b/test/mail_special_use_folders.bats
@@ -1,0 +1,56 @@
+load 'test_helper/common'
+
+setup() {
+    run_setup_file_if_necessary
+}
+
+teardown() {
+    run_teardown_file_if_necessary
+}
+
+setup_file() {
+    docker run -d --name mail_special_use_folders \
+		-v "`pwd`/test/config":/tmp/docker-mailserver \
+		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
+                -e SASL_PASSWD="external-domain.com username:password" \
+                -e ENABLE_CLAMAV=0 \
+                -e ENABLE_SPAMASSASSIN=0 \
+                --cap-add=SYS_PTRACE \
+                -e PERMIT_DOCKER=host \
+                -e DMS_DEBUG=0 \
+                -h mail.my-domain.com -t ${NAME}
+    wait_for_smtp_port_in_container mail_special_use_folders
+}
+
+teardown_file() {
+    docker rm -f mail_special_use_folders
+}
+
+@test "first" {
+    skip 'only used to call setup_file from setup'
+}
+
+
+@test "checking normal delivery" {
+  run docker exec mail_special_use_folders /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/existing-user1.txt"
+  assert_success
+
+  repeat_until_success_or_timeout 30 docker exec mail_special_use_folders /bin/sh -c '[ $(ls /var/mail/localhost.localdomain/user1/new | wc -l) -eq 1 ]'
+}
+
+@test "checking special-use folders not yet created" {
+  run docker exec mail_special_use_folders /bin/bash -c "ls -A /var/mail/localhost.localdomain/user1 | grep -E '.Drafts|.Sent|.Trash' | wc -l"
+  assert_success
+  assert_output 0
+}
+
+@test "checking special-use folders available in IMAP" {
+  run docker exec mail_special_use_folders /bin/sh -c "nc -w 8 0.0.0.0 143 < /tmp/docker-mailserver-test/nc_templates/imap_special_use_folders.txt | grep -E 'Drafts|Junk|Trash|Sent' | wc -l"
+  assert_success
+  assert_output 4
+}
+
+
+@test "last" {
+    skip 'only used to call teardown_file from teardown'
+}

--- a/test/test-files/nc_templates/imap_special_use_folders.txt
+++ b/test/test-files/nc_templates/imap_special_use_folders.txt
@@ -1,0 +1,3 @@
+a1 LOGIN user1@localhost.localdomain mypassword
+a2 LIST "" "*"
+a3 LOGOUT

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -294,22 +294,19 @@ function count_processed_changes() {
   [ "${lines[2]}" = "added@localhost.localdomain" ]
 }
 
-@test "checking accounts: user mail folders for user1" {
-  run docker exec mail /bin/bash -c "ls -A /var/mail/localhost.localdomain/user1 | grep -E '.Drafts|.Sent|.Trash|cur|new|subscriptions|tmp' | wc -l"
+@test "checking accounts: user mail folder for user1" {
+  run docker exec mail /bin/bash -c "ls -d /var/mail/localhost.localdomain/user1"
   assert_success
-  assert_output 7
 }
 
-@test "checking accounts: user mail folders for user2" {
-  run docker exec mail /bin/bash -c "ls -A /var/mail/otherdomain.tld/user2 | grep -E '.Drafts|.Sent|.Trash|cur|new|subscriptions|tmp' | wc -l"
+@test "checking accounts: user mail folder for user2" {
+  run docker exec mail /bin/bash -c "ls -d /var/mail/otherdomain.tld/user2"
   assert_success
-  assert_output 7
 }
 
-@test "checking accounts: user mail folders for added user" {
-  run docker exec mail /bin/bash -c "ls -A /var/mail/localhost.localdomain/added | grep -E '.Drafts|.Sent|.Trash|cur|new|subscriptions|tmp' | wc -l"
+@test "checking accounts: user mail folder for added user" {
+  run docker exec mail /bin/bash -c "ls -d /var/mail/localhost.localdomain/added"
   assert_success
-  assert_output 7
 }
 
 @test "checking accounts: comments are not parsed" {


### PR DESCRIPTION
Test added. See PR #1297

_According to Dovecot configuration /etc/dovecot/conf.d/15-mailboxes.conf
Drafts, Junk, Trash and Sent folders will be created on the fly (reference documentation: https://wiki.dovecot.org/MailboxSettings)_