### PR TITLE
fix: dont use TTY in docker if not present, rem TTY necessity in tests

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -98,10 +98,14 @@ _docker_image_exists() {
   fi
 }
 
+if [ -t 1 ] ; then
+  USE_TTY="-ti"
+fi
+
 _docker_image() {
   if [ "$USE_CONTAINER" = true ]; then
     # Reuse existing container specified on command line
-    docker exec -ti "$CONTAINER_NAME" "$@"
+    docker exec ${USE_TTY} "$CONTAINER_NAME" "$@"
   else
     # Start temporary container with specified image
     if ! _docker_image_exists "$IMAGE_NAME"; then
@@ -112,13 +116,13 @@ _docker_image() {
     docker run \
       --rm \
       -v "$CONFIG_PATH":/tmp/docker-mailserver \
-      -ti "$IMAGE_NAME" $@
+      ${USE_TTY} "$IMAGE_NAME" $@
   fi
 }
 
 _docker_container() {
   if [ -n "$CONTAINER_NAME" ]; then
-    docker exec -ti "$CONTAINER_NAME" "$@"
+    docker exec ${USE_TTY} "$CONTAINER_NAME" "$@"
   else
     echo "The docker-mailserver is not running!"
     exit 1
@@ -273,7 +277,7 @@ case $1 in
         ;;
       login)
         shift
-	if [ -z "$1" ]; then
+        if [ -z "$1" ]; then
           _docker_container /bin/bash
         else
           _docker_container /bin/bash -c "$@"

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -701,13 +701,13 @@ function count_processed_changes() {
 }
 
 @test "checking amavis: VIRUSMAILS_DELETE_DELAY override works as expected" {
-  run docker run -ti --rm -e VIRUSMAILS_DELETE_DELAY=2 `docker inspect --format '{{ .Config.Image }}' mail` /bin/bash -c 'echo $VIRUSMAILS_DELETE_DELAY | grep 2'
+  run docker run --rm -e VIRUSMAILS_DELETE_DELAY=2 `docker inspect --format '{{ .Config.Image }}' mail` /bin/bash -c 'echo $VIRUSMAILS_DELETE_DELAY | grep 2'
   assert_success
 }
 
 @test "checking amavis: old virusmail is wipped by cron" {
   docker exec mail bash -c 'touch -d "`date --date=2000-01-01`" /var/lib/amavis/virusmails/should-be-deleted'
-  run docker exec -ti mail bash -c '/usr/local/bin/virus-wiper'
+  run docker exec mail bash -c '/usr/local/bin/virus-wiper'
   assert_success
   run docker exec mail bash -c 'ls -la /var/lib/amavis/virusmails/ | grep should-be-deleted'
   assert_failure
@@ -715,7 +715,7 @@ function count_processed_changes() {
 
 @test "checking amavis: recent virusmail is not wipped by cron" {
   docker exec mail bash -c 'touch -d "`date`"  /var/lib/amavis/virusmails/should-not-be-deleted'
-  run docker exec -ti mail bash -c '/usr/local/bin/virus-wiper'
+  run docker exec mail bash -c '/usr/local/bin/virus-wiper'
   assert_success
   run docker exec mail bash -c 'ls -la /var/lib/amavis/virusmails/ | grep should-not-be-deleted'
   assert_success


### PR DESCRIPTION
When running tests in Gitlab CI they fail because currently docker commands are hardcoded with `-ti` argument. This gives the following errors:
```
not ok 182 checking amavis: VIRUSMAILS_DELETE_DELAY override works as expected
# (from function `assert_success' in file test/test_helper/bats-assert/src/assert.bash, line 114,
#  in test file test/tests.bats, line 705)
#   `assert_success' failed
# 
# -- command failed --
# status : 1
# output : the input device is not a TTY
# --
# 
not ok 183 checking amavis: old virusmail is wipped by cron
# (from function `assert_success' in file test/test_helper/bats-assert/src/assert.bash, line 114,
#  in test file test/tests.bats, line 711)
#   `assert_success' failed
# 
# -- command failed --
# status : 1
# output : the input device is not a TTY
# --
# 
not ok 184 checking amavis: recent virusmail is not wipped by cron
# (from function `assert_success' in file test/test_helper/bats-assert/src/assert.bash, line 114,
#  in test file test/tests.bats, line 719)
#   `assert_success' failed
# 
# -- command failed --
# status : 1
# output : the input device is not a TTY
# --
# 
```

This fix only passes `-ti` if a TTY was detected in setup.sh and skips the `-ti` in the failing tests where it is not necessary.

Info @wt-io-it