### PR TITLE
Remove lower-case check for postfix-main.cf

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1152,11 +1152,7 @@ function _setup_postfix_override_configuration() {
 
 	if [ -f /tmp/docker-mailserver/postfix-main.cf ]; then
 		while read line; do
-		# all valid postfix options start with a lower case letter
-		# http://www.postfix.org/postconf.5.html
-		if [[ "$line" =~ ^[a-z] ]]; then
-			postconf -e "$line"
-		fi
+		postconf -e "$line"
 		done < /tmp/docker-mailserver/postfix-main.cf
 		notify 'inf' "Loaded 'config/postfix-main.cf'"
 	else


### PR DESCRIPTION
The check excludes any line with uppercase letters, such as cipher lines. Remove it because it is pretty rudimentary anyways.

I tried to add the following config line by using postfix-main.cf:
smtpd_tls_exclude_ciphers = aNULL,MD5,DES,3DES
It does not get applied because it fails the regex check.