### PR TITLE
Improve container/image name detection

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -25,13 +25,10 @@ if [ -z "$CRI" ]; then
   fi
 fi
 
-INFO=$($CRI ps \
-  --no-trunc \
-  --format="{{.Image}} {{.Names}} {{.Command}}" | \
-  grep "supervisord -c /etc/supervisor/supervisord.conf")
+INFO=$($CRI ps --no-trunc --format "{{.Image}};{{.Names}}" --filter label=org.label-schema.name="docker-mailserver")
 
-IMAGE_NAME=$(echo $INFO | awk '{print $1}')
-CONTAINER_NAME=$(echo $INFO | awk '{print $2}')
+IMAGE_NAME=${INFO%;*}
+CONTAINER_NAME=${INFO#*;}
 DEFAULT_CONFIG_PATH="$(pwd)/config"
 USE_CONTAINER=false
 

--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,7 @@ if [ -z "$CRI" ]; then
   fi
 fi
 
-INFO=$($CRI ps --no-trunc --format "{{.Image}};{{.Names}}" --filter label=org.label-schema.name="docker-mailserver")
+INFO=$($CRI ps --no-trunc --format "{{.Image}};{{.Names}}" --filter label=org.label-schema.name="docker-mailserver" | tail -1)
 
 IMAGE_NAME=${INFO%;*}
 CONTAINER_NAME=${INFO#*;}

--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,11 @@ if [ -z "$CRI" ]; then
   fi
 fi
 
-INFO=$($CRI ps --no-trunc --format "{{.Image}};{{.Names}}" --filter label=org.label-schema.name="docker-mailserver" | tail -1)
+INFO=$($CRI ps \
+  --no-trunc \
+  --format "{{.Image}};{{.Names}}" \
+  --filter label=org.label-schema.name="docker-mailserver" | \
+  tail -1)
 
 IMAGE_NAME=${INFO%;*}
 CONTAINER_NAME=${INFO#*;}


### PR DESCRIPTION
Problem: `setup.sh` fails, if more than one container uses `CMD ["supervisord", "-c", "/etc/supervisor/supervisord.conf"]`

Current container/image name detection: List all containers, grep for "supervisor".

New approach: List container, with label `org.label-schema.name="docker-mailserver"`