### PR TITLE
Enabling Multi-Domain-Support in saslauthd

### DIFF
--- a/target/supervisor/conf.d/saslauth.conf
+++ b/target/supervisor/conf.d/saslauth.conf
@@ -4,7 +4,7 @@ autostart=false
 autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
-command=/usr/sbin/saslauthd -d -a ldap -O /etc/saslauthd.conf
+command=/usr/sbin/saslauthd -dr -a ldap -O /etc/saslauthd.conf
 pidfile=/var/run/saslauthd/saslauthd.pid
 
 [program:saslauthd_mysql]


### PR DESCRIPTION
Enabling Multi-Domain-Support.
! Needs to be mentioned in "README.md" as an important change! -> users won't be able to just use "username" anymore.

-> Combine the realm with the login (with an '@' sign in between). e.g. login: "foo" realm: "bar" will get passed as login: "foo@bar".