### PR TITLE
Fix sasl_password generation to allow passwords containing hashes

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1326,7 +1326,7 @@ function _setup_postfix_relay_hosts() {
 	if [ -f /tmp/docker-mailserver/postfix-sasl-password.cf ]; then
 		notify 'inf' "Adding relay authentication from postfix-sasl-password.cf"
 		while read line; do
-			if ! echo "$line" | grep -q -e "^\s*#"; then
+			if ! echo "$line" | grep -q -e "^\s*#";  then
 				echo "$line" >> /etc/postfix/sasl_passwd
 			fi
 		done < /tmp/docker-mailserver/postfix-sasl-password.cf

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1326,7 +1326,7 @@ function _setup_postfix_relay_hosts() {
 	if [ -f /tmp/docker-mailserver/postfix-sasl-password.cf ]; then
 		notify 'inf' "Adding relay authentication from postfix-sasl-password.cf"
 		while read line; do
-			if ! echo "$line" | grep -q -e "^\s*#";  then
+			if ! echo "$line" | grep -q -e "^\s*#"; then
 				echo "$line" >> /etc/postfix/sasl_passwd
 			fi
 		done < /tmp/docker-mailserver/postfix-sasl-password.cf

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1326,7 +1326,7 @@ function _setup_postfix_relay_hosts() {
 	if [ -f /tmp/docker-mailserver/postfix-sasl-password.cf ]; then
 		notify 'inf' "Adding relay authentication from postfix-sasl-password.cf"
 		while read line; do
-			if ! echo "$line" | grep -q -e "\s*#"; then
+			if ! echo "$line" | grep -q -e "^\s*#"; then
 				echo "$line" >> /etc/postfix/sasl_passwd
 			fi
 		done < /tmp/docker-mailserver/postfix-sasl-password.cf


### PR DESCRIPTION
This is a pull request to allow postfix SASL account to contain hashes (#).