### PR TITLE
amavis: fix config permission

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1440,7 +1440,7 @@ function _setup_security_stack() {
 	fi
 
 	echo "1;  # ensure a defined return" >> $dms_amavis_file
-
+	chmod 444 $dms_amavis_file
 
 	# Fail2ban
 	if [ "$ENABLE_FAIL2BAN" = 1 ]; then


### PR DESCRIPTION
When running docker-mailserver in [podman](https://podman.io) (which works nicely otherwise), I am getting this warning from amavis in my log:

```
2020-03-24 14:42:39,337 INFO spawned: 'amavis' with pid 1275
2020-03-24 14:42:40,339 INFO success: amavis entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
Mar 24 14:42:41 mail amavis[1275]: starting. /usr/sbin/amavisd-new at mail.**** amavisd-new-2.10.1 (20141025), Unicode aware
Mar 24 14:42:42 mail amavis[1275]: Net::Server: Group Not Defined.  Defaulting to EGID '111 111'
Mar 24 14:42:42 mail amavis[1275]: Net::Server: User Not Defined.  Defaulting to EUID '109'
Mar 24 14:42:42 mail amavis[1275]: (!!)FATAL: Config file "/etc/amavis/conf.d/61-dms_auto_generated" is writable, UID 109, EUID 109, EGID 111 111
Mar 24 14:42:42 mail amavis[1275]: (!!)TROUBLE in pre_loop_hook: SECURITY PROBLEM, ABORTING at /usr/sbin/amavisd-new line 12567.
2020-03-24 14:42:42,186 INFO exited: amavis (exit status 255; not expected)
```

It then restarts over and over. From what I gathered, the file should be read-only.
So doing `podman exec mail.service chmod 444 /etc/amavis/conf.d/61-dms_auto_generated` instantly fixed the problem and the server starts up without a problem.

From that I created this quick patch, which should hopefully fix this issue.
I have no idea, if this is a podman-specific thing or if it also happens in docker. But I guess it cannot cause any issues for docker installs.