### PR TITLE
Fix dovecot variable with whitespace

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -786,7 +786,7 @@ function _setup_ldap() {
 	# _dovecot_ldap_mapping["DOVECOT_USER_FILTER"]="${DOVECOT_USER_FILTER:="${LDAP_QUERY_FILTER_USER}"}"
 
 	for var in ${!_dovecot_ldap_mapping[@]}; do
-		export $var=${_dovecot_ldap_mapping[$var]}
+		export $var="${_dovecot_ldap_mapping[$var]}"
 	done
 
 	configomat.sh "DOVECOT_" "/etc/dovecot/dovecot-ldap.conf.ext"


### PR DESCRIPTION
Signed-off-by: Arthur Outhenin-Chalandre <arthur@cri.epita.fr>

This fixes shell expansion for dovecot variables by adding quotes. I saw this bug while trying to use a ldap bind dn with a space in it.