### PR TITLE
Feature: Spam to Junk folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,6 +125,7 @@ RUN echo "0 */6 * * * clamav /usr/bin/freshclam --quiet" > /etc/cron.d/clamav-fr
 # Configures Dovecot
 COPY target/dovecot/auth-passwdfile.inc target/dovecot/??-*.conf /etc/dovecot/conf.d/
 COPY target/dovecot/scripts/quota-warning.sh /usr/local/bin/quota-warning.sh
+COPY target/dovecot/sieve/* /usr/lib/dovecot/sieve-global/
 WORKDIR /usr/share/dovecot
 # hadolint ignore=SC2016,SC2086
 RUN sed -i -e 's/include_try \/usr\/share\/dovecot\/protocols\.d/include_try \/etc\/dovecot\/protocols\.d/g' /etc/dovecot/dovecot.conf && \

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ services:
       - ./config/:/tmp/docker-mailserver/
     environment:
       - ENABLE_SPAMASSASSIN=1
+      - SPAMASSASSIN_SPAM_TO_INBOX=1
       - ENABLE_CLAMAV=1
       - ENABLE_FAIL2BAN=1
       - ENABLE_POSTGREY=1
@@ -202,6 +203,7 @@ services:
       - ./config/:/tmp/docker-mailserver/
     environment:
       - ENABLE_SPAMASSASSIN=1
+      - SPAMASSASSIN_SPAM_TO_INBOX=1
       - ENABLE_CLAMAV=1
       - ENABLE_FAIL2BAN=1
       - ENABLE_POSTGREY=1
@@ -483,8 +485,25 @@ Finally the logrotate interval **may** affect the period for generated reports. 
 
 ##### ENABLE_SPAMASSASSIN
 
+
   - **0** => Spamassassin is disabled
   - 1 => Spamassassin is enabled
+
+**/!\\ Spam delivery:** when Spamassassin is enabled, messages marked as spam WILL NOT BE DELIVERED. 
+Use `SPAMASSASSIN_SPAM_TO_INBOX=1` for receiving spam messages.
+
+##### SPAMASSASSIN_SPAM_TO_INBOX
+
+
+  - **0** => Spam messages will be bounced (_rejected_) without any notification (_dangerous_).
+  - 1 => Spam messages will be delivered to the inbox and tagged as spam using `SA_SPAM_SUBJECT`.
+
+##### MOVE_SPAM_TO_JUNK
+
+  - **1** => Spam messages will be delivered in the `Junk` folder.
+  - 0 => Spam messages will be delivered in the mailbox.
+
+Note: this setting needs `SPAMASSASSIN_SPAM_TO_INBOX=1`
 
 ##### SA_TAG
 

--- a/env-mailserver.dist
+++ b/env-mailserver.dist
@@ -177,8 +177,11 @@ POSTFIX_INET_PROTOCOLS=all
 
 ENABLE_SPAMASSASSIN=0
 
-#If Enabled, SPAM goes to your inbox with added SPAM header, you can then move it to a specific SPAM folder with SIEVE rules
+# deliver spam messages in the inbox (eventually tagged using SA_SPAM_SUBJECT)
 SPAMASSASSIN_SPAM_TO_INBOX=1
+
+# spam messages will be moved in the Junk folder (SPAMASSASSIN_SPAM_TO_INBOX=1 required)
+MOVE_SPAM_TO_JUNK=1
 
 # add spam info headers if at, or above that level:
 SA_TAG=2.0

--- a/target/amavis/conf.d/49-docker-mailserver
+++ b/target/amavis/conf.d/49-docker-mailserver
@@ -3,7 +3,8 @@ use strict;
 # Override options set in earlier files, use 50-user to override these
 
 # Bounce spam, the default option for buster is D_PASS to deliver
-$final_spam_destiny = D_BOUNCE;
+$final_spam_destiny       = D_BOUNCE;
+$final_bad_header_destiny = D_BOUNCE;
 
 # Higher log level to get expected messages at startup
 $log_level = 2;

