### PR TITLE
AllowSupplementaryGroups change removed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,6 @@ RUN echo "0 */6 * * * clamav /usr/bin/freshclam --quiet" > /etc/cron.d/clamav-fr
   chmod 644 /etc/clamav/freshclam.conf && \
   freshclam && \
   sed -i 's/Foreground false/Foreground true/g' /etc/clamav/clamd.conf && \
-  sed -i 's/AllowSupplementaryGroups false/AllowSupplementaryGroups true/g' /etc/clamav/clamd.conf && \
   mkdir /var/run/clamav && \
   chown -R clamav:root /var/run/clamav && \
   rm -rf /var/log/clamav/


### PR DESCRIPTION
1. "AllowSupplementaryGroups false" is no longer present in /etc/clamav/clamd.conf, therefore the command does not work anymore.
2. Since Clamd 0.100.0, "AllowSupplementaryGroups" is deprecated. See: https://blog.clamav.net/2018/04/clamav-01000-has-been-released.html

"Deprecation of the AllowSupplementaryGroups parameter statement in clamd, clamav-milter, and freshclam. Use of supplementary is now in effect by default."