### PR TITLE
Updating SPAMASSASSIN_SPAM_TO_INBOX to support default amavis override

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1488,6 +1488,18 @@ function _setup_security_stack() {
 						  then
 									   sed -i "/final_spam_destiny/ s|D_BOUNCE|D_PASS|" /etc/amavis/conf.d/20-debian_defaults
 							fi
+              
+        finalbouncecheckOverride=`egrep "final_spam_destiny.*D_BOUNCE" /etc/amavis/conf.d/49-docker-mailserver`
+				  if [ -n "$finalbouncecheckOverride" ] ;
+						  then
+									   sed -i "/final_spam_destiny/ s|D_BOUNCE|D_PASS|" /etc/amavis/conf.d/49-docker-mailserver
+							fi
+              
+         finalbouncecheckUserOverride=`egrep "final_spam_destiny.*D_BOUNCE" /etc/amavis/conf.d/50-user`
+				  if [ -n "$finalbouncecheckUserOverride" ] ;
+						  then
+                     notify 'err' "If you want to override final_spam_destiny=D_BOUNCE in /etc/amavis/conf.d/50-user, you must set SPAMASSASSIN_SPAM_TO_INBOX=0, the SPAM will then be quarantined."
+							fi
 		fi
 
 	fi


### PR DESCRIPTION
Updating SPAMASSASSIN_SPAM_TO_INBOX to support the default overload in the amavis/conf.d/49-docker-mailserver file.
If the user decides to override this value, then an error message will be displayed during initialization to tell the user to make a choice.