### PR TITLE
Allow to configure SRS sender classes easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,18 @@ Note: This postgrey setting needs `ENABLE_POSTGREY=1`
 
 ## SRS (Sender Rewriting Scheme)
 
+##### SRS_SENDER_CLASSES
+
+An email has an "envelope" sender (indicating the sending server) and a
+"header" sender (indicating who sent it). More strict SPF policies may require
+you to replace both instead of just the envelope sender.
+
+[More info](https://www.mybluelinux.com/what-is-email-envelope-and-email-header/).
+
+  - **envelope_sender** => Rewrite only envelope sender address
+  - header_sender => Rewrite only header sender (not recommended)
+  - envelope_sender,header_sender => Rewrite both senders
+
 ##### SRS_EXCLUDE_DOMAINS
 
   - **empty** => Envelope sender will be rewritten for all domains

--- a/env-mailserver.dist
+++ b/env-mailserver.dist
@@ -294,6 +294,14 @@ SASL_PASSWD=
 # ---------------- SRS section --------------------------------------------------------------------------------------------
 # -----------------------------------------------------------------------------------------------------------------------------
 
+# envelope_sender => Rewrite only envelope sender address (default)
+# header_sender => Rewrite only header sender (not recommended)
+# envelope_sender,header_sender => Rewrite both senders
+# An email has an "envelope" sender (indicating the sending server) and a
+# "header" sender (indicating who sent it). More strict SPF policies may require
+# you to replace both instead of just the envelope sender.
+SRS_SENDER_CLASSES=envelope_sender
+
 # empty => Envelope sender will be rewritten for all domains
 # provide comma separated list of domains to exclude from rewriting
 SRS_EXCLUDE_DOMAINS=

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -33,6 +33,7 @@ DEFAULT_VARS["POSTSCREEN_ACTION"]="${POSTSCREEN_ACTION:="enforce"}"
 DEFAULT_VARS["SPOOF_PROTECTION"]="${SPOOF_PROTECTION:="0"}"
 DEFAULT_VARS["TLS_LEVEL"]="${TLS_LEVEL:="modern"}"
 DEFAULT_VARS["ENABLE_SRS"]="${ENABLE_SRS:="0"}"
+DEFAULT_VARS["SRS_SENDER_CLASSES"]="${SRS_SENDER_CLASSES:="envelope_sender"}"
 DEFAULT_VARS["REPORT_RECIPIENT"]="${REPORT_RECIPIENT:="0"}"
 DEFAULT_VARS["LOGROTATE_INTERVAL"]="${LOGROTATE_INTERVAL:=${REPORT_INTERVAL:-"daily"}}"
 DEFAULT_VARS["LOGWATCH_INTERVAL"]="${LOGWATCH_INTERVAL:="none"}"
@@ -906,7 +907,7 @@ function _setup_postfix_aliases() {
 function _setup_SRS() {
 	notify 'task' 'Setting up SRS'
 	postconf -e "sender_canonical_maps = tcp:localhost:10001"
-	postconf -e "sender_canonical_classes = envelope_sender"
+	postconf -e "sender_canonical_classes = $SRS_SENDER_CLASSES"
 	postconf -e "recipient_canonical_maps = tcp:localhost:10002"
 	postconf -e "recipient_canonical_classes = envelope_recipient,header_recipient"
 }


### PR DESCRIPTION
This will allow to forward safely any email from any host, no matter how strict their SPF policy is, by setting `SRS_SENDER_CLASSES=envelope_sender,header_sender`.

@Tecnativa TT20505