### PR TITLE
Add SASLAUTHD_LDAP_FILTER to ldap example

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ services:
       - SASLAUTHD_LDAP_BIND_DN=cn=admin,dc=localhost,dc=localdomain
       - SASLAUTHD_LDAP_PASSWORD=admin
       - SASLAUTHD_LDAP_SEARCH_BASE=ou=people,dc=localhost,dc=localdomain
+      - SASLAUTHD_LDAP_FILTER=(&(objectClass=PostfixBookMailAccount)(uniqueIdentifier=%U))
       - POSTMASTER_ADDRESS=postmaster@localhost.localdomain
       - POSTFIX_MESSAGE_SIZE_LIMIT=100000000
     cap_add:


### PR DESCRIPTION
Added as an example SASLAUTHD_LDAP_FILTER. 
I'm going to add full example with docker-openldap to the ldap wiki page. Thanks.