### PR TITLE
Fix for #1603

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -57,7 +57,7 @@ function _update_config_path()
 {
   if [[ -n ${CONTAINER_NAME} ]]
   then
-    VOLUME=$(docker inspect "${CONTAINER_NAME}" \
+    VOLUME=$(${CRI} inspect "${CONTAINER_NAME}" \
       --format="{{range .Mounts}}{{ println .Source .Destination}}{{end}}" | \
       grep "/tmp/docker-mailserver$" 2>/dev/null)
   fi


### PR DESCRIPTION
This is nothing more than a fix for #1603 regarding the use of "${CRI}" instead of `docker` to make `podmand` work.