### PR TITLE
Prevent sieve symlink to be evaluated as a directory by dovecot

### DIFF
--- a/target/dovecot/10-mail.conf
+++ b/target/dovecot/10-mail.conf
@@ -250,7 +250,12 @@ mail_plugins = $mail_plugins quota
 # This is done by stat()ing each entry, so it causes more disk I/O.
 # (For systems setting struct dirent->d_type, this check is free and it's
 # done always regardless of this setting)
-#maildir_stat_dirs = no
+# -------
+# tomav/docker-mailserver:
+# Seen dovecot-sieve is always enabled, setting `maildir_stat_dirs = yes` permits
+# to avoid  `/var/mail/domain.tld/user/.dovecot.sieve` (symlink) to be treated as a directory (default behavior).
+# According to https://github.com/Mailu/Mailu/issues/143#issuecomment-274596931, there is no noticeable impact when this is enabled.
+maildir_stat_dirs = yes
 
 # When copying a message, do it with hard links whenever possible. This makes
 # the performance much better, and it's unlikely to have any side effects.


### PR DESCRIPTION
Seen dovecot-sieve is always enabled, setting `maildir_stat_dirs = yes` permits to avoid  `/var/mail/domain.tld/user/.dovecot.sieve` (symlink) to be treated as a directory (default behavior).

According to https://github.com/Mailu/Mailu/issues/143#issuecomment-274596931, there is no noticeable impact when this is enabled.

An advanced user could eventually set `maildir_stat_dirs=no` in `config/dovecot.cf` if sieve is not used at all.

Fix https://github.com/tomav/docker-mailserver/issues/1480.