### PR TITLE
CISOfy/lynis MAIL-8818 - Postfix information leakage

### DIFF
--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -1,6 +1,6 @@
 # See /usr/share/postfix/main.cf.dist for a commented, more complete version
 
-smtpd_banner = $myhostname ESMTP $mail_name (Debian)
+smtpd_banner = $myhostname ESMTP
 biff = no
 append_dot_mydomain = no
 readme_directory = no


### PR DESCRIPTION
To prevent announcing software or version to malicious people or scripts, it is advised to hide such information.


This information is provided as part of the Lynis community project. It is related to Lynis control MAIL-8818 and should be considered as-is and without guarantees.

https://cisofy.com/lynis/controls/MAIL-8818/