--- a/target/dovecot/90-sieve.conf
+++ b/target/dovecot/90-sieve.conf
@@ -32,7 +32,7 @@ plugin {
   # file names, using a normal 8bit per-character comparison. Multiple script
   # file or directory paths can be specified by appending an increasing number.
   #sieve_before = /usr/lib/dovecot/sieve-global/before.dovecot.sieve
-  #sieve_before2 =
+  #sieve_before2 = /usr/lib/dovecot/sieve-global/before.spam.sieve
   #sieve_before3 = (etc...)
 
   # Identical to sieve_before, only the specified scripts are executed after the

--- a/target/dovecot/sieve/before.spam.sieve
+++ b/target/dovecot/sieve/before.spam.sieve
@@ -1,0 +1,4 @@
+require "fileinto";
+if header :contains "X-Spam-Flag" "YES" {
+    fileinto "Junk";
+}

--- a/test/mail_spam_bounced.bats
+++ b/test/mail_spam_bounced.bats
@@ -1,0 +1,49 @@
+load 'test_helper/common'
+
+# Test case
+# ---------
+# When SPAMASSASSIN_SPAM_TO_INBOX=0, spam messages must be bounced.
+
+
+function setup() {
+    run_setup_file_if_necessary
+}
+
+function teardown() {
+    run_teardown_file_if_necessary
+}
+
+function setup_file() {
+    docker run -d --name mail_spam_bounced \
+		-v "`pwd`/test/config":/tmp/docker-mailserver \
+		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
+		-e ENABLE_SPAMASSASSIN=1 \
+		-e SPAMASSASSIN_SPAM_TO_INBOX=0 \
+		-h mail.my-domain.com -t "${NAME}"
+
+    wait_for_finished_setup_in_container mail_spam_bounced
+}
+
+function teardown_file() {
+    docker rm -f mail_spam_bounced
+}
+
+@test "first" {
+  skip 'this test must come first to reliably identify when to run setup_file'
+}
+
+@test "checking amavis: spam message is bounced" {
+  run sh -c "docker logs mail_spam_bounced | grep 'Spam messages WILL NOT BE DELIVERED'"
+  assert_success
+
+  # send a spam message
+  run docker exec mail_spam_bounced /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/amavis-spam.txt"
+  assert_success
+
+  run repeat_until_success_or_timeout 20 sh -c "docker logs mail_spam_bounced | grep 'Blocked SPAM {NoBounceInbound,Quarantined}'"
+  assert_success
+}
+
+@test "last" {
+  skip 'this test is only there to reliably mark the end for the teardown_file'
+}

--- a/test/mail_spam_junk_folder.bats
+++ b/test/mail_spam_junk_folder.bats
@@ -2,7 +2,7 @@ load 'test_helper/common'
 
 # Test case
 # ---------
-# When SPAMASSASSIN_SPAM_TO_INBOX=1, spam messages must be delivered and moved to the Junk folder.
+# When SPAMASSASSIN_SPAM_TO_INBOX=1, spam messages must be delivered and eventually (MOVE_SPAM_TO_JUNK=1) moved to the Junk folder.
 
 
 function setup() {
@@ -14,35 +14,61 @@ function teardown() {
 }
 
 function setup_file() {
-    docker run -d --name mail_spam_moved \
+    docker run -d --name mail_spam_moved_junk \
 		-v "`pwd`/test/config":/tmp/docker-mailserver \
 		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
 		-e ENABLE_SPAMASSASSIN=1 \
 		-e SPAMASSASSIN_SPAM_TO_INBOX=1 \
+		-e MOVE_SPAM_TO_JUNK=1 \
 		-e SA_SPAM_SUBJECT="SPAM: " \
 		-h mail.my-domain.com -t "${NAME}"
 
-    wait_for_finished_setup_in_container mail_spam_moved
+    wait_for_finished_setup_in_container mail_spam_moved_junk
+
+    docker run -d --name mail_spam_moved_new \
+		-v "`pwd`/test/config":/tmp/docker-mailserver \
+		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
+		-e ENABLE_SPAMASSASSIN=1 \
+		-e SPAMASSASSIN_SPAM_TO_INBOX=1 \
+		-e MOVE_SPAM_TO_JUNK=0 \
+		-e SA_SPAM_SUBJECT="SPAM: " \
+		-h mail.my-domain.com -t "${NAME}"
+
+    wait_for_finished_setup_in_container mail_spam_moved_new
 }
 
 function teardown_file() {
-    docker rm -f mail_spam_moved
+    docker rm -f mail_spam_moved_new
+    docker rm -f mail_spam_moved_junk
 }
 
 @test "first" {
   skip 'this test must come first to reliably identify when to run setup_file'
 }
 
-@test "checking amavis: spam message is delivered and moved to the Junk folder" {
+@test "checking amavis: spam message is delivered and moved to the Junk folder (MOVE_SPAM_TO_JUNK=1)" {
   # send a spam message
-  run docker exec mail_spam_moved /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/amavis-spam.txt"
+  run docker exec mail_spam_moved_junk /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/amavis-spam.txt"
   assert_success
 
-  run repeat_until_success_or_timeout 20 sh -c "docker logs mail_spam_moved | grep 'Passed SPAM {RelayedTaggedInbound,Quarantined}'"
+  run repeat_until_success_or_timeout 20 sh -c "docker logs mail_spam_moved_junk | grep 'Passed SPAM {RelayedTaggedInbound,Quarantined}'"
   assert_success
 
   # spam moved to Junk folder
-  run repeat_until_success_or_timeout 20 sh -c "docker exec mail_spam_moved sh -c 'grep \"Subject: SPAM: \" /var/mail/localhost.localdomain/user1/.Junk/new/ -R'"
+  run repeat_until_success_or_timeout 20 sh -c "docker exec mail_spam_moved_junk sh -c 'grep \"Subject: SPAM: \" /var/mail/localhost.localdomain/user1/.Junk/new/ -R'"
+  assert_success
+}
+
+@test "checking amavis: spam message is delivered to INBOX (MOVE_SPAM_TO_JUNK=0)" {
+  # send a spam message
+  run docker exec mail_spam_moved_new /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/amavis-spam.txt"
+  assert_success
+
+  run repeat_until_success_or_timeout 20 sh -c "docker logs mail_spam_moved_new | grep 'Passed SPAM {RelayedTaggedInbound,Quarantined}'"
+  assert_success
+
+  # spam moved to INBOX
+  run repeat_until_success_or_timeout 20 sh -c "docker exec mail_spam_moved_new sh -c 'grep \"Subject: SPAM: \" /var/mail/localhost.localdomain/user1/new/ -R'"
   assert_success
 }
 

--- a/test/mail_spam_junk_folder.bats
+++ b/test/mail_spam_junk_folder.bats
@@ -1,0 +1,51 @@
+load 'test_helper/common'
+
+# Test case
+# ---------
+# When SPAMASSASSIN_SPAM_TO_INBOX=1, spam messages must be delivered and moved to the Junk folder.
+
+
+function setup() {
+    run_setup_file_if_necessary
+}
+
+function teardown() {
+    run_teardown_file_if_necessary
+}
+
+function setup_file() {
+    docker run -d --name mail_spam_moved \
+		-v "`pwd`/test/config":/tmp/docker-mailserver \
+		-v "`pwd`/test/test-files":/tmp/docker-mailserver-test:ro \
+		-e ENABLE_SPAMASSASSIN=1 \
+		-e SPAMASSASSIN_SPAM_TO_INBOX=1 \
+		-e SA_SPAM_SUBJECT="SPAM: " \
+		-h mail.my-domain.com -t "${NAME}"
+
+    wait_for_finished_setup_in_container mail_spam_moved
+}
+
+function teardown_file() {
+    docker rm -f mail_spam_moved
+}
+
+@test "first" {
+  skip 'this test must come first to reliably identify when to run setup_file'
+}
+
+@test "checking amavis: spam message is delivered and moved to the Junk folder" {
+  # send a spam message
+  run docker exec mail_spam_moved /bin/sh -c "nc 0.0.0.0 25 < /tmp/docker-mailserver-test/email-templates/amavis-spam.txt"
+  assert_success
+
+  run repeat_until_success_or_timeout 20 sh -c "docker logs mail_spam_moved | grep 'Passed SPAM {RelayedTaggedInbound,Quarantined}'"
+  assert_success
+
+  # spam moved to Junk folder
+  run repeat_until_success_or_timeout 20 sh -c "docker exec mail_spam_moved sh -c 'grep \"Subject: SPAM: \" /var/mail/localhost.localdomain/user1/.Junk/new/ -R'"
+  assert_success
+}
+
+@test "last" {
+  skip 'this test is only there to reliably mark the end for the teardown_file'
+}


### PR DESCRIPTION
This PR is related to https://github.com/tomav/docker-mailserver/issues/1396

Features:
- Fix `SPAMASSASSIN_SPAM_TO_INBOX` behavior
- `MOVE_SPAM_TO_JUNK=1` permits to move spams to Junk folder using a global sieve rule
- Warning raised when `SPAMASSASSIN_SPAM_TO_INBOX=0`
- Tests

`MOVE_SPAM_TO_JUNK=1` will allow [SpamAssassin Lear](https://github.com/tomav/docker-mailserver/wiki/FAQ-and-Tips#how-can-i-make-spamassassin-learn-spam) to work. 

~TODO:~
- ~README update: strong warning about the default behavior of spam bouncing~

fix https://github.com/tomav/docker-mailserver/issues/1396