### PR TITLE
Fix broken fail2ban dovecot filter; use <HOST>.

### DIFF
--- a/target/fail2ban/filter.d/dovecot.conf
+++ b/target/fail2ban/filter.d/dovecot.conf
@@ -10,7 +10,7 @@ failregex = ^%(__prefix_line)s(pam_unix(\(dovecot:auth\))?:)?\s+authentication f
             ^%(__prefix_line)s(pop3|imap)-login: (Info: )?(Aborted login|Disconnected)(: Inactivity)? \(((no auth attempts|auth failed, \d+ attempts)( in \d+ secs)?|tried to use (disabled|disallowed) \S+ auth)\):( user=<\S*>,)?( method=\S+,)? rip=<HOST>, lip=(\d{1,3}\.){3}\d{1,3}(, session=<\w+>)?(, TLS( handshaking)?(: Disconnected)?)?\s*$
             ^%(__prefix_line)s(Info|dovecot: auth\(default\)): pam\(\S+,<HOST>\): pam_authenticate\(\) failed: (User not known to the underlying authentication module: \d+ Time\(s\)|Authentication failure \(password mismatch\?\))\s*$
             ^\s.*passwd-file\(\S*,<HOST>\): unknown user.*$
-            (?: pop3-login|imap-login): .*(?:Authentication failure|Aborted login \(auth failed|Aborted login \(tried to use disabled|Disconnected \(auth failed).*rip=(?P<host>\S*),.*
+            (?: pop3-login|imap-login): .*(?:Authentication failure|Aborted login \(auth failed|Aborted login \(tried to use disabled|Disconnected \(auth failed).*rip=(<HOST>),.*
 
 ## ^%(__prefix_line)spasswd-file\(\S*,<HOST>\): unknown user.*$
 ignoreregex =


### PR DESCRIPTION
* Replace deprecated, undocumented fail2ban feature ```(?P<host>S*)``` with
  supported host match ```<HOST>```.
* Fixes ```No failure-id group in '(?: pop3-login|ima ...``` fail2ban dovecot filter
  error message.
* See: https://github.com/fail2ban/fail2ban/issues/2130