### PR TITLE
Fix #1507 - Do not try to reload freshclam daemon after log rotation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -221,7 +221,7 @@ RUN sed -i -r "/^#?compress/c\compress\ncopytruncate" /etc/logrotate.conf && \
   sed -i -r 's|/var/log/clamav|/var/log/mail|g' /etc/logrotate.d/clamav-daemon && \
   sed -i -r 's|invoke-rc.d.*|/usr/bin/supervisorctl signal hup clamav >/dev/null \|\| true|g' /etc/logrotate.d/clamav-daemon && \
   sed -i -r 's|/var/log/clamav|/var/log/mail|g' /etc/logrotate.d/clamav-freshclam && \
-  sed -i -r 's|invoke-rc.d|#invoke-rc.d|g' /etc/logrotate.d/clamav-freshclam && \
+  sed -i -r '/postrotate/,/endscript/d' /etc/logrotate.d/clamav-freshclam && \
   sed -i -r 's|/var/log/mail|/var/log/mail/mail|g' /etc/logrotate.d/rsyslog && \
   sed -i -r '/\/var\/log\/mail\/mail.log/d' /etc/logrotate.d/rsyslog && \
   # prevent syslog logrotate warnings \


### PR DESCRIPTION
Freshclam is not run as daemon. Fix #1507 