### PR TITLE
Allow to set comfortably inet_protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ Set different options for mynetworks option (can be overwrite in postfix-main.cf
   - network => Add the docker default bridge network (172.16.0.0/12); **WARNING**: `docker-compose` might use others (e.g. 192.168.0.0/16) use `PERMIT_DOCKER=connected-networks` in this case
   - connected-networks => Add all connected docker networks (ipv4 only)
 
+Note: you probably want to [set `POSTFIX_INET_PROTOCOLS=ipv4`](#postfix_inet_protocols) to make it work fine with Docker.
+
 ##### VIRUSMAILS_DELETE_DELAY
 
 Set how many days a virusmail will stay on the server before being deleted
@@ -368,6 +370,14 @@ Set the message size limit for all users. If set to zero, the size will be unlim
   - mdbox ==> (experimental) uses Dovecot high-performance mailbox format, multiple messages per file and multiple files per box
 
 This option has been added in November 2019. Using other format than Maildir is considered as experimental in docker-mailserver and should only be used for testing purpose. For more details, please refer to [Dovecot Documentation](https://wiki2.dovecot.org/MailboxFormat).
+
+##### POSTFIX_INET_PROTOCOLS
+
+- **all** => All possible protocols.
+- ipv4 => Use only IPv4 traffic. Most likely you want this behind Docker.
+- ipv6 => Use only IPv6 traffic.
+
+Note: More details in http://www.postfix.org/postconf.5.html#inet_protocols
 
 ## Reports
 

--- a/env-mailserver.dist
+++ b/env-mailserver.dist
@@ -130,6 +130,14 @@ REPORT_SENDER=
 # Note: This Variable actually controls logrotate inside the container and rotates the log depending on this setting. The main log output is still available in its entirety via `docker logs mail` (Or your respective container name). If you want to control logrotation for the docker generated logfile see: [Docker Logging Drivers](https://docs.docker.com/config/containers/logging/configure/)
 REPORT_INTERVAL=daily
 
+# Choose TCP/IP protocols to use
+# **all** => All possible protocols.
+# ipv4 => Use only IPv4 traffic. Most likely you want this behind Docker.
+# ipv6 => Use only IPv6 traffic.
+#
+# Note: More details in http://www.postfix.org/postconf.5.html#inet_protocols
+POSTFIX_INET_PROTOCOLS=all
+
 # -----------------------------------------------------------------------------------------------------------------------------
 # --------------------- Spamassassin section ----------------------------------------------------------------------------------
 # -----------------------------------------------------------------------------------------------------------------------------

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -25,6 +25,7 @@ DEFAULT_VARS["POSTGREY_AUTO_WHITELIST_CLIENTS"]="${POSTGREY_AUTO_WHITELIST_CLIEN
 DEFAULT_VARS["POSTGREY_TEXT"]="${POSTGREY_TEXT:="Delayed by postgrey"}"
 DEFAULT_VARS["POSTFIX_MESSAGE_SIZE_LIMIT"]="${POSTFIX_MESSAGE_SIZE_LIMIT:="10240000"}"  # ~10 MB by default
 DEFAULT_VARS["POSTFIX_MAILBOX_SIZE_LIMIT"]="${POSTFIX_MAILBOX_SIZE_LIMIT:="0"}"        # no limit by default
+DEFAULT_VARS["POSTFIX_INET_PROTOCOLS"]="${POSTFIX_INET_PROTOCOLS:="all"}"
 DEFAULT_VARS["ENABLE_SASLAUTHD"]="${ENABLE_SASLAUTHD:="0"}"
 DEFAULT_VARS["SMTP_ONLY"]="${SMTP_ONLY:="0"}"
 DEFAULT_VARS["DMS_DEBUG"]="${DMS_DEBUG:="0"}"
@@ -118,6 +119,9 @@ function register_functions() {
 
 	_register_setup_function "_setup_dkim"
 	_register_setup_function "_setup_ssl"
+	if [ "$POSTFIX_INET_PROTOCOLS" != "all" ]; then
+    _register_setup_function "_setup_inet_protocols"
+  fi
 	_register_setup_function "_setup_docker_permit"
 
 	_register_setup_function "_setup_mailname"
@@ -175,7 +179,7 @@ function register_functions() {
 	if [ "$LOGWATCH_TRIGGER" != "none" ]; then
 		_register_setup_function "_setup_logwatch"
 	fi
-	
+
 	_register_setup_function "_setup_user_patches"
 
         # Compute last as the config files are modified in-place
@@ -1098,6 +1102,11 @@ function _setup_postfix_vhost() {
   elif [ ! -f /etc/postfix/vhost ]; then
     touch /etc/postfix/vhost
 	fi
+}
+
+function _setup_inet_protocols() {
+  notify 'task' 'Setting up POSTFIX_INET_PROTOCOLS option'
+  postconf -e "inet_protocols = $POSTFIX_INET_PROTOCOLS"
 }
 
 function _setup_docker_permit() {


### PR DESCRIPTION
Setting `inet_protocols = ipv4` is almost a requirement when running behind Docker. Provide a way to make it easy.

@Tecnativa TT22925