### PR TITLE
Add an option to place spam in the inbox, and then sort the mail by a sieve rule

### DIFF
--- a/env-mailserver.dist
+++ b/env-mailserver.dist
@@ -136,6 +136,9 @@ REPORT_INTERVAL=daily
 
 ENABLE_SPAMASSASSIN=0
 
+#If Enabled, SPAM goes to your inbox with added SPAM header, you can then move it to a specific SPAM folder with SIEVE rules
+SPAMASSASSIN_SPAM_TO_INBOX=0
+
 # add spam info headers if at, or above that level:
 SA_TAG=2.0
 

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -37,6 +37,7 @@ DEFAULT_VARS["SRS_SENDER_CLASSES"]="${SRS_SENDER_CLASSES:="envelope_sender"}"
 DEFAULT_VARS["REPORT_RECIPIENT"]="${REPORT_RECIPIENT:="0"}"
 DEFAULT_VARS["LOGROTATE_INTERVAL"]="${LOGROTATE_INTERVAL:=${REPORT_INTERVAL:-"daily"}}"
 DEFAULT_VARS["LOGWATCH_INTERVAL"]="${LOGWATCH_INTERVAL:="none"}"
+DEFAULT_VARS["SPAMASSASSIN_SPAM_TO_INBOX"]="${SPAMASSASSIN_SPAM_TO_INBOX:="0"}"
 DEFAULT_VARS["VIRUSMAILS_DELETE_DELAY"]="${VIRUSMAILS_DELETE_DELAY:="7"}"
 
 ##########################################################################
@@ -1402,6 +1403,23 @@ function _setup_security_stack() {
         fi
 
 		test -e /tmp/docker-mailserver/spamassassin-rules.cf && cp /tmp/docker-mailserver/spamassassin-rules.cf /etc/spamassassin/
+		
+		
+		if [ "$SPAMASSASSIN_SPAM_TO_INBOX" = "1" ]; then
+				notify 'inf' "Configure Spamassassin/Amavis to put SPAM inbox"
+				bannedbouncecheck=`egrep "final_banned_destiny.*D_BOUNCE" /etc/amavis/conf.d/20-debian_defaults`
+				  if [ -n "$bannedbouncecheck" ] ;
+						  then
+									   sed -i "/final_banned_destiny/ s|D_BOUNCE|D_REJECT|" /etc/amavis/conf.d/20-debian_defaults
+							fi
+							
+				finalbouncecheck=`egrep "final_spam_destiny.*D_BOUNCE" /etc/amavis/conf.d/20-debian_defaults`
+				  if [ -n "$finalbouncecheck" ] ;
+						  then
+									   sed -i "/final_spam_destiny/ s|D_BOUNCE|D_PASS|" /etc/amavis/conf.d/20-debian_defaults
+							fi
+		fi
+
 	fi
 
 	# Clamav


### PR DESCRIPTION
By default, spam is quarantined. However, many people want to be able to view missed SPAM. To do this, this pull request adds an option to place the spam in the inbox, after adding the Spamassassin headers, and then allows the user to sort it automatically as desired, for example, by automatically moving it to a specific SPAM folder with a SIEVE rule.

**This does not change the default operation**