### PR TITLE
Update dovecot-ldap.conf.ext

### DIFF
--- a/env-mailserver.dist
+++ b/env-mailserver.dist
@@ -270,6 +270,11 @@ DOVECOT_PASS_FILTER=
 # default is maildir, supported values are: sdbox, mdbox, maildir
 DOVECOT_MAILBOX_FORMAT=maildir
 
+# empty => no
+# yes => Allow bind authentication for LDAP
+# https://wiki.dovecot.org/AuthDatabase/LDAP/AuthBinds
+DOVECOT_AUTH_BIND=
+
 # -----------------------------------------------------------------------------------------------------------------------------
 # ---------------- Postgrey section -------------------------------------------------------------------------------------------
 # -----------------------------------------------------------------------------------------------------------------------------

--- a/target/dovecot/dovecot-ldap.conf.ext
+++ b/target/dovecot/dovecot-ldap.conf.ext
@@ -9,3 +9,4 @@ pass_attrs          = uniqueIdentifier=user,userPassword=password
 pass_filter         = (&(objectClass=PostfixBookMailAccount)(uniqueIdentifier=%n))
 user_attrs          = mailHomeDirectory=home,mailUidNumber=uid,mailGidNumber=gid,mailStorageDirectory=mail
 user_filter         = (&(objectClass=PostfixBookMailAccount)(uniqueIdentifier=%n))
+auth_bind           = no


### PR DESCRIPTION
add auth_bind = no so that it can be overridden via the env-mailserver file used by docker compose.

This is related to #1526