### PR TITLE
Add executable flag for scripts in /usr/lib/dovecot/sieve-pipe

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -630,7 +630,7 @@ function _setup_dovecot() {
 	fi
 	chown docker:docker -R /usr/lib/dovecot/sieve*
 	chmod 550 -R /usr/lib/dovecot/sieve*
-	chmod +x /usr/lib/dovecot/sieve-pipe/*
+	chmod -f +x /usr/lib/dovecot/sieve-pipe/*
 }
 
 function _setup_dovecot_local_user() {

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -630,6 +630,7 @@ function _setup_dovecot() {
 	fi
 	chown docker:docker -R /usr/lib/dovecot/sieve*
 	chmod 550 -R /usr/lib/dovecot/sieve*
+	chmod +x /usr/lib/dovecot/sieve-pipe/*
 }
 
 function _setup_dovecot_local_user() {


### PR DESCRIPTION
Fixes missing executable permissions for sieve-pipe scripts (see #1376).