### PR TITLE
fix: fix test setup.sh debug fetchmail on wildcard domains

### DIFF
--- a/test/config/fetchmail.cf
+++ b/test/config/fetchmail.cf
@@ -1,4 +1,4 @@
-poll pop3.example.com with proto POP3
+poll pop3.example.com. with proto POP3
 	user 'username' there with
 	password 'secret'
 	is 'user2@domain.tld'

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1086,8 +1086,7 @@ function count_processed_changes() {
 @test "checking setup.sh: setup.sh debug fetchmail" {
   run ./setup.sh -c mail debug fetchmail
   [ "$status" -eq 11 ]
-# TODO: Fix output check
-# [ "$output" = "fetchmail: no mailservers have been specified." ]
+  [[ "$output" == *"fetchmail: normal termination, status 11"* ]]
 }
 @test "checking setup.sh: setup.sh debug inspect" {
   run ./setup.sh -c mail debug inspect


### PR DESCRIPTION
on hosts that belong to wildcard domains pop3.example.com might
 actually resolve to pop3.example.com.[mydomain.com] and give a valid ip
 the return code of fetchmail then no longer is 11 (dns failure) but
 something else (2 for socket error in our case)

to make sure we always get return code 11 we use the domain name
pop3.example.com. that is not allowed to be resolved to a subdomain.

Info @wt-io-it