### PR TITLE
Populate relayhost_map from virtual accounts (and other fixes)

### DIFF
--- a/target/check-for-changes.sh
+++ b/target/check-for-changes.sh
@@ -81,6 +81,7 @@ if ! cmp --silent -- "$CHKSUM_FILE" "$CHKSUM_FILE.new"; then
 	#regen postfix accounts.
 	echo -n > /etc/postfix/vmailbox
 	echo -n > /etc/dovecot/userdb
+
 	if [ -f /tmp/docker-mailserver/postfix-accounts.cf -a "$ENABLE_LDAP" != 1 ]; then
 		sed -i 's/\r//g' /tmp/docker-mailserver/postfix-accounts.cf
 		echo "# WARNING: this file is auto-generated. Modify config/postfix-accounts.cf to edit user list." > /etc/postfix/vmailbox

--- a/target/helper_functions.sh
+++ b/target/helper_functions.sh
@@ -73,3 +73,23 @@ for key, value in acme.items():
     return 1
   fi
 }
+
+# File storing the checksums of the monitored files.
+CHKSUM_FILE=/tmp/docker-mailserver-config-chksum
+
+# Compute checksums of monitored files.
+function monitored_files_checksums() {
+  (
+    cd /tmp/docker-mailserver
+    # (2>/dev/null to ignore warnings about files that don't exist)
+    exec sha512sum 2>/dev/null -- \
+           postfix-accounts.cf \
+           postfix-virtual.cf \
+           postfix-aliases.cf \
+           dovecot-quotas.cf \
+           /etc/letsencrypt/acme.json \
+           "/etc/letsencrypt/live/$HOSTNAME/key.pem" \
+           "/etc/letsencrypt/live/$HOSTNAME/fullchain.pem"
+  )
+  return 0
+}

--- a/target/helper_functions.sh
+++ b/target/helper_functions.sh
@@ -149,9 +149,12 @@ function populate_relayhost_map() {
     sed -n '/^\s*[^#[:space:]]\S*\s\+\S/p' /tmp/docker-mailserver/postfix-relaymap.cf \
         >> /etc/postfix/relayhost_map
   fi
-  # Note: Won't detect domains when lhs has spaces (but who does that?!).
-  sed -n '/^\s*[^#[:space:]]/ s/^[^@|]*@\([^|]\+\)|.*$/\1/p' /tmp/docker-mailserver/postfix-accounts.cf |
-  while read domain; do
+  {
+    # Note: Won't detect domains when lhs has spaces (but who does that?!).
+    sed -n '/^\s*[^#[:space:]]/ s/^[^@|]*@\([^|]\+\)|.*$/\1/p' /tmp/docker-mailserver/postfix-accounts.cf
+    [ -f /tmp/docker-mailserver/postfix-virtual.cf ] &&
+      sed -n '/^\s*[^#[:space:]]/ s/^\s*[^@[:space:]]*@\(\S\+\)\s.*/\1/p' /tmp/docker-mailserver/postfix-virtual.cf
+  } | while read domain; do
     if ! grep -q -e "^@${domain}\b" /etc/postfix/relayhost_map &&
        ! grep -qs -e "^\s*@${domain}\s*$" /tmp/docker-mailserver/postfix-relaymap.cf; then
       # Domain not already present *and* not ignored.

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -500,19 +500,9 @@ function _setup_file_permissions() {
 function _setup_chksum_file() {
         notify 'task' "Setting up configuration checksum file"
 
-
         if [ -d /tmp/docker-mailserver ]; then
-          pushd /tmp/docker-mailserver
-
-          declare -a cf_files=()
-          for file in postfix-accounts.cf postfix-virtual.cf postfix-aliases.cf dovecot-quotas.cf /etc/letsencrypt/acme.json "/etc/letsencrypt/live/$HOSTNAME/key.pem" "/etc/letsencrypt/live/$HOSTNAME/fullchain.pem"; do
-            [ -f "$file" ] && cf_files+=("$file")
-          done
-
           notify 'inf' "Creating $CHKSUM_FILE"
-          sha512sum ${cf_files[@]/#/--tag } >$CHKSUM_FILE
-
-          popd
+          monitored_files_checksums >"$CHKSUM_FILE"
         else
           # We could just skip the file, but perhaps config can be added later?
           # If so it must be processed by the check for changes script

--- a/test/config/relay-hosts/postfix-virtual.cf
+++ b/test/config/relay-hosts/postfix-virtual.cf
@@ -1,0 +1,1 @@
+@domain1.tld user1@domainone.tld

--- a/test/mail_ssl_letsencrypt.bats
+++ b/test/mail_ssl_letsencrypt.bats
@@ -118,7 +118,7 @@ function teardown_file() {
   assert_output --partial "Cert found in /etc/letsencrypt/acme.json for *.example.com"
   assert_output --partial "postfix: stopped"
   assert_output --partial "postfix: started"
-  assert_output --partial "Update checksum"
+  assert_output --partial "Change detected"
 
   run docker exec mail_lets_acme_json /bin/bash -c "cat /etc/letsencrypt/live/mail.my-domain.com/key.pem"
   assert_output "$(cat "`pwd`/test/config/letsencrypt/changed/key.pem")"

--- a/test/mail_with_relays.bats
+++ b/test/mail_with_relays.bats
@@ -42,6 +42,11 @@ function teardown_file() {
   assert_output -e '^@domainone.tld\s+\[default.relay.com\]:2525$'
 }
 
+@test "checking relay hosts: default mapping is added from env vars for virtual user entry" {
+  run docker exec mail_with_relays grep -e domain1.tld /etc/postfix/relayhost_map
+  assert_output -e '^@domain1.tld\s+\[default.relay.com\]:2525$'
+}
+
 @test "checking relay hosts: default mapping is added from env vars for new user entry" {
   run docker exec mail_with_relays grep -e domainzero.tld /etc/postfix/relayhost_map
   assert_output ''
@@ -52,6 +57,18 @@ function teardown_file() {
     [[ $status == 0 ]] && break
   done
   assert_output -e '^@domainzero.tld\s+\[default.relay.com\]:2525$'
+}
+
+@test "checking relay hosts: default mapping is added from env vars for new virtual user entry" {
+  run docker exec mail_with_relays grep -e domain2.tld /etc/postfix/relayhost_map
+  assert_output ''
+  run ./setup.sh -c mail_with_relays alias add user2@domain2.tld user2@domaintwo.tld
+  for i in {1..10}; do
+    sleep 1
+    run docker exec mail_with_relays grep -e domain2.tld /etc/postfix/relayhost_map
+    [[ $status == 0 ]] && break
+  done
+  assert_output -e '^@domain2.tld\s+\[default.relay.com\]:2525$'
 }
 
 @test "checking relay hosts: custom mapping is added from file" {

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -20,7 +20,7 @@ function wait_for_service() {
 
 function count_processed_changes() {
   containerName=$1
-  docker exec $containerName cat /var/log/supervisor/changedetector.log | grep "Update checksum" | wc -l
+  docker exec $containerName cat /var/log/supervisor/changedetector.log | grep "Change detected" | wc -l
 }
 
 #


### PR DESCRIPTION
I started this branch to enable relaying through virtual account domains (before, only domains found in postfix-accounts.cf and postfix-relaymap.cf were taken into account). I bumped into some bugs along the way so I ended up having to do a bit of fixing and refactoring (see first two commits).