### PR TITLE
chore: Remove obsolete postfix parameter `smtpd_use_tls`

### DIFF
--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -26,7 +26,10 @@ smtpd_tls_security_level = may
 smtpd_tls_loglevel = 1
 smtp_tls_security_level = may
 smtp_tls_loglevel = 1
+
+# Reduces CPU overhead with `NO_COMPRESSION`, SMTP not at risk of CRIME attack (see git blame for details)
 tls_ssl_options = NO_COMPRESSION
+
 tls_high_cipherlist = ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
 tls_preempt_cipherlist = yes
 smtpd_tls_protocols = !SSLv2,!SSLv3,!TLSv1,!TLSv1.1

--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -23,7 +23,6 @@ smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
 #smtpd_tls_CAfile=
 #smtp_tls_CAfile=
 smtpd_tls_security_level = may
-smtpd_use_tls=yes
 smtpd_tls_loglevel = 1
 smtp_tls_security_level = may
 smtp_tls_loglevel = 1


### PR DESCRIPTION
`smtpd_tls_security_level` has replaced this config parameter. `smtpd_use_tls` has no relevance in the config anymore.

See: http://www.postfix.org/postconf.5.html#smtpd_tls_security_level

> this overrides the obsolete parameters `smtpd_use_tls` and `smtpd_enforce_tls`.