### PR TITLE
Add documentation example for Goolgle Mail users

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Download the docker-compose.yml, the .env and the setup.sh files:
 #### Create your mail accounts
 
     ./setup.sh email add <user@domain> [<password>]
+    
+#### GMail aliases for mail accounts (in case you encounter error 550 5.1.1)
+
+    ./setup.sh alias add <user@domain> <user>
 
 #### Generate DKIM keys
 


### PR DESCRIPTION
Added command which helps people to work with GMail servers properly (If you compose email using Web client, it uses and alias for your email address, <user>, not FQDN in form <user@domain>)