### PR TITLE
fix: extractCertsFromAcmeJson fails if "sans" not in Certificates.domain.main

### DIFF
--- a/target/helper_functions.sh
+++ b/target/helper_functions.sh
@@ -49,7 +49,7 @@ for key, value in acme.items():
         if 'domain' in cert and 'key' in cert:
             if 'main' in cert['domain'] and cert['domain']['main'] == '$WHAT' or 'sans' in cert['domain'] and '$WHAT' in cert['domain']['sans']:
                 print cert['key']
-print ''
+                break
 ")
   CERT=$(cat /etc/letsencrypt/acme.json | python -c "
 import sys,json
@@ -60,7 +60,7 @@ for key, value in acme.items():
         if 'domain' in cert and 'certificate' in cert:
             if 'main' in cert['domain'] and cert['domain']['main'] == '$WHAT' or 'sans' in cert['domain'] and '$WHAT' in cert['domain']['sans']:
                 print cert['certificate']
-print ''
+                break
 ")
 
   if [[ -n "${KEY}${CERT}" ]]; then

--- a/target/helper_functions.sh
+++ b/target/helper_functions.sh
@@ -39,9 +39,29 @@ function _sanitize_ipv4_to_subnet_cidr() {
 # extracts certificates from acme.json and returns 0 if found
 function extractCertsFromAcmeJson() {
   WHAT=$1
-  # sorry for the code-golf :(
-  KEY=$(cat /etc/letsencrypt/acme.json | python -c "import sys,json,itertools;  print map(lambda c: c[\"key\"]         if (c[\"domain\"][\"main\"]==\"$WHAT\" or \"$WHAT\" in c[\"domain\"][\"sans\"]) else \"\", list(itertools.chain.from_iterable(map(lambda x: x[\"Certificates\"], json.load(sys.stdin).values()))))[0]")
-  CERT=$(cat /etc/letsencrypt/acme.json | python -c "import sys,json,itertools; print map(lambda c: c[\"certificate\"] if (c[\"domain\"][\"main\"]==\"$WHAT\" or \"$WHAT\" in c[\"domain\"][\"sans\"]) else \"\", list(itertools.chain.from_iterable(map(lambda x: x[\"Certificates\"], json.load(sys.stdin).values()))))[0]")
+
+  KEY=$(cat /etc/letsencrypt/acme.json | python -c "
+import sys,json
+acme = json.load(sys.stdin)
+for key, value in acme.items():
+    certs = value['Certificates']
+    for cert in certs:
+        if 'domain' in cert and 'key' in cert:
+            if 'main' in cert['domain'] and cert['domain']['main'] == '$WHAT' or 'sans' in cert['domain'] and '$WHAT' in cert['domain']['sans']:
+                print cert['key']
+print ''
+")
+  CERT=$(cat /etc/letsencrypt/acme.json | python -c "
+import sys,json
+acme = json.load(sys.stdin)
+for key, value in acme.items():
+    certs = value['Certificates']
+    for cert in certs:
+        if 'domain' in cert and 'certificate' in cert:
+            if 'main' in cert['domain'] and cert['domain']['main'] == '$WHAT' or 'sans' in cert['domain'] and '$WHAT' in cert['domain']['sans']:
+                print cert['certificate']
+print ''
+")
 
   if [[ -n "${KEY}${CERT}" ]]; then
     mkdir -p /etc/letsencrypt/live/"$HOSTNAME"/


### PR DESCRIPTION
@MichaelSp made a great PR #1553 supporting acme.json from traefik. 

However, if `acme.json's` `Certificates[x].domain.sans === undefined` python will crash and the keys won't be added to `/etc/letsencrypt/live/"$HOSTNAME"/key|fullchain.pem`.
In my case this (`sans === undefined`) is true for all my certificates in `acme.json`; I just have the `main`-entry.

My logs when I start `docker-mailserver`:
```
[...]
Initializing setup
Checking configuration
Configuring mail server
Traceback (mosat recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 1, in <lambda>
KeyError: 'sans'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 1, in <lambda>
KeyError: 'sans'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 1, in <lambda>
KeyError: 'sans'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 1, in <lambda>
KeyError: 'sans'
  * Cannot access '/etc/letsencrypt/live/mail.mydomain.de/fullchain.pem' or '/etc/letsencrypt/live/mydomain.de/fullchain.pem'
[...]
```

tbh I am not really into python and I don't get everything what's going on in @MichaelSp python code. I did therefore rewrite it to my understanding (but maybe this is dumb because my lack of python-skills and we should just add the `\"sans\" in c[\"domain\"]` check to the existing code.