### PR TITLE
Upgrade packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV SASLAUTHD_MECH_OPTIONS=""
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Packages
-# hadolint ignore=DL3015
+# hadolint ignore=DL3015,DL3005
 RUN \
   apt-get update -q --fix-missing && \
   apt-get -y upgrade && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3015
 RUN \
   apt-get update -q --fix-missing && \
+  apt-get -y upgrade && \
   apt-get -y install postfix && \
   apt-get -y install --no-install-recommends \
     altermime \


### PR DESCRIPTION
Some packages from the base image are upgradable. For example, that's the case for `libgnutls30` at the moment.