### PR TITLE
major refactoring for setup.sh (#1590)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/tomav/docker-mailserver.svg?branch=master)](https://travis-ci.org/tomav/docker-mailserver) [![Docker Pulls](https://img.shields.io/docker/pulls/tvial/docker-mailserver.svg)](https://hub.docker.com/r/tvial/docker-mailserver/) [![Docker layers](https://images.microbadger.com/badges/image/tvial/docker-mailserver.svg)](https://microbadger.com/images/tvial/docker-mailserver) [![Github Stars](https://img.shields.io/github/stars/tomav/docker-mailserver.svg?label=github%20%E2%98%85)](https://github.com/tomav/docker-mailserver/) [![Github Stars](https://img.shields.io/github/contributors/tomav/docker-mailserver.svg)](https://github.com/tomav/docker-mailserver/) [![Github Forks](https://img.shields.io/github/forks/tomav/docker-mailserver.svg?label=github%20forks)](https://github.com/tomav/docker-mailserver/) [![Gitter](https://img.shields.io/gitter/room/tomav/docker-mailserver.svg)](https://gitter.im/tomav/docker-mailserver)
 
-
 A fullstack but simple mail server (smtp, imap, antispam, antivirus...).
 Only configuration files, no SQL database. Keep it simple and versioned.
 Easy to deploy and upgrade.
@@ -13,12 +12,12 @@ At this point we have merged the next branch based on Debian Buster into master.
 That means the docker image latest uses Buster. The change may break things!
 
 The following possibly breaking changes are known:
+
 - Filebeat is removed and should be handled by another container, see [Wiki](https://github.com/tomav/docker-mailserver/wiki/).
 - Dovecot will be downgraded a little bit (same major version) so that we can use the official Debian version.
 
 If you want to stick to the old version a while longer, either switch to stable or to a specific version.
 If you run into problems, please raise issues and ask for help. Don't forget to provide details.
-
 
 Includes:
 
@@ -50,11 +49,13 @@ Before you open an issue, please have a look this `README`, the [Wiki](https://g
 ## Requirements
 
 Recommended:
+
 - 1 CPU
 - 1-2GB RAM
 - Swap enabled for the container
 
 Minimum:
+
 - 1 CPU
 - 512MB RAM
 
@@ -62,7 +63,7 @@ Minimum:
 
 ## Usage
 
-#### Get the tools
+### Get the tools
 
 Download the docker-compose.yml, the .env and the setup.sh files:
 
@@ -76,7 +77,7 @@ curl -o .env https://raw.githubusercontent.com/tomav/docker-mailserver/master/.e
 curl -o env-mailserver https://raw.githubusercontent.com/tomav/docker-mailserver/master/env-mailserver.dist
 ```
 
-#### Create a docker-compose environment
+### Create a docker-compose environment
 
 - Edit the files `.env` and `env-mailserver` to your liking:
   - `.env` contains the configuration for docker-compose
@@ -88,24 +89,35 @@ curl -o env-mailserver https://raw.githubusercontent.com/tomav/docker-mailserver
 
 **Note:** If you want to use a bare domain (host name equals domain name) see [FAQ](https://github.com/tomav/docker-mailserver/wiki/FAQ-and-Tips#can-i-use-nakedbare-domains-no-host-name).
 
-#### Start Container
-    docker-compose up -d mail
+### Starting the Container
 
-#### Create your mail accounts
+``` BASH
+docker-compose up -d mail
+```
 
-    ./setup.sh email add <user@domain> [<password>]
+### Create your mail accounts
 
-#### Generate DKIM keys
+``` BASH
+./setup.sh email add <user@domain> [<password>]
+```
 
-    ./setup.sh config dkim
+### Generate DKIM keys
+
+``` BASH
+./setup.sh config dkim
+```
 
 Now the keys are generated, you can configure your DNS server by just pasting the content of `config/opendkim/keys/domain.tld/mail.txt` in your `domain.tld.hosts` zone.
 
+### Miscellaneous
+
 #### Restart and update the container
 
-    docker-compose down
-    docker pull tvial/docker-mailserver:latest
-    docker-compose up -d mail
+``` BASH
+docker-compose down
+docker pull tvial/docker-mailserver:latest
+docker-compose up -d mail
+```
 
 You're done!
 
@@ -115,7 +127,7 @@ And don't forget to have a look at the remaining functions of the `setup.sh` scr
 
 If you got any problems with SPF and/or forwarding mails, give [SRS](https://github.com/roehling/postsrsd/blob/master/README.md) a try. You enable SRS by setting `ENABLE_SRS=1`. See the variable description for further information.
 
-#### For informational purposes:
+#### For informational purposes
 
 Your config folder will be mounted in `/tmp/docker-mailserver/`. To understand how things work on boot, please have a look at [start-mailserver.sh](https://github.com/tomav/docker-mailserver/blob/master/target/start-mailserver.sh)
 
@@ -123,12 +135,12 @@ Your config folder will be mounted in `/tmp/docker-mailserver/`. To understand h
 
 #### Exposed ports
 
-| Protocol | Opt-in Encryption<sup>1</sup> | Enforced Encryption | Purpose              |
-|----------|-------------------------------|---------------------|----------------------|
-| SMTP     | 25                            | N/A                 | Transfer<sup>2</sup> |
-| ESMTP    | 587                           | 465<sup>3</sup>     | Submission           |
-| POP3     | 110                           | 995                 | Retrieval            |
-| IMAP4    | 143                           | 993                 | Retrieval            |
+| Protocol | Opt-in Encryption &#185; | Enforced Encryption | Purpose        |
+| :------: | :----------------------: | :-----------------: | :------------: |
+| SMTP     | 25                       | N/A                 | Transfer&#178; |
+| ESMTP    | 587                      | 465&#179;           | Submission     |
+| POP3     | 110                      | 995                 | Retrieval      |
+| IMAP4    | 143                      | 993                 | Retrieval      |
 
 1. A connection *may* be secured over TLS when both ends support `STARTTLS`. On ports 110, 143 and 587, `docker-mailserver` will reject a connection that cannot be secured. Port 25 is [required](https://serverfault.com/questions/623692/is-it-still-wrong-to-require-starttls-on-incoming-smtp-messages) to support insecure connections.
 2. Receives email and filters for spam and viruses. For submitting outgoing mail you should prefer the submission ports(465, 587), which require authentication. Unless a relay host is configured, outgoing email will leave the server via port 25(thus outbound traffic must not be blocked by your provider or firewall).
@@ -136,7 +148,9 @@ Your config folder will be mounted in `/tmp/docker-mailserver/`. To understand h
 
 See the [wiki](https://github.com/tomav/docker-mailserver/wiki) for further details and best practice advice, especially regarding security concerns.
 
-##### Examples with just the relevant environmental variables:
+### Examples
+
+#### Just the relevant environmental variables
 
 ```yaml
 version: '2'
@@ -178,9 +192,9 @@ volumes:
     driver: local
 ```
 
-__for ldap setup__:
+#### LDAP setup
 
-```yaml
+``` YAML
 version: '2'
 
 services:
@@ -240,57 +254,61 @@ volumes:
     driver: local
 ```
 
-# Environment variables
+## Environment variables
 
 Please check [how the container starts](https://github.com/tomav/docker-mailserver/blob/master/target/start-mailserver.sh) to understand what's expected. Also if an option doesn't work as documented here, check if you are running the latest image!
 
 Value in **bold** is the default value.
 
-## General
+### Assignments
+
+#### General
 
 ##### DMS_DEBUG
 
-  - **0** => Debug disabled
-  - 1 => Enables debug on startup
+- **0** => Debug disabled
+- 1 => Enables debug on startup
 
 ##### ENABLE_CLAMAV
 
-  - **0** => Clamav is disabled
-  - 1 => Clamav is enabled
+- **0** => Clamav is disabled
+- 1 => Clamav is enabled
 
 ##### ONE_DIR
 
-  - **0** => state in default directories
-  - 1 => consolidate all states into a single directory (`/var/mail-state`) to allow persistence using docker volumes
+- **0** => state in default directories
+- 1 => consolidate all states into a single directory (`/var/mail-state`) to allow persistence using docker volumes
 
 ##### ENABLE_POP3
 
-  - **empty** => POP3 service disabled
-  - 1 => Enables POP3 service
+- **empty** => POP3 service disabled
+- 1 => Enables POP3 service
 
 ##### ENABLE_FAIL2BAN
 
-  - **0** => fail2ban service disabled
-  - 1 => Enables fail2ban service
+- **0** => fail2ban service disabled
+- 1 => Enables fail2ban service
 
 If you enable Fail2Ban, don't forget to add the following lines to your `docker-compose.yml`:
 
-    cap_add:
-      - NET_ADMIN
+``` BASH
+cap_add:
+  - NET_ADMIN
+```
 
 Otherwise, `iptables` won't be able to ban IPs.
 
 ##### SMTP_ONLY
 
-  - **empty** => all daemons start
-  - 1 => only launch postfix smtp
+- **empty** => all daemons start
+- 1 => only launch postfix smtp
 
 ##### SSL_TYPE
 
-  - **empty** => SSL disabled
-  - letsencrypt => Enables Let's Encrypt certificates
-  - custom => Enables custom certificates
-  - manual => Let you manually specify locations of your SSL certificates for non-standard cases
+- **empty** => SSL disabled
+- letsencrypt => Enables Let's Encrypt certificates
+- custom => Enables custom certificates
+- manual => Let you manually specify locations of your SSL certificates for non-standard cases
   - self-signed => Enables self-signed certificates
   - _any other value_ => SSL required, settings by default
 
@@ -298,36 +316,41 @@ Please read [the SSL page in the wiki](https://github.com/tomav/docker-mailserve
 
 ##### TLS_LEVEL
 
-  - **empty** => modern
-  - modern => Enables TLSv1.2 and modern ciphers only. (default)
-  - intermediate => Enables TLSv1, TLSv1.1 and TLSv1.2 and broad compatibility ciphers.
-  - old => NOT implemented. If you really need it, then customize the TLS ciphers overriding postfix and dovecot settings [ wiki](https://github.com/tomav/docker-mailserver/wiki/
+- **empty** => modern
+- modern => Enables TLSv1.2 and modern ciphers only. (default)
+- intermediate => Enables TLSv1, TLSv1.1 and TLSv1.2 and broad compatibility ciphers.
+- old => NOT implemented. If you really need it, then customize the TLS ciphers overriding postfix and dovecot settings [wiki](https://github.com/tomav/docker-mailserver/wiki/)
 
 ##### SPOOF_PROTECTION
+
 Configures the handling of creating mails with forged sender addresses.
-  - **empty** => Mail address spoofing allowed. Any logged in user may create email messages with a forged sender address. See also [Wikipedia](https://en.wikipedia.org/wiki/Email_spoofing)(not recommended, but default for backwards compatibility reasons)
-  - 1 => (recommended) Mail spoofing denied. Each user may only send with his own or his alias addresses. Addresses with [extension delimiters](http://www.postfix.org/postconf.5.html#recipient_delimiter) are not able to send messages.
+
+- **empty** => Mail address spoofing allowed. Any logged in user may create email messages with a forged sender address. See also [Wikipedia](https://en.wikipedia.org/wiki/Email_spoofing)(not recommended, but default for backwards compatibility reasons)
+- 1 => (recommended) Mail spoofing denied. Each user may only send with his own or his alias addresses. Addresses with [extension delimiters](http://www.postfix.org/postconf.5.html#recipient_delimiter) are not able to send messages.
 
 ##### ENABLE_SRS
+
 Enables the Sender Rewriting Scheme. SRS is needed if your mail server acts as forwarder. See [postsrsd](https://github.com/roehling/postsrsd/blob/master/README.md#sender-rewriting-scheme-crash-course) for further explanation.
-  - **0** => Disabled
-  - 1 => Enabled
+
+- **0** => Disabled
+- 1 => Enabled
 
 ##### PERMIT_DOCKER
 
 Set different options for mynetworks option (can be overwrite in postfix-main.cf) **WARNING**: Adding the docker network's gateway to the list of trusted hosts, e.g. using the `network` or `connected-networks` option, can create an [**open relay**](https://en.wikipedia.org/wiki/Open_mail_relay), [for instance](https://github.com/tomav/docker-mailserver/issues/1405#issuecomment-590106498) if IPv6 is enabled on the host machine but not in Docker.
-  - **empty** => localhost only
-  - host => Add docker host (ipv4 only)
-  - network => Add the docker default bridge network (172.16.0.0/12); **WARNING**: `docker-compose` might use others (e.g. 192.168.0.0/16) use `PERMIT_DOCKER=connected-networks` in this case
-  - connected-networks => Add all connected docker networks (ipv4 only)
+
+- **empty** => localhost only
+- host => Add docker host (ipv4 only)
+- network => Add the docker default bridge network (172.16.0.0/12); **WARNING**: `docker-compose` might use others (e.g. 192.168.0.0/16) use `PERMIT_DOCKER=connected-networks` in this case
+- connected-networks => Add all connected docker networks (ipv4 only)
 
 Note: you probably want to [set `POSTFIX_INET_PROTOCOLS=ipv4`](#postfix_inet_protocols) to make it work fine with Docker.
 
 ##### VIRUSMAILS_DELETE_DELAY
 
 Set how many days a virusmail will stay on the server before being deleted
-  - **empty** => 7 days
 
+- **empty** => 7 days
 
 ##### ENABLE_POSTFIX_VIRTUAL_TRANSPORT
 
@@ -342,7 +365,7 @@ Enabled by ENABLE_POSTFIX_VIRTUAL_TRANSPORT. Specify the final delivery of postf
 
 - **empty**: fail
 - `lmtp:unix:private/dovecot-lmtp` (use socket)
-- `lmtps:inet:<host>:<port>` (secure lmtp with starttls, take a look at https://sys4.de/en/blog/2014/11/17/sicheres-lmtp-mit-starttls-in-dovecot/)
+- `lmtps:inet:<host>:<port>` (secure lmtp with starttls, take a look at <https://sys4.de/en/blog/2014/11/17/sicheres-lmtp-mit-starttls-in-dovecot/>)
 - `lmtp:<kopano-host>:2003` (use kopano as mailstore)
 - etc.
 
@@ -351,7 +374,6 @@ Enabled by ENABLE_POSTFIX_VIRTUAL_TRANSPORT. Specify the final delivery of postf
 Set the mailbox size limit for all users. If set to zero, the size will be unlimited (default).
 
 - **empty** => 0 (no limit)
-
 
 ##### ENABLE_QUOTAS
 
@@ -368,31 +390,30 @@ Set the message size limit for all users. If set to zero, the size will be unlim
 
 ##### ENABLE_MANAGESIEVE
 
-  - **empty** => Managesieve service disabled
-  - 1 => Enables Managesieve on port 4190
+- **empty** => Managesieve service disabled
+- 1 => Enables Managesieve on port 4190
 
 ##### OVERRIDE_HOSTNAME
 
-  - **empty** => uses the `hostname` command to get the mail server's canonical hostname
-  - => Specify a fully-qualified domainname to serve mail for.  This is used for many of the config features so if you can't set your hostname (e.g. you're in a container platform that doesn't let you) specify it in this environment variable.
+- **empty** => uses the `hostname` command to get the mail server's canonical hostname
+- => Specify a fully-qualified domainname to serve mail for.  This is used for many of the config features so if you can't set your hostname (e.g. you're in a container platform that doesn't let you) specify it in this environment variable.
 
 ##### POSTMASTER_ADDRESS
 
-  - **empty** => postmaster@domain.com
-  - => Specify the postmaster address
-
+- **empty** => postmaster@domain.com
+- => Specify the postmaster address
 
 ##### POSTSCREEN_ACTION
 
-  - **enforce** => Allow other tests to complete. Reject attempts to deliver mail with a 550 SMTP reply, and log the helo/sender/recipient information. Repeat this test the next time the client connects.
-  - drop => Drop the connection immediately with a 521 SMTP reply. Repeat this test the next time the client connects.
-  - ignore => Ignore the failure of this test. Allow other tests to complete. Repeat this test the next time the client connects. This option is useful for testing and collecting statistics without blocking mail.
+- **enforce** => Allow other tests to complete. Reject attempts to deliver mail with a 550 SMTP reply, and log the helo/sender/recipient information. Repeat this test the next time the client connects.
+- drop => Drop the connection immediately with a 521 SMTP reply. Repeat this test the next time the client connects.
+- ignore => Ignore the failure of this test. Allow other tests to complete. Repeat this test the next time the client connects. This option is useful for testing and collecting statistics without blocking mail.
 
 ##### DOVECOT_MAILBOX_FORMAT
 
-  - **maildir** => uses very common Maildir format, one file contains one message
-  - sdbox => (experimental) uses Dovecot high-performance mailbox format, one file contains one message
-  - mdbox ==> (experimental) uses Dovecot high-performance mailbox format, multiple messages per file and multiple files per box
+- **maildir** => uses very common Maildir format, one file contains one message
+- sdbox => (experimental) uses Dovecot high-performance mailbox format, one file contains one message
+- mdbox ==> (experimental) uses Dovecot high-performance mailbox format, multiple messages per file and multiple files per box
 
 This option has been added in November 2019. Using other format than Maildir is considered as experimental in docker-mailserver and should only be used for testing purpose. For more details, please refer to [Dovecot Documentation](https://wiki2.dovecot.org/MailboxFormat).
 
@@ -402,64 +423,72 @@ This option has been added in November 2019. Using other format than Maildir is 
 - ipv4 => Use only IPv4 traffic. Most likely you want this behind Docker.
 - ipv6 => Use only IPv6 traffic.
 
-Note: More details in http://www.postfix.org/postconf.5.html#inet_protocols
+Note: More details in <http://www.postfix.org/postconf.5.html#inet_protocols>
 
-## Reports
+#### Reports
 
 ##### PFLOGSUMM_TRIGGER
 
-  Enables regular pflogsumm mail reports.
-  - **not set** => No report
-  - daily_cron => Daily report for the previous day
-  - logrotate => Full report based on the mail log when it is rotated
+Enables regular pflogsumm mail reports.
+
+- **not set** => No report
+- daily_cron => Daily report for the previous day
+- logrotate => Full report based on the mail log when it is rotated
 
 This is a new option. The old REPORT options are still supported for backwards compatibility.
 If this is not set and reports are enabled with the old options, logrotate will be used.
 
 ##### PFLOGSUMM_RECIPIENT
 
-  Recipient address for pflogsumm reports.
-  - **not set** => Use REPORT_RECIPIENT or POSTMASTER_ADDRESS
-  - => Specify the recipient address(es)
+Recipient address for pflogsumm reports.
+
+- **not set** => Use REPORT_RECIPIENT or POSTMASTER_ADDRESS
+- => Specify the recipient address(es)
 
 ##### PFLOGSUMM_SENDER
 
-  From address for pflogsumm reports.
-  - **not set** => Use REPORT_SENDER or POSTMASTER_ADDRESS
-  - => Specify the sender address
+From address for pflogsumm reports.
+
+- **not set** => Use REPORT_SENDER or POSTMASTER_ADDRESS
+- => Specify the sender address
 
 ##### LOGWATCH_INTERVAL
 
-  Interval for logwatch report.
-  - **none** => No report is generated
-  - daily => Send a daily report
-  - weekly => Send a report every week
+Interval for logwatch report.
+
+- **none** => No report is generated
+- daily => Send a daily report
+- weekly => Send a report every week
 
 ##### LOGWATCH_RECIPIENT
 
-  Recipient address for logwatch reports if they are enabled.
-  - **not set** => Use REPORT_RECIPIENT or POSTMASTER_ADDRESS
-  - => Specify the recipient address(es)
+Recipient address for logwatch reports if they are enabled.
+
+- **not set** => Use REPORT_RECIPIENT or POSTMASTER_ADDRESS
+- => Specify the recipient address(es)
 
 ##### REPORT_RECIPIENT (deprecated)
 
-  Enables a report being sent (created by pflogsumm) on a regular basis.
-  - **0** => Report emails are disabled unless enabled by other options
-  - 1 => Using POSTMASTER_ADDRESS as the recipient
-  - => Specify the recipient address
+Enables a report being sent (created by pflogsumm) on a regular basis.
+
+- **0** => Report emails are disabled unless enabled by other options
+- 1 => Using POSTMASTER_ADDRESS as the recipient
+- => Specify the recipient address
 
 ##### REPORT_SENDER (deprecated)
 
-  Change the sending address for mail report
-  - **empty** => mailserver-report@hostname
-  - => Specify the report sender (From) address
+Change the sending address for mail report
+
+- **empty** => mailserver-report@hostname
+- => Specify the report sender (From) address
 
 ##### REPORT_INTERVAL (deprecated)
 
-  changes the interval in which logs are rotated and a report is being sent (deprecated).
-  - **daily** => Send a daily report
-  - weekly => Send a report every week
-  - monthly => Send a report every month
+Changes the interval in which logs are rotated and a report is being sent (deprecated).
+
+- **daily** => Send a daily report
+- weekly => Send a report every week
+- monthly => Send a report every month
 
 Note: This variable used to control logrotate inside the container and sent the pflogsumm report when the logs were rotated.
 It is still supported for backwards compatibility, but the new option LOGROTATE_INTERVAL has been added that only rotates
@@ -467,10 +496,11 @@ the logs.
 
 ##### LOGROTATE_INTERVAL
 
-  Defines the interval in which the mail log is being rotated.
-  - **daily** => Rotate daily.
-  - weekly => Rotate weekly.
-  - monthly => Rotate monthly.
+Defines the interval in which the mail log is being rotated.
+
+- **daily** => Rotate daily.
+- weekly => Rotate weekly.
+- monthly => Rotate monthly.
 
 Note that only the log inside the container is affected.
 The full log output is still available via `docker logs mail` (or your respective container name).
@@ -480,57 +510,55 @@ Also note that by default the logs are lost when the container is recycled. To k
 
 Finally the logrotate interval **may** affect the period for generated reports. That is the case when the reports are triggered by log rotation.
 
-## Spamassassin
+#### Spamassassin
 
 ##### ENABLE_SPAMASSASSIN
 
+- **0** => Spamassassin is disabled
+- 1 => Spamassassin is enabled
 
-  - **0** => Spamassassin is disabled
-  - 1 => Spamassassin is enabled
-
-**/!\\ Spam delivery:** when Spamassassin is enabled, messages marked as spam WILL NOT BE DELIVERED. 
+**/!\\ Spam delivery:** when Spamassassin is enabled, messages marked as spam WILL NOT BE DELIVERED.
 Use `SPAMASSASSIN_SPAM_TO_INBOX=1` for receiving spam messages.
 
 ##### SPAMASSASSIN_SPAM_TO_INBOX
 
-
-  - **0** => Spam messages will be bounced (_rejected_) without any notification (_dangerous_).
-  - 1 => Spam messages will be delivered to the inbox and tagged as spam using `SA_SPAM_SUBJECT`.
+- **0** => Spam messages will be bounced (_rejected_) without any notification (_dangerous_).
+- 1 => Spam messages will be delivered to the inbox and tagged as spam using `SA_SPAM_SUBJECT`.
 
 ##### MOVE_SPAM_TO_JUNK
 
-  - **1** => Spam messages will be delivered in the `Junk` folder.
-  - 0 => Spam messages will be delivered in the mailbox.
+- **1** => Spam messages will be delivered in the `Junk` folder.
+- 0 => Spam messages will be delivered in the mailbox.
 
 Note: this setting needs `SPAMASSASSIN_SPAM_TO_INBOX=1`
 
 ##### SA_TAG
 
-  - **2.0** => add spam info headers if at, or above that level
+- **2.0** => add spam info headers if at, or above that level
 
 Note: this spamassassin setting needs `ENABLE_SPAMASSASSIN=1`
 
 ##### SA_TAG2
 
-  - **6.31** => add 'spam detected' headers at that level
+- **6.31** => add 'spam detected' headers at that level
 
 Note: this spamassassin setting needs `ENABLE_SPAMASSASSIN=1`
 
 ##### SA_KILL
 
-  - **6.31** => triggers spam evasive actions
+- **6.31** => triggers spam evasive actions
 
 Note: this spamassassin setting needs `ENABLE_SPAMASSASSIN=1`. By default, the mailserver is configured to quarantine spam emails. If emails are quarantined, they are compressed and stored in a location dependent on the ONE_DIR setting above. If `ONE_DIR=1` the location is /var/mail-state/lib-amavis/virusmails/. If `ONE_DIR=0` it is /var/lib/amavis/virusmails/. These paths are inside the docker container. To inhibit this behaviour and deliver spam emails, set this to a very high value e.g. 100.0.
 
 ##### SA_SPAM_SUBJECT
 
-  - **\*\*\*SPAM\*\*\*** => add tag to subject if spam detected
+- **\*\*\*SPAM\*\*\*** => add tag to subject if spam detected
 
 Note: this spamassassin setting needs `ENABLE_SPAMASSASSIN=1`. Add the spamassassin score to the subject line by inserting the keyword _SCORE_: **\*\*\*SPAM(_SCORE_)\*\*\***.
 
 ##### SA_SHORTCIRCUIT_BAYES_SPAM
 
-  - **1** => will activate spamassassin short circuiting for bayes spam detection.
+- **1** => will activate spamassassin short circuiting for bayes spam detection.
 
 This will uncomment the respective line in ```/etc/spamassasin/local.cf```
 
@@ -538,71 +566,73 @@ Note: activate this only if you are confident in your bayes database for identif
 
 ##### SA_SHORTCIRCUIT_BAYES_HAM
 
-  - **1** => will activate spamassassin short circuiting for bayes ham detection
+- **1** => will activate spamassassin short circuiting for bayes ham detection
 
 This will uncomment the respective line in ```/etc/spamassasin/local.cf```
 
 Note: activate this only if you are confident in your bayes database for identifying ham.
 
-## Fetchmail
+#### Fetchmail
 
 ##### ENABLE_FETCHMAIL
-  - **0** => `fetchmail` disabled
-  - 1 => `fetchmail` enabled
+
+- **0** => `fetchmail` disabled
+- 1 => `fetchmail` enabled
 
 ##### FETCHMAIL_POLL
-  - **300** => `fetchmail` The number of seconds for the interval
 
-## LDAP
+- **300** => `fetchmail` The number of seconds for the interval
+
+#### LDAP
 
 ##### ENABLE_LDAP
 
-  - **empty** => LDAP authentification is disabled
-  - 1 => LDAP authentification is enabled
-  - NOTE:
-    - A second container for the ldap service is necessary (e.g. [docker-openldap](https://github.com/osixia/docker-openldap))
-    - For preparing the ldap server to use in combination with this container [this](http://acidx.net/wordpress/2014/06/installing-a-mailserver-with-postfix-dovecot-sasl-ldap-roundcube/) article may be helpful
+- **empty** => LDAP authentification is disabled
+- 1 => LDAP authentification is enabled
+- NOTE:
+  - A second container for the ldap service is necessary (e.g. [docker-openldap](https://github.com/osixia/docker-openldap))
+  - For preparing the ldap server to use in combination with this container [this](http://acidx.net/wordpress/2014/06/installing-a-mailserver-with-postfix-dovecot-sasl-ldap-roundcube/) article may be helpful
 
 ##### LDAP_START_TLS
 
-  - **empty** => no
-  - yes => LDAP over TLS enabled for Postfix
+- **empty** => no
+- yes => LDAP over TLS enabled for Postfix
 
 ##### LDAP_SERVER_HOST
 
-  - **empty** => mail.domain.com
-  - => Specify the dns-name/ip-address where the ldap-server
-  - NOTE: If you going to use the mailserver in combination with docker-compose you can set the service name here
+- **empty** => mail.domain.com
+- => Specify the dns-name/ip-address where the ldap-server
+- NOTE: If you going to use the mailserver in combination with docker-compose you can set the service name here
 
 ##### LDAP_SEARCH_BASE
 
-  - **empty** => ou=people,dc=domain,dc=com
-  - => e.g. LDAP_SEARCH_BASE=dc=mydomain,dc=local
+- **empty** => ou=people,dc=domain,dc=com
+- => e.g. LDAP_SEARCH_BASE=dc=mydomain,dc=local
 
 ##### LDAP_BIND_DN
 
-  - **empty** => cn=admin,dc=domain,dc=com
-  - => take a look at examples of SASL_LDAP_BIND_DN
+- **empty** => cn=admin,dc=domain,dc=com
+- => take a look at examples of SASL_LDAP_BIND_DN
 
 ##### LDAP_BIND_PW
 
-  - **empty** => admin
-  - => Specify the password to bind against ldap
+- **empty** => admin
+- => Specify the password to bind against ldap
 
 ##### LDAP_QUERY_FILTER_USER
 
-  - e.g. `(&(mail=%s)(mailEnabled=TRUE))`
-  - => Specify how ldap should be asked for users
+- e.g. `(&(mail=%s)(mailEnabled=TRUE))`
+- => Specify how ldap should be asked for users
 
 ##### LDAP_QUERY_FILTER_GROUP
 
-  - e.g. `(&(mailGroupMember=%s)(mailEnabled=TRUE))`
-  - => Specify how ldap should be asked for groups
+- e.g. `(&(mailGroupMember=%s)(mailEnabled=TRUE))`
+- => Specify how ldap should be asked for groups
 
 ##### LDAP_QUERY_FILTER_ALIAS
 
-  - e.g. `(&(mailAlias=%s)(mailEnabled=TRUE))`
-  - => Specify how ldap should be asked for aliases
+- e.g. `(&(mailAlias=%s)(mailEnabled=TRUE))`
+- => Specify how ldap should be asked for aliases
 
 ##### LDAP_QUERY_FILTER_DOMAIN
 
@@ -611,28 +641,28 @@ Note: activate this only if you are confident in your bayes database for identif
 
 ##### DOVECOT_TLS
 
-  - **empty** => no
-  - yes => LDAP over TLS enabled for Dovecot
+- **empty** => no
+- yes => LDAP over TLS enabled for Dovecot
 
-## Dovecot
+#### Dovecot
 
 The following variables overwrite the default values for ```/etc/dovecot/dovecot-ldap.conf.ext```.
 
 ##### DOVECOT_USER_FILTER
 
-  - e.g. `(&(objectClass=PostfixBookMailAccount)(uniqueIdentifier=%n))`
+- e.g. `(&(objectClass=PostfixBookMailAccount)(uniqueIdentifier=%n))`
 
 ##### DOVECOT_USER_ATTRS
 
- - e.g. `homeDirectory=home,qmailUID=uid,qmailGID=gid,mailMessageStore=mail`
- - => Specify the directory to dovecot attribute mapping that fits your directory structure.
- - Note: This is necessary for directories that do not use the [Postfix Book Schema](test/docker-openldap/bootstrap/schema/mmc/postfix-book.schema).
- - Note: The left-hand value is the directory attribute, the right hand value is the dovecot variable.
- - More details on the [Dovecot Wiki](https://wiki.dovecot.org/AuthDatabase/LDAP/Userdb)
+- e.g. `homeDirectory=home,qmailUID=uid,qmailGID=gid,mailMessageStore=mail`
+- => Specify the directory to dovecot attribute mapping that fits your directory structure.
+- Note: This is necessary for directories that do not use the [Postfix Book Schema](test/docker-openldap/bootstrap/schema/mmc/postfix-book.schema).
+- Note: The left-hand value is the directory attribute, the right hand value is the dovecot variable.
+- More details on the [Dovecot Wiki](https://wiki.dovecot.org/AuthDatabase/LDAP/Userdb)
 
 ##### DOVECOT_PASS_FILTER
 
-  - e.g. `(&(objectClass=PostfixBookMailAccount)(uniqueIdentifier=%n))`
+- e.g. `(&(objectClass=PostfixBookMailAccount)(uniqueIdentifier=%n))`
 
 ##### DOVECOT_PASS_ATTRS
 
@@ -642,95 +672,95 @@ The following variables overwrite the default values for ```/etc/dovecot/dovecot
 - Note: The left-hand value is the directory attribute, the right hand value is the dovecot variable.
 - More details on the [Dovecot Wiki](https://wiki.dovecot.org/AuthDatabase/LDAP/PasswordLookups)
 
-## Postgrey
+#### Postgrey
 
 ##### ENABLE_POSTGREY
 
-  - **0** => `postgrey` is disabled
-  - 1 => `postgrey` is enabled
+- **0** => `postgrey` is disabled
+- 1 => `postgrey` is enabled
 
 ##### POSTGREY_DELAY
 
-  - **300** => greylist for N seconds
+- **300** => greylist for N seconds
 
 Note: This postgrey setting needs `ENABLE_POSTGREY=1`
 
 ##### POSTGREY_MAX_AGE
 
-  - **35** => delete entries older than N days since the last time that they have been seen
+- **35** => delete entries older than N days since the last time that they have been seen
 
 Note: This postgrey setting needs `ENABLE_POSTGREY=1`
 
 ##### POSTGREY_AUTO_WHITELIST_CLIENTS
 
-  - **5** => whitelist host after N successful deliveries (N=0 to disable whitelisting)
+- **5** => whitelist host after N successful deliveries (N=0 to disable whitelisting)
 
 Note: This postgrey setting needs `ENABLE_POSTGREY=1`
 
 ##### POSTGREY_TEXT
 
-  - **Delayed by postgrey** => response when a mail is greylisted
+- **Delayed by postgrey** => response when a mail is greylisted
 
 Note: This postgrey setting needs `ENABLE_POSTGREY=1`
 
-## SASL Auth
+#### SASL Auth
 
 ##### ENABLE_SASLAUTHD
 
-  - **0** => `saslauthd` is disabled
-  - 1 => `saslauthd` is enabled
+- **0** => `saslauthd` is disabled
+- 1 => `saslauthd` is enabled
 
 ##### SASLAUTHD_MECHANISMS
 
-  - empty => pam
-  - `ldap` => authenticate against ldap server
-  - `shadow` => authenticate against local user db
-  - `mysql` => authenticate against mysql db
-  - `rimap` => authenticate against imap server
-  - NOTE: can be a list of mechanisms like pam ldap shadow
+- empty => pam
+- `ldap` => authenticate against ldap server
+- `shadow` => authenticate against local user db
+- `mysql` => authenticate against mysql db
+- `rimap` => authenticate against imap server
+- NOTE: can be a list of mechanisms like pam ldap shadow
 
 ##### SASLAUTHD_MECH_OPTIONS
 
-  - empty => None
-  - e.g. with SASLAUTHD_MECHANISMS rimap you need to specify the ip-address/servername of the imap server  ==> xxx.xxx.xxx.xxx
+- empty => None
+- e.g. with SASLAUTHD_MECHANISMS rimap you need to specify the ip-address/servername of the imap server  ==> xxx.xxx.xxx.xxx
 
 ##### SASLAUTHD_LDAP_SERVER
 
-  - empty => localhost
+- empty => localhost
 
 ##### SASLAUTHD_LDAP_SSL
 
-  - empty or 0 => `ldap://` will be used
-  - 1 => `ldaps://` will be used
+- empty or 0 => `ldap://` will be used
+- 1 => `ldaps://` will be used
 
 ##### SASLAUTHD_LDAP_BIND_DN
 
-  - empty => anonymous bind
-  - specify an object with privileges to search the directory tree
-  - e.g. active directory: SASLAUTHD_LDAP_BIND_DN=cn=Administrator,cn=Users,dc=mydomain,dc=net
-  - e.g. openldap: SASLAUTHD_LDAP_BIND_DN=cn=admin,dc=mydomain,dc=net
+- empty => anonymous bind
+- specify an object with privileges to search the directory tree
+- e.g. active directory: SASLAUTHD_LDAP_BIND_DN=cn=Administrator,cn=Users,dc=mydomain,dc=net
+- e.g. openldap: SASLAUTHD_LDAP_BIND_DN=cn=admin,dc=mydomain,dc=net
 
 ##### SASLAUTHD_LDAP_PASSWORD
 
-  - empty => anonymous bind
+- empty => anonymous bind
 
 ##### SASLAUTHD_LDAP_SEARCH_BASE
 
-  - empty => Reverting to SASLAUTHD_MECHANISMS pam
-  - specify the search base
+- empty => Reverting to SASLAUTHD_MECHANISMS pam
+- specify the search base
 
 ##### SASLAUTHD_LDAP_FILTER
 
-  - empty => default filter `(&(uniqueIdentifier=%u)(mailEnabled=TRUE))`
-  - e.g. for active directory: `(&(sAMAccountName=%U)(objectClass=person))`
-  - e.g. for openldap: `(&(uid=%U)(objectClass=person))`
+- empty => default filter `(&(uniqueIdentifier=%u)(mailEnabled=TRUE))`
+- e.g. for active directory: `(&(sAMAccountName=%U)(objectClass=person))`
+- e.g. for openldap: `(&(uid=%U)(objectClass=person))`
 
 ##### SASL_PASSWD
 
-  - **empty** => No sasl_passwd will be created
-  - string => `/etc/postfix/sasl_passwd` will be created with the string as password
+- **empty** => No sasl_passwd will be created
+- string => `/etc/postfix/sasl_passwd` will be created with the string as password
 
-## SRS (Sender Rewriting Scheme)
+#### SRS (Sender Rewriting Scheme)
 
 ##### SRS_SENDER_CLASSES
 
@@ -740,55 +770,55 @@ you to replace both instead of just the envelope sender.
 
 [More info](https://www.mybluelinux.com/what-is-email-envelope-and-email-header/).
 
-  - **envelope_sender** => Rewrite only envelope sender address
-  - header_sender => Rewrite only header sender (not recommended)
-  - envelope_sender,header_sender => Rewrite both senders
+- **envelope_sender** => Rewrite only envelope sender address
+- header_sender => Rewrite only header sender (not recommended)
+- envelope_sender,header_sender => Rewrite both senders
 
 ##### SRS_EXCLUDE_DOMAINS
 
-  - **empty** => Envelope sender will be rewritten for all domains
-  - provide comma separated list of domains to exclude from rewriting
+- **empty** => Envelope sender will be rewritten for all domains
+- provide comma separated list of domains to exclude from rewriting
 
 ##### SRS_SECRET
 
-  - **empty** => generated when the container is started for the first time
-  - provide a secret to use in base64
-  - you may specify multiple keys, comma separated. the first one is used for signing and the remaining will be used for verification. this is how you rotate and expire keys
-  - if you have a cluster/swarm make sure the same keys are on all nodes
-  - example command to generate a key: `dd if=/dev/urandom bs=24 count=1 2>/dev/null | base64`
+- **empty** => generated when the container is started for the first time
+- provide a secret to use in base64
+- you may specify multiple keys, comma separated. the first one is used for signing and the remaining will be used for verification. this is how you rotate and expire keys
+- if you have a cluster/swarm make sure the same keys are on all nodes
+- example command to generate a key: `dd if=/dev/urandom bs=24 count=1 2>/dev/null | base64`
 
 ##### SRS_DOMAINNAME
 
-  - **empty** => Derived from OVERRIDE_HOSTNAME, DOMAINNAME, or the container's hostname
-  - Set this if auto-detection fails, isn't what you want, or you wish to have a separate container handle DSNs
+- **empty** => Derived from OVERRIDE_HOSTNAME, DOMAINNAME, or the container's hostname
+- Set this if auto-detection fails, isn't what you want, or you wish to have a separate container handle DSNs
 
-## Default Relay Host
+#### Default Relay Host
 
 #### DEFAULT_RELAY_HOST
 
-  - **empty** => don't set default relayhost setting in main.cf
-  - default host and port to relay all mail through.
+- **empty** => don't set default relayhost setting in main.cf
+- default host and port to relay all mail through.
     Format: `[example.com]:587` (don't forget the brackets if you need this to
     be compatible with `$RELAY_USER` and `$RELAY_PASSWORD`, explained below).
 
-## Multi-domain Relay Hosts
+#### Multi-domain Relay Hosts
 
 #### RELAY_HOST
 
-  - **empty** => don't configure relay host
-  - default host to relay mail through
+- **empty** => don't configure relay host
+- default host to relay mail through
 
 #### RELAY_PORT
 
-  - **empty** => 25
-  - default port to relay mail through
+- **empty** => 25
+- default port to relay mail through
 
 #### RELAY_USER
 
-  - **empty** => no default
-  - default relay username (if no specific entry exists in postfix-sasl-password.cf)
+- **empty** => no default
+- default relay username (if no specific entry exists in postfix-sasl-password.cf)
 
 #### RELAY_PASSWORD
 
-  - **empty** => no default
-  - password for default relay user
+- **empty** => no default
+- password for default relay user

--- a/README.md
+++ b/README.md
@@ -62,21 +62,19 @@ Minimum:
 
 ## Usage
 
-#### Get latest image
-
-    docker pull tvial/docker-mailserver:latest
-
 #### Get the tools
 
 Download the docker-compose.yml, the .env and the setup.sh files:
 
-    curl -o setup.sh https://raw.githubusercontent.com/tomav/docker-mailserver/master/setup.sh; chmod a+x ./setup.sh
+``` SH
+curl -o setup.sh https://raw.githubusercontent.com/tomav/docker-mailserver/master/setup.sh; chmod a+x ./setup.sh
 
-    curl -o docker-compose.yml https://raw.githubusercontent.com/tomav/docker-mailserver/master/docker-compose.yml.dist
+curl -o docker-compose.yml https://raw.githubusercontent.com/tomav/docker-mailserver/master/docker-compose.yml.dist
 
-    curl -o .env https://raw.githubusercontent.com/tomav/docker-mailserver/master/.env.dist
+curl -o .env https://raw.githubusercontent.com/tomav/docker-mailserver/master/.env.dist
 
-    curl -o env-mailserver https://raw.githubusercontent.com/tomav/docker-mailserver/master/env-mailserver.dist
+curl -o env-mailserver https://raw.githubusercontent.com/tomav/docker-mailserver/master/env-mailserver.dist
+```
 
 #### Create a docker-compose environment
 

--- a/setup.sh
+++ b/setup.sh
@@ -19,6 +19,7 @@ DEFAULT_CONFIG_PATH="$(pwd)/config"
 USE_CONTAINER=false
 WISHED_CONFIG_PATH=''
 CONFIG_PATH=''
+VOLUME=''
 USE_TTY=''
 
 function _check_root()

--- a/setup.sh
+++ b/setup.sh
@@ -276,7 +276,7 @@ main()
 
     config)
       shift ; case ${1:-} in
-        dkim     ) _docker_image generate-dkim-config "$2" ;;
+        dkim     ) _docker_image generate-dkim-config "${2:-2048}" ;;
         ssl      ) _docker_image generate-ssl-certificate "$2" ;;
         *        ) _usage ;;
       esac


### PR DESCRIPTION
# Improvements for `setup.sh`

Following #1590, I re-wrote and refactored `setup.sh` to

- make shellcheck happy
- improve the overall readability of the script
- make the script consistent

**This PR obsoletes** #1258.

## Rationale

Looking at #1258, I adopted some changes, namely `set -eu` and the use of default values. This PR has the podman changes already in it and does therefore not need to be rebased. Looking at the use of `set -eu`, I am really not sure whether this is the best solution to be honest, and I would like to hear an opinion on this.

Furthermore, I restructured the script, setting description and default values in the beginning, followed by all functions. I believe this to be more consistent.

I also included the changes to `README.md` to reflect what @fbartels already did in #1258.

## Disclaimer

Not sure whether I made (one or more) (minor / major) mistakes while refactoring. The test will show. Bash is still Bash in the end.