### PR TITLE
Filebeat in its own container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,17 +119,6 @@ RUN \
   rm -f /etc/postsrsd.secret && \
   rm -f /etc/cron.daily/00logwatch
 
-# install filebeat for logging
-# SKIP and run in an external container instead
-#RUN curl https://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add - && \
-#  echo "deb http://packages.elastic.co/beats/apt stable main" | tee -a /etc/apt/sources.list.d/beats.list && \
-#  apt-get update -q --fix-missing && \
-#  apt-get -y install --no-install-recommends \
-#    filebeat \
-#  && apt-get clean \
-#  && rm -rf /var/lib/apt/lists/*
-#COPY target/filebeat.yml.tmpl /etc/filebeat/filebeat.yml.tmpl
-
 RUN echo "0 */6 * * * clamav /usr/bin/freshclam --quiet" > /etc/cron.d/clamav-freshclam && \
   chmod 644 /etc/clamav/freshclam.conf && \
   freshclam && \

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If you got any problems with SPF and/or forwarding mails, give [SRS](https://git
 
 Your config folder will be mounted in `/tmp/docker-mailserver/`. To understand how things work on boot, please have a look at [start-mailserver.sh](https://github.com/tomav/docker-mailserver/blob/master/target/start-mailserver.sh)
 
-`restart: always` ensures that the mail server container (and ELK container when using the mail server together with ELK stack) is automatically restarted by Docker in cases like a Docker service or host restart or container exit.
+`restart: always` ensures that the mail server container (and Filebeat/ELK containers when using the mail server together with ELK stack) is automatically restarted by Docker in cases like a Docker service or host restart or container exit.
 
 #### Exposed ports
 * 25 receiving email from other mailservers

--- a/config/filebeat.docker.yml
+++ b/config/filebeat.docker.yml
@@ -1,0 +1,16 @@
+filebeat.config:
+  modules:
+    path: ${path.config}/modules.d/*.yml
+    reload.enabled: false
+
+filebeat.autodiscover:
+  providers:
+    - type: docker
+      hints.enabled: true
+      hints.default_config.enabled: false
+
+processors:
+- add_cloud_metadata: ~
+
+output.logstash:
+    hosts: ["127.0.0.1:5044"]

--- a/docker-compose.filebeat.yml.dist
+++ b/docker-compose.filebeat.yml.dist
@@ -1,24 +1,22 @@
 version: '2'
-
 services:
   mail:
     image: tvial/docker-mailserver:latest
     hostname: ${HOSTNAME}
     domainname: ${DOMAINNAME}
     container_name: ${CONTAINER_NAME}
-    links:
-    - elk
-    labels:
-    - "co.elastic.logs/enabled=true"
-    - "co.elastic.logs/module=system"
-    - "co.elastic.logs/fileset.stdout=syslog"
     ports:
     - "25:25"
     - "143:143"
     - "587:587"
     - "993:993"
+    labels:
+    - "co.elastic.logs/enabled=true"
+    - "co.elastic.logs/module=system"
+    - "co.elastic.logs/fileset.stdout=syslog"
     volumes:
     - maildata:/var/mail
+    - mailstate:/var/mail-state
     - maillogs:/var/log/mail
     - ./config/:/tmp/docker-mailserver/
     env_file:
@@ -37,15 +35,6 @@ services:
     - /var/lib/docker/containers/:/var/lib/docker/containers/:ro
     command: ["filebeat", "-e", "--strict.perms=false"]
     restart: always
-  elk:
-     build: elk
-     ports:
-     - "5601:5601"
-     - "9200:9200"
-     - "5044:5044"
-     - "5000:5000"
-     restart: always
-
 volumes:
   maildata:
     driver: local

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -95,10 +95,6 @@ function register_functions() {
 	_register_setup_function "_setup_default_vars"
 	_register_setup_function "_setup_file_permissions"
 
-	if [ "$ENABLE_ELK_FORWARDER" = 1 ]; then
-		_register_setup_function "_setup_elk_forwarder"
-	fi
-
 	if [ "$SMTP_ONLY" != 1 ]; then
 		_register_setup_function "_setup_dovecot"
                 _register_setup_function "_setup_dovecot_dhparam"
@@ -207,10 +203,6 @@ function register_functions() {
 
 	_register_start_daemon "_start_daemons_cron"
 	_register_start_daemon "_start_daemons_rsyslog"
-
-	if [ "$ENABLE_ELK_FORWARDER" = 1 ]; then
-		_register_start_daemon "_start_daemons_filebeat"
-	fi
 
 	if [ "$SMTP_ONLY" != 1 ]; then
 		_register_start_daemon "_start_daemons_dovecot"
@@ -1452,18 +1444,6 @@ function _setup_security_stack() {
 	fi
 }
 
-function _setup_elk_forwarder() {
-	notify 'task' 'Setting up Elk forwarder'
-
-	ELK_PORT=${ELK_PORT:="5044"}
-	ELK_HOST=${ELK_HOST:="elk"}
-	notify 'inf' "Enabling log forwarding to ELK ($ELK_HOST:$ELK_PORT)"
-	cat /etc/filebeat/filebeat.yml.tmpl \
-		| sed "s@\$ELK_HOST@$ELK_HOST@g" \
-		| sed "s@\$ELK_PORT@$ELK_PORT@g" \
-		> /etc/filebeat/filebeat.yml
-}
-
 function _setup_logrotate() {
 	notify 'inf' "Setting up logrotate"
 
@@ -1748,11 +1728,6 @@ function _start_daemons_dovecot() {
 		#echo "Listing users"
 		#/usr/sbin/dovecot user '*'
 	#fi
-}
-
-function _start_daemons_filebeat() {
-	notify 'task' 'Starting filebeat' 'n'
-    supervisorctl start filebeat
 }
 
 function _start_daemons_fetchmail() {


### PR DESCRIPTION
### Implementation of Filebeat in its own container

Filebeat configuration is done through _Hints based autodiscover_ (following [Elastic](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html) practice).
Nevertheless, I have decided to change the default behavior (logs from all containers) in order to only log from mailserver (I guess some people can run other containers and do not want to push all the logs to filebeat).


**Filebeat with local ELK container:**
- `docker-compose.elk.yml.dist`: updated with the new filebeat container

**Filebeat forwarding to remote ELK:**
- `docker-compose.filebeat.yml.dist`: new file for those who only need filebeat (remote elk)
- `config/filebeat.docker.yml` to update with ELK server IP

Any references to filebeat previous implementation are removed.