### PR TITLE
Allow calling setup.sh from other scripts

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -127,7 +127,7 @@ _docker_image_exists() {
   fi
 }
 
-if [ -t 1 ] ; then
+if tty -s ; then
   USE_TTY="-ti"
 fi
 


### PR DESCRIPTION
Calling setup.sh from other scripts fails, for example when adding a new mailbox:

    the input device is not a TTY