### PR TITLE
Complete refactoring for `start-mailserver.sh`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,10 +51,10 @@ The development workflow is the following:
 
 ### Bash and Shell
 
-When refactoring, writing or altering Script, that is Shell and Bash scripts, in any way, adhere to these rules:
+When refactoring, writing or altering scripts, that is Shell and Bash scripts, in any way, adhere to these rules:
 
 1. **Adjust your style of coding to the style that is already present**! Even if you do not like it, this is due to consistency. Look up the GNU coding style guide. There was a lot of work involved in making these scripts consistent.
-2. **Use `shellcheck` to check your scripts**! Your contributions are checked by TravisCI with shellcheck.
+2. **Use `shellcheck` to check your scripts**! Your contributions are checked by TravisCI with shellcheck. You can check your scripts like Travis with `make shellcheck`.
 3. There is a **`.editorconfig`** file. Make your IDE use it or adhere to it manually!
 4. It's okay to use `/bin/bash` instead of `/bin/sh`. You can alternatively use `/usr/bin/env bash`.
 5. `setup.sh` provides a good starting point to look for.
@@ -84,15 +84,15 @@ When writing a script, provide the version and the script's task. We use [semant
 if [[ <CONDITION1> ]] && [[ -f ${FILE} ]]
 then
   <CODE TO RUN>
-# when running code, you don't need them
+# when running commands, you don't need braces
 elif <COMMAND TO RUN>
   <CODE TO TUN>
 else
   <CODE TO TUN>
 fi
 
-# equality checks with numbers, use
-# -eq/-ne/-lt/-ge, not != or ==
+# equality checks with numbers are done
+# with -eq/-ne/-lt/-ge, not != or ==
 if [[ $VAR -ne 42 ]] || [[ $SOME_VAR -eq 6 ]]
 then
   <CODE TO RUN>
@@ -133,7 +133,7 @@ function _<name_underscored_and_lowercase>()
   <CODE TO RUN>
 
   # variables that can be local should be local
-  local _<LOCAL_VARIABLE_NAME>
+  local <LOCAL_VARIABLE_NAME>
 }
 ```
 
@@ -157,23 +157,6 @@ function _report_err()
 
 Comments should only describe non-obvious matters. Comments should start lowercase when they aren't sentences. Make the code **self-descriptive** by using meaningful names! Make comments not longer than approximately 80 columns, then wrap the line.
 
-A negative example:
-
-``` BASH
-# adds one to the first argument and print it to stdout
-function _add_one()
-{
-  # save the first variable
-  local FIRST=$1
-
-  # add one here
-  local RESULT=$(( _FIRST + 1 ))
-
-  # print it to stdout
-  echo "$_RESULT"
-}
-```
-
 A positive example:
 
 ``` BASH
@@ -184,14 +167,31 @@ function _add_one()
 }
 ```
 
+A negative example:
+
+``` BASH
+# adds one to the first argument and print it to stdout
+function _add_one()
+{
+  # save the first variable
+  local FIRST=$1
+
+  # add one here
+  local RESULT=$(( FIRST + 1 ))
+
+  # print it to stdout
+  echo "$_RESULT"
+}
+```
+
 ### YAML
 
-When formatting YAML files, you can opt for [Prettier][prettier]. There are any plugins for IDEs around.
+When formatting YAML files, you can opt for [Prettier][prettier]. There are many plugins for IDEs around.
 
 [//]: # (Links)
 
 [commit]: https://help.github.com/articles/closing-issues-via-commit-messages/
 [gpg]: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
 [semver]: https://semver.org/
-[regex]: https://regex101.com/r/ikzJpF/4
+[regex]: https://regex101.com/r/ikzJpF/5
 [prettier]: https://prettier.io

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ shellcheck:
 	@ shellcheck --version
 	@ echo ''
 # currently without `start-mailserver` as this is to be merged separately
-	@ if find -iname "*.sh" -not -path "./test/*" -not -path "./target/docker-configomat/*" -not -wholename ./target/start-mailserver.sh -exec shellcheck -S style -Cauto -o all -e SC2250,SC2154 -W 50 {} \; | grep .; then\
+	@ if find -iname "*.sh" -not -path "./test/*" -not -path "./target/docker-configomat/*" -exec shellcheck -S style -Cauto -o all -e SC2154 -W 50 {} \; | grep .; then\
 		echo -e "\nError" ;\
 		exit 1 ;\
 	else\

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ shellcheck:
 	@ echo -e "Testing shell / bash scripts with shellcheck\n"
 	@ /usr/bin/shellcheck --version
 	@ echo ''
-	@ if find -iname "*.sh" -not -path "./test/*" -not -path "./target/docker-configomat/*" -exec shellcheck -S style -Cauto -o all -e SC2154 -W 50 {} \; | grep .; then\
+	@ if find -iname "*.sh" -not -path "./test/*" -not -path "./target/docker-configomat/*" -exec /usr/bin/shellcheck -S style -Cauto -o all -e SC2154 -W 50 {} \; | grep .; then\
 		echo -e "\nError" ;\
 		exit 1 ;\
 	else\

--- a/target/dovecot/scripts/quota-warning.sh
+++ b/target/dovecot/scripts/quota-warning.sh
@@ -2,10 +2,11 @@
 
 # Report a quota usage warning to an user
 
-PERCENT=$1
-USER=$2
-DOMAIN=$3
+PERCENT="${1}"
+USER="${2}"
+DOMAIN="${3}"
 
+# shellcheck disable=SC2250
 cat << EOF | /usr/lib/dovecot/dovecot-lda -d "$USER" -o "plugin/quota=maildir:User quota:noenforcing"
 From: postmaster@$DOMAIN
 Subject: quota warning

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -96,130 +96,130 @@ CHKSUM_FILE=/tmp/docker-mailserver-config-chksum
 
 function register_functions()
 {
-	_notify 'taskgrp' 'Initializing setup'
-	_notify 'task' 'Registering check,setup,fix,misc and start-daemons functions'
+  _notify 'taskgrp' 'Initializing setup'
+  _notify 'task' 'Registering check,setup,fix,misc and start-daemons functions'
 
-	################### >> check funcs
+  ################### >> check funcs
 
-	_register_check_function "_check_environment_variables"
-	_register_check_function "_check_hostname"
+  _register_check_function "_check_environment_variables"
+  _register_check_function "_check_hostname"
 
-	################### << check funcs
+  ################### << check funcs
 
-	################### >> setup funcs
+  ################### >> setup funcs
 
-	_register_setup_function "_setup_default_vars"
-	_register_setup_function "_setup_file_permissions"
+  _register_setup_function "_setup_default_vars"
+  _register_setup_function "_setup_file_permissions"
 
-	if [[ $SMTP_ONLY -ne 1 ]]
+  if [[ ${SMTP_ONLY} -ne 1 ]]
   then
-		_register_setup_function "_setup_dovecot"
+    _register_setup_function "_setup_dovecot"
     _register_setup_function "_setup_dovecot_dhparam"
-		_register_setup_function "_setup_dovecot_quota"
-		_register_setup_function "_setup_dovecot_local_user"
-	fi
+    _register_setup_function "_setup_dovecot_quota"
+    _register_setup_function "_setup_dovecot_local_user"
+  fi
 
-	[[ $ENABLE_LDAP -eq 1 ]] && _register_setup_function "_setup_ldap"
-	[[ $ENABLE_SASLAUTHD -eq 1 ]] && _register_setup_function "_setup_saslauthd"
-	[[ $ENABLE_POSTGREY -eq 1 ]] && _register_setup_function "_setup_postgrey"
+  [[ ${ENABLE_LDAP} -eq 1 ]] && _register_setup_function "_setup_ldap"
+  [[ ${ENABLE_SASLAUTHD} -eq 1 ]] && _register_setup_function "_setup_saslauthd"
+  [[ ${ENABLE_POSTGREY} -eq 1 ]] && _register_setup_function "_setup_postgrey"
 
-	_register_setup_function "_setup_dkim"
-	_register_setup_function "_setup_ssl"
+  _register_setup_function "_setup_dkim"
+  _register_setup_function "_setup_ssl"
 
-	[[ $POSTFIX_INET_PROTOCOLS != "all" ]] && _register_setup_function "_setup_inet_protocols"
+  [[ ${POSTFIX_INET_PROTOCOLS} != "all" ]] && _register_setup_function "_setup_inet_protocols"
 
-	_register_setup_function "_setup_docker_permit"
+  _register_setup_function "_setup_docker_permit"
 
-	_register_setup_function "_setup_mailname"
-	_register_setup_function "_setup_amavis"
-	_register_setup_function "_setup_dmarc_hostname"
-	_register_setup_function "_setup_postfix_hostname"
-	_register_setup_function "_setup_dovecot_hostname"
+  _register_setup_function "_setup_mailname"
+  _register_setup_function "_setup_amavis"
+  _register_setup_function "_setup_dmarc_hostname"
+  _register_setup_function "_setup_postfix_hostname"
+  _register_setup_function "_setup_dovecot_hostname"
 
-	_register_setup_function "_setup_postfix_smtputf8"
-	_register_setup_function "_setup_postfix_sasl"
-	_register_setup_function "_setup_postfix_sasl_password"
-	_register_setup_function "_setup_security_stack"
-	_register_setup_function "_setup_postfix_aliases"
-	_register_setup_function "_setup_postfix_vhost"
-	_register_setup_function "_setup_postfix_dhparam"
-	_register_setup_function "_setup_postfix_postscreen"
-	_register_setup_function "_setup_postfix_sizelimits"
+  _register_setup_function "_setup_postfix_smtputf8"
+  _register_setup_function "_setup_postfix_sasl"
+  _register_setup_function "_setup_postfix_sasl_password"
+  _register_setup_function "_setup_security_stack"
+  _register_setup_function "_setup_postfix_aliases"
+  _register_setup_function "_setup_postfix_vhost"
+  _register_setup_function "_setup_postfix_dhparam"
+  _register_setup_function "_setup_postfix_postscreen"
+  _register_setup_function "_setup_postfix_sizelimits"
 
-  [[ $SPOOF_PROTECTION -eq 1 ]] && _register_setup_function "_setup_spoof_protection"
+  [[ ${SPOOF_PROTECTION} -eq 1 ]] && _register_setup_function "_setup_spoof_protection"
 
-	if [[ $ENABLE_SRS -eq 1  ]]
+  if [[ ${ENABLE_SRS} -eq 1  ]]
   then
-		_register_setup_function "_setup_SRS"
-		_register_start_daemon "_start_daemons_postsrsd"
-	fi
+    _register_setup_function "_setup_SRS"
+    _register_start_daemon "_start_daemons_postsrsd"
+  fi
 
   _register_setup_function "_setup_postfix_access_control"
 
-	if [[ -n $AWS_SES_HOST ]] && [[ -n $AWS_SES_USERPASS ]]
+  if [[ -n ${AWS_SES_HOST} ]] && [[ -n ${AWS_SES_USERPASS} ]]
   then
-		_register_setup_function "_setup_postfix_relay_hosts"
-	fi
+    _register_setup_function "_setup_postfix_relay_hosts"
+  fi
 
-	[[ -n $DEFAULT_RELAY_HOST ]] && _register_setup_function "_setup_postfix_default_relay_host"
-	[[ -n $RELAY_HOST ]] && _register_setup_function "_setup_postfix_relay_hosts"
-	[[ $ENABLE_POSTFIX_VIRTUAL_TRANSPORT -eq 1 ]] && _register_setup_function "_setup_postfix_virtual_transport"
+  [[ -n ${DEFAULT_RELAY_HOST} ]] && _register_setup_function "_setup_postfix_default_relay_host"
+  [[ -n ${RELAY_HOST} ]] && _register_setup_function "_setup_postfix_relay_hosts"
+  [[ ${ENABLE_POSTFIX_VIRTUAL_TRANSPORT} -eq 1 ]] && _register_setup_function "_setup_postfix_virtual_transport"
 
-	_register_setup_function "_setup_postfix_override_configuration"
+  _register_setup_function "_setup_postfix_override_configuration"
   _register_setup_function "_setup_environment"
   _register_setup_function "_setup_logrotate"
 
-  [[ $PFLOGSUMM_TRIGGER != "none" ]] && _register_setup_function "_setup_mail_summary"
-	[[ $LOGWATCH_TRIGGER != "none" ]] && _register_setup_function "_setup_logwatch"
+  [[ ${PFLOGSUMM_TRIGGER} != "none" ]] && _register_setup_function "_setup_mail_summary"
+  [[ ${LOGWATCH_TRIGGER} != "none" ]] && _register_setup_function "_setup_logwatch"
 
-	_register_setup_function "_setup_user_patches"
+  _register_setup_function "_setup_user_patches"
 
   # Compute last as the config files are modified in-place
   _register_setup_function "_setup_chksum_file"
 
-	################### << setup funcs
+  ################### << setup funcs
 
-	################### >> fix funcs
+  ################### >> fix funcs
 
-	_register_fix_function "_fix_var_mail_permissions"
-	_register_fix_function "_fix_var_amavis_permissions"
+  _register_fix_function "_fix_var_mail_permissions"
+  _register_fix_function "_fix_var_amavis_permissions"
 
-	[[ $ENABLE_CLAMAV -eq 0 ]] && _register_fix_function "_fix_cleanup_clamav"
-	[[ $ENABLE_SPAMASSASSIN -eq 0 ]] &&	_register_fix_function "_fix_cleanup_spamassassin"
+  [[ ${ENABLE_CLAMAV} -eq 0 ]] && _register_fix_function "_fix_cleanup_clamav"
+  [[ ${ENABLE_SPAMASSASSIN} -eq 0 ]] &&	_register_fix_function "_fix_cleanup_spamassassin"
 
-	################### << fix funcs
+  ################### << fix funcs
 
-	################### >> misc funcs
+  ################### >> misc funcs
 
-	_register_misc_function "_misc_save_states"
+  _register_misc_function "_misc_save_states"
 
-	################### << misc funcs
+  ################### << misc funcs
 
-	################### >> daemon funcs
+  ################### >> daemon funcs
 
-	_register_start_daemon "_start_daemons_cron"
-	_register_start_daemon "_start_daemons_rsyslog"
+  _register_start_daemon "_start_daemons_cron"
+  _register_start_daemon "_start_daemons_rsyslog"
 
-	[[ $SMTP_ONLY -ne 1 ]] && _register_start_daemon "_start_daemons_dovecot"
+  [[ ${SMTP_ONLY} -ne 1 ]] && _register_start_daemon "_start_daemons_dovecot"
 
-	# needs to be started before saslauthd
-	_register_start_daemon "_start_daemons_opendkim"
-	_register_start_daemon "_start_daemons_opendmarc"
+  # needs to be started before saslauthd
+  _register_start_daemon "_start_daemons_opendkim"
+  _register_start_daemon "_start_daemons_opendmarc"
 
-	#postfix uses postgrey, needs to be started before postfix
-	[[ $ENABLE_POSTGREY -eq 1 ]] &&	_register_start_daemon "_start_daemons_postgrey"
+  #postfix uses postgrey, needs to be started before postfix
+  [[ ${ENABLE_POSTGREY} -eq 1 ]] &&	_register_start_daemon "_start_daemons_postgrey"
 
-	_register_start_daemon "_start_daemons_postfix"
+  _register_start_daemon "_start_daemons_postfix"
 
-	[[ $ENABLE_SASLAUTHD -eq 1 ]] && _register_start_daemon "_start_daemons_saslauthd"
-	[[ $ENABLE_FAIL2BAN -eq 1 ]] &&	_register_start_daemon "_start_daemons_fail2ban" # care :: needs to run after postfix
-	[[ $ENABLE_FETCHMAIL -eq 1 ]] && _register_start_daemon "_start_daemons_fetchmail"
-	[[ $ENABLE_CLAMAV -eq 1 ]] &&	_register_start_daemon "_start_daemons_clamav"
-  [[ $ENABLE_LDAP -eq 0 ]] && _register_start_daemon "_start_changedetector"
+  [[ ${ENABLE_SASLAUTHD} -eq 1 ]] && _register_start_daemon "_start_daemons_saslauthd"
+  [[ ${ENABLE_FAIL2BAN} -eq 1 ]] &&	_register_start_daemon "_start_daemons_fail2ban" # care :: needs to run after postfix
+  [[ ${ENABLE_FETCHMAIL} -eq 1 ]] && _register_start_daemon "_start_daemons_fetchmail"
+  [[ ${ENABLE_CLAMAV} -eq 1 ]] &&	_register_start_daemon "_start_daemons_clamav"
+  [[ ${ENABLE_LDAP} -eq 0 ]] && _register_start_daemon "_start_changedetector"
 
-	_register_start_daemon "_start_daemons_amavis"
+  _register_start_daemon "_start_daemons_amavis"
 
-	################### << daemon funcs
+  ################### << daemon funcs
 }
 
 ##########################################################################
@@ -254,32 +254,32 @@ declare -a DAEMONS_START
 
 function _register_start_daemon()
 {
-	DAEMONS_START+=("$1")
-	_notify 'inf' "$1() registered"
+  DAEMONS_START+=("${1}")
+  _notify 'inf' "${1}() registered"
 }
 
 function _register_setup_function()
 {
-	FUNCS_SETUP+=("$1")
-	_notify 'inf' "$1() registered"
+  FUNCS_SETUP+=("${1}")
+  _notify 'inf' "${1}() registered"
 }
 
 function _register_fix_function()
 {
-	FUNCS_FIX+=("$1")
-	_notify 'inf' "$1() registered"
+  FUNCS_FIX+=("${1}")
+  _notify 'inf' "${1}() registered"
 }
 
 function _register_check_function()
 {
-	FUNCS_CHECK+=("$1")
-	_notify 'inf' "$1() registered"
+  FUNCS_CHECK+=("${1}")
+  _notify 'inf' "${1}() registered"
 }
 
 function _register_misc_function()
 {
-	FUNCS_MISC+=("$1")
-	_notify 'inf' "$1() registered"
+  FUNCS_MISC+=("${1}")
+  _notify 'inf' "${1}() registered"
 }
 
 ##########################################################################
@@ -288,27 +288,27 @@ function _register_misc_function()
 
 function _defunc()
 {
-	_notify 'fatal' "Please fix your configuration. Exiting..."
-	exit 1
+  _notify 'fatal' "Please fix your configuration. Exiting..."
+  exit 1
 }
 
 function display_startup_daemon()
 {
-  $1 &>/dev/null
-  res=$?
+  ${1} &>/dev/null
+  local RES=${?}
 
   if [[ ${DEFAULT_VARS["DMS_DEBUG"]} -eq 1 ]]
   then
-	  if [[ $res -eq 0 ]]
+    if [[ ${RES} -eq 0 ]]
     then
-			_notify 'started' " [ OK ]"
-		else
-	  	echo "false"
-			_notify 'err' " [ FAILED ]"
-		fi
+      _notify 'started' " [ OK ]"
+    else
+      echo "false"
+      _notify 'err' " [ FAILED ]"
+    fi
   fi
 
-	return $res
+  return "${RES}"
 }
 
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -324,45 +324,45 @@ function display_startup_daemon()
 
 function check()
 {
-	_notify 'taskgrp' 'Checking configuration'
+  _notify 'taskgrp' 'Checking configuration'
 
-	for _func in "${FUNCS_CHECK[@]}"
+  for FUNC in "${FUNCS_CHECK[@]}"
   do
-		if ! $_func
+    if ! ${FUNC}
     then
       _defunc
     fi
-	done
+  done
 }
 
 function _check_hostname()
 {
   # shellcheck disable=SC2128
-	_notify "task" "Check that hostname/domainname is provided or overridden (no default docker hostname/kubernetes) [$FUNCNAME]"
+  _notify "task" "Check that hostname/domainname is provided or overridden (no default docker hostname/kubernetes) [${FUNCNAME}]"
 
-	if [[ -n ${DEFAULT_VARS["OVERRIDE_HOSTNAME"]} ]]
+  if [[ -n ${DEFAULT_VARS["OVERRIDE_HOSTNAME"]} ]]
   then
-		export HOSTNAME=${DEFAULT_VARS["OVERRIDE_HOSTNAME"]}
-		export DOMAINNAME="${HOSTNAME#*.}"
-	fi
+    export HOSTNAME=${DEFAULT_VARS["OVERRIDE_HOSTNAME"]}
+    export DOMAINNAME="${HOSTNAME#*.}"
+  fi
 
-	_notify 'inf' "Domain has been set to $DOMAINNAME"
-	_notify 'inf' "Hostname has been set to $HOSTNAME"
+  _notify 'inf' "Domain has been set to ${DOMAINNAME}"
+  _notify 'inf' "Hostname has been set to ${HOSTNAME}"
 
-	if ( ! echo $HOSTNAME | grep -E '^(\S+[.]\S+)$' > /dev/null )
+  if ( ! echo "${HOSTNAME}" | grep -E '^(\S+[.]\S+)$' > /dev/null )
   then
-		_notify 'err' "Setting hostname/domainname is required"
-		kill "$(cat /var/run/supervisord.pid)" && return 1
-	else
-		return 0
-	fi
+    _notify 'err' "Setting hostname/domainname is required"
+    kill "$(cat /var/run/supervisord.pid)" && return 1
+  else
+    return 0
+  fi
 }
 
 function _check_environment_variables()
 {
   # shellcheck disable=SC2128
-	_notify "task" "Check that there are no conflicts with env variables [$FUNCNAME]"
-	return 0
+  _notify "task" "Check that there are no conflicts with env variables [${FUNCNAME}]"
+  return 0
 }
 
 ##########################################################################
@@ -378,55 +378,55 @@ function _check_environment_variables()
 
 function setup()
 {
-	_notify 'taskgrp' 'Configuring mail server'
-	for _func in "${FUNCS_SETUP[@]}"
+  _notify 'taskgrp' 'Configuring mail server'
+  for FUNC in "${FUNCS_SETUP[@]}"
   do
-		$_func
-	done
+    ${FUNC}
+  done
 }
 
 function _setup_default_vars()
 {
   # shellcheck disable=SC2128
-	_notify 'task' "Setting up default variables [$FUNCNAME]"
+  _notify 'task' "Setting up default variables [${FUNCNAME}]"
 
-	# update POSTMASTER_ADDRESS - must be done done after _check_hostname
-	DEFAULT_VARS["POSTMASTER_ADDRESS"]="${POSTMASTER_ADDRESS:=postmaster@${DOMAINNAME}}"
+  # update POSTMASTER_ADDRESS - must be done done after _check_hostname
+  DEFAULT_VARS["POSTMASTER_ADDRESS"]="${POSTMASTER_ADDRESS:=postmaster@${DOMAINNAME}}"
 
-	# update REPORT_SENDER - must be done done after _check_hostname
-	DEFAULT_VARS["REPORT_SENDER"]="${REPORT_SENDER:=mailserver-report@${HOSTNAME}}"
-	DEFAULT_VARS["PFLOGSUMM_SENDER"]="${PFLOGSUMM_SENDER:=${REPORT_SENDER}}"
+  # update REPORT_SENDER - must be done done after _check_hostname
+  DEFAULT_VARS["REPORT_SENDER"]="${REPORT_SENDER:=mailserver-report@${HOSTNAME}}"
+  DEFAULT_VARS["PFLOGSUMM_SENDER"]="${PFLOGSUMM_SENDER:=${REPORT_SENDER}}"
 
-	# set PFLOGSUMM_TRIGGER here for backwards compatibility
-	# when REPORT_RECIPIENT is on the old method should be used
-	if [[ "$REPORT_RECIPIENT" == "0" ]]
+  # set PFLOGSUMM_TRIGGER here for backwards compatibility
+  # when REPORT_RECIPIENT is on the old method should be used
+  if [[ "${REPORT_RECIPIENT}" == "0" ]]
   then
-		DEFAULT_VARS["PFLOGSUMM_TRIGGER"]="${PFLOGSUMM_TRIGGER:="none"}"
-	else
-		DEFAULT_VARS["PFLOGSUMM_TRIGGER"]="${PFLOGSUMM_TRIGGER:="logrotate"}"
-	fi
+    DEFAULT_VARS["PFLOGSUMM_TRIGGER"]="${PFLOGSUMM_TRIGGER:="none"}"
+  else
+    DEFAULT_VARS["PFLOGSUMM_TRIGGER"]="${PFLOGSUMM_TRIGGER:="logrotate"}"
+  fi
 
-	# expand address to simplify the rest of the script
-	if [[ "$REPORT_RECIPIENT" == "0" ]] || [[ "$REPORT_RECIPIENT" == "1" ]]
+  # expand address to simplify the rest of the script
+  if [[ "${REPORT_RECIPIENT}" == "0" ]] || [[ "${REPORT_RECIPIENT}" == "1" ]]
   then
-		REPORT_RECIPIENT="$POSTMASTER_ADDRESS"
-		DEFAULT_VARS["REPORT_RECIPIENT"]="${REPORT_RECIPIENT}"
-	fi
+    REPORT_RECIPIENT="${POSTMASTER_ADDRESS}"
+    DEFAULT_VARS["REPORT_RECIPIENT"]="${REPORT_RECIPIENT}"
+  fi
 
-	DEFAULT_VARS["PFLOGSUMM_RECIPIENT"]="${PFLOGSUMM_RECIPIENT:=${REPORT_RECIPIENT}}"
-	DEFAULT_VARS["LOGWATCH_RECIPIENT"]="${LOGWATCH_RECIPIENT:=${REPORT_RECIPIENT}}"
+  DEFAULT_VARS["PFLOGSUMM_RECIPIENT"]="${PFLOGSUMM_RECIPIENT:=${REPORT_RECIPIENT}}"
+  DEFAULT_VARS["LOGWATCH_RECIPIENT"]="${LOGWATCH_RECIPIENT:=${REPORT_RECIPIENT}}"
 
-	for var in "${!DEFAULT_VARS[@]}"
+  for var in "${!DEFAULT_VARS[@]}"
   do
-		if ! echo "export $var=\"${DEFAULT_VARS[$var]}\"" >> /root/.bashrc
+    if ! echo "export ${var}=\"${DEFAULT_VARS[${var}]}\"" >>/root/.bashrc
     then
-      _notify 'err' "Unable to set $var=${DEFAULT_VARS[$var]}"
+      _notify 'err' "Unable to set ${var}=${DEFAULT_VARS[${var}]}"
       kill -15 "$(cat /var/run/supervisord.pid)"
       return 1
     fi
 
-		_notify 'inf' "Set $var=${DEFAULT_VARS[$var]}"
-	done
+    _notify 'inf' "Set ${var}=${DEFAULT_VARS[${var}]}"
+  done
 }
 
 # File/folder permissions are fine when using docker volumes, but may be wrong
@@ -434,20 +434,20 @@ function _setup_default_vars()
 # Set the expected values and create missing folders/files just in case.
 function _setup_file_permissions()
 {
-	_notify 'task' "Setting file/folder permissions"
+  _notify 'task' "Setting file/folder permissions"
 
-	mkdir -p /var/log/supervisor
+  mkdir -p /var/log/supervisor
 
-	mkdir -p /var/log/mail
-	chown syslog:root /var/log/mail
+  mkdir -p /var/log/mail
+  chown syslog:root /var/log/mail
 
-	touch /var/log/mail/clamav.log
-	chown clamav:adm /var/log/mail/clamav.log
-	chmod 640 /var/log/mail/clamav.log
+  touch /var/log/mail/clamav.log
+  chown clamav:adm /var/log/mail/clamav.log
+  chmod 640 /var/log/mail/clamav.log
 
-	touch /var/log/mail/freshclam.log
-	chown clamav:adm /var/log/mail/freshclam.log
-	chmod 640 /var/log/mail/freshclam.log
+  touch /var/log/mail/freshclam.log
+  chown clamav:adm /var/log/mail/freshclam.log
+  chmod 640 /var/log/mail/freshclam.log
 }
 
 function _setup_chksum_file()
@@ -456,65 +456,67 @@ function _setup_chksum_file()
 
   if [[ -d /tmp/docker-mailserver ]]
   then
-    _notify 'inf' "Creating $CHKSUM_FILE"
-    _monitored_files_checksums >"$CHKSUM_FILE"
+    _notify 'inf' "Creating ${CHKSUM_FILE}"
+    _monitored_files_checksums >"${CHKSUM_FILE}"
   else
     # We could just skip the file, but perhaps config can be added later?
     # If so it must be processed by the check for changes script
-    _notify 'inf' "Creating empty $CHKSUM_FILE (no config)"
-    touch $CHKSUM_FILE
+    _notify 'inf' "Creating empty ${CHKSUM_FILE} (no config)"
+    touch "${CHKSUM_FILE}"
   fi
 }
 
 function _setup_mailname()
 {
-	_notify 'task' 'Setting up Mailname'
+  _notify 'task' 'Setting up Mailname'
 
-	_notify 'inf' "Creating /etc/mailname"
-	echo $DOMAINNAME > /etc/mailname
+  _notify 'inf' "Creating /etc/mailname"
+  echo "${DOMAINNAME}" > /etc/mailname
 }
 
 function _setup_amavis()
 {
-	_notify 'task' 'Setting up Amavis'
+  _notify 'task' 'Setting up Amavis'
 
-	_notify 'inf' "Applying hostname to /etc/amavis/conf.d/05-node_id"
-  # shellcheck disable=SC2016
-	sed -i 's/^#\$myhostname = "mail.example.com";/\$myhostname = "'$HOSTNAME'";/' /etc/amavis/conf.d/05-node_id
+  _notify 'inf' "Applying hostname to /etc/amavis/conf.d/05-node_id"
+  # shellcheck disable=SC2016,SC2248,SC2250
+  sed -i 's/^#\$myhostname = "mail.example.com";/\$myhostname = "'$HOSTNAME'";/' /etc/amavis/conf.d/05-node_id
 }
 
 function _setup_dmarc_hostname()
 {
-	_notify 'task' 'Setting up dmarc'
+  _notify 'task' 'Setting up dmarc'
 
-	_notify 'inf' "Applying hostname to /etc/opendmarc.conf"
-	sed -i -e 's/^AuthservID.*$/AuthservID          '$HOSTNAME'/g' \
-	  -e 's/^TrustedAuthservIDs.*$/TrustedAuthservIDs  '$HOSTNAME'/g' /etc/opendmarc.conf
+  _notify 'inf' "Applying hostname to /etc/opendmarc.conf"
+  # shellcheck disable=SC2248,SC2250
+  sed -i -e 's/^AuthservID.*$/AuthservID          '$HOSTNAME'/g' \
+    -e 's/^TrustedAuthservIDs.*$/TrustedAuthservIDs  '$HOSTNAME'/g' /etc/opendmarc.conf
 }
 
 function _setup_postfix_hostname()
 {
-	_notify 'task' 'Applying hostname and domainname to Postfix'
+  _notify 'task' 'Applying hostname and domainname to Postfix'
 
-	_notify 'inf' "Applying hostname to /etc/postfix/main.cf"
-	postconf -e "myhostname = $HOSTNAME"
-	postconf -e "mydomain = $DOMAINNAME"
+  _notify 'inf' "Applying hostname to /etc/postfix/main.cf"
+  postconf -e "myhostname = ${HOSTNAME}"
+  postconf -e "mydomain = ${DOMAINNAME}"
 }
 
 function _setup_dovecot_hostname()
 {
-	_notify 'task' 'Applying hostname to Dovecot'
+  _notify 'task' 'Applying hostname to Dovecot'
 
-	_notify 'inf' "Applying hostname to /etc/dovecot/conf.d/15-lda.conf"
-	sed -i 's/^#hostname =.*$/hostname = '$HOSTNAME'/g' /etc/dovecot/conf.d/15-lda.conf
+  _notify 'inf' "Applying hostname to /etc/dovecot/conf.d/15-lda.conf"
+  # shellcheck disable=SC2248,SC2250
+  sed -i 's/^#hostname =.*$/hostname = '$HOSTNAME'/g' /etc/dovecot/conf.d/15-lda.conf
 }
 
 function _setup_dovecot()
 {
-	_notify 'task' 'Setting up Dovecot'
+  _notify 'task' 'Setting up Dovecot'
 
   # moved from docker file, copy or generate default self-signed cert
-  if [[ -f /var/mail-state/lib-dovecot/dovecot.pem ]] && [[ $ONE_DIR -eq 1 ]]
+  if [[ -f /var/mail-state/lib-dovecot/dovecot.pem ]] && [[ ${ONE_DIR} -eq 1 ]]
   then
     _notify 'inf' "Copying default dovecot cert"
     cp /var/mail-state/lib-dovecot/dovecot.key /etc/dovecot/ssl/
@@ -529,7 +531,7 @@ function _setup_dovecot()
     ./mkcert.sh
     popd || return 1
 
-    if [[ $ONE_DIR -eq 1 ]]
+    if [[ ${ONE_DIR} -eq 1 ]]
     then
       mkdir -p /var/mail-state/lib-dovecot
       cp /etc/dovecot/ssl/dovecot.key /var/mail-state/lib-dovecot/
@@ -537,20 +539,22 @@ function _setup_dovecot()
     fi
   fi
 
-	cp -a /usr/share/dovecot/protocols.d /etc/dovecot/
-	# disable pop3 (it will be eventually enabled later in the script, if requested)
-	mv /etc/dovecot/protocols.d/pop3d.protocol /etc/dovecot/protocols.d/pop3d.protocol.disab
-	mv /etc/dovecot/protocols.d/managesieved.protocol /etc/dovecot/protocols.d/managesieved.protocol.disab
-	sed -i -e 's/#ssl = yes/ssl = yes/g' /etc/dovecot/conf.d/10-master.conf
-	sed -i -e 's/#port = 993/port = 993/g' /etc/dovecot/conf.d/10-master.conf
-	sed -i -e 's/#port = 995/port = 995/g' /etc/dovecot/conf.d/10-master.conf
-	sed -i -e 's/#ssl = yes/ssl = required/g' /etc/dovecot/conf.d/10-ssl.conf
-	sed -i 's/^postmaster_address = .*$/postmaster_address = '$POSTMASTER_ADDRESS'/g' /etc/dovecot/conf.d/15-lda.conf
+  cp -a /usr/share/dovecot/protocols.d /etc/dovecot/
+  # disable pop3 (it will be eventually enabled later in the script, if requested)
+  mv /etc/dovecot/protocols.d/pop3d.protocol /etc/dovecot/protocols.d/pop3d.protocol.disab
+  mv /etc/dovecot/protocols.d/managesieved.protocol /etc/dovecot/protocols.d/managesieved.protocol.disab
+  sed -i -e 's/#ssl = yes/ssl = yes/g' /etc/dovecot/conf.d/10-master.conf
+  sed -i -e 's/#port = 993/port = 993/g' /etc/dovecot/conf.d/10-master.conf
+  sed -i -e 's/#port = 995/port = 995/g' /etc/dovecot/conf.d/10-master.conf
+  sed -i -e 's/#ssl = yes/ssl = required/g' /etc/dovecot/conf.d/10-ssl.conf
+  # shellcheck disable=SC2248,SC2250
+  sed -i 's/^postmaster_address = .*$/postmaster_address = '$POSTMASTER_ADDRESS'/g' /etc/dovecot/conf.d/15-lda.conf
 
   # set mail_location according to mailbox format
-  case "$DOVECOT_MAILBOX_FORMAT" in
+  case "${DOVECOT_MAILBOX_FORMAT}" in
     sdbox|mdbox|maildir )
-      _notify 'inf' "Dovecot $DOVECOT_MAILBOX_FORMAT format configured"
+      _notify 'inf' "Dovecot ${DOVECOT_MAILBOX_FORMAT} format configured"
+      # shellcheck disable=SC2248,SC2250
       sed -i -e 's/^mail_location = .*$/mail_location = '$DOVECOT_MAILBOX_FORMAT':\/var\/mail\/%d\/%n/g' /etc/dovecot/conf.d/10-mail.conf
       ;;
     * )
@@ -559,63 +563,61 @@ function _setup_dovecot()
       ;;
   esac
 
-	# enable Managesieve service by setting the symlink
-	# to the configuration file Dovecot will actually find
-	if [[ $ENABLE_MANAGESIEVE -eq 1 ]]
+  # enable Managesieve service by setting the symlink
+  # to the configuration file Dovecot will actually find
+  if [[ ${ENABLE_MANAGESIEVE} -eq 1 ]]
   then
-		_notify 'inf' "Sieve management enabled"
-		mv /etc/dovecot/protocols.d/managesieved.protocol.disab /etc/dovecot/protocols.d/managesieved.protocol
-	fi
+    _notify 'inf' "Sieve management enabled"
+    mv /etc/dovecot/protocols.d/managesieved.protocol.disab /etc/dovecot/protocols.d/managesieved.protocol
+  fi
 
-	# copy pipe and filter programs, if any
-	rm -f /usr/lib/dovecot/sieve-filter/*
-	rm -f /usr/lib/dovecot/sieve-pipe/*
-	[[ -d /tmp/docker-mailserver/sieve-filter ]] && cp /tmp/docker-mailserver/sieve-filter/* /usr/lib/dovecot/sieve-filter/
-	[[ -d /tmp/docker-mailserver/sieve-pipe ]] && cp /tmp/docker-mailserver/sieve-pipe/* /usr/lib/dovecot/sieve-pipe/
+  # copy pipe and filter programs, if any
+  rm -f /usr/lib/dovecot/sieve-filter/*
+  rm -f /usr/lib/dovecot/sieve-pipe/*
+  [[ -d /tmp/docker-mailserver/sieve-filter ]] && cp /tmp/docker-mailserver/sieve-filter/* /usr/lib/dovecot/sieve-filter/
+  [[ -d /tmp/docker-mailserver/sieve-pipe ]] && cp /tmp/docker-mailserver/sieve-pipe/* /usr/lib/dovecot/sieve-pipe/
 
   # create global sieve directories
-	mkdir -p /usr/lib/dovecot/sieve-global/before
-	mkdir -p /usr/lib/dovecot/sieve-global/after
+  mkdir -p /usr/lib/dovecot/sieve-global/before
+  mkdir -p /usr/lib/dovecot/sieve-global/after
 
-	if [[ -f /tmp/docker-mailserver/before.dovecot.sieve ]]
+  if [[ -f /tmp/docker-mailserver/before.dovecot.sieve ]]
   then
-		cp /tmp/docker-mailserver/before.dovecot.sieve /usr/lib/dovecot/sieve-global/before/50-before.dovecot.sieve
-		sievec /usr/lib/dovecot/sieve-global/before/50-before.dovecot.sieve
-	else
-	  rm -f /usr/lib/dovecot/sieve-global/before/50-before.dovecot.sieve /usr/lib/dovecot/sieve-global/before/50-before.dovecot.svbin
-	fi
+    cp /tmp/docker-mailserver/before.dovecot.sieve /usr/lib/dovecot/sieve-global/before/50-before.dovecot.sieve
+    sievec /usr/lib/dovecot/sieve-global/before/50-before.dovecot.sieve
+  else
+    rm -f /usr/lib/dovecot/sieve-global/before/50-before.dovecot.sieve /usr/lib/dovecot/sieve-global/before/50-before.dovecot.svbin
+  fi
 
-	if [[ -f /tmp/docker-mailserver/after.dovecot.sieve ]]
+  if [[ -f /tmp/docker-mailserver/after.dovecot.sieve ]]
   then
-		cp /tmp/docker-mailserver/after.dovecot.sieve /usr/lib/dovecot/sieve-global/after/50-after.dovecot.sieve
-		sievec /usr/lib/dovecot/sieve-global/after/50-after.dovecot.sieve
-	else
-	  rm -f /usr/lib/dovecot/sieve-global/after/50-after.dovecot.sieve /usr/lib/dovecot/sieve-global/after/50-after.dovecot.svbin
-	fi
+    cp /tmp/docker-mailserver/after.dovecot.sieve /usr/lib/dovecot/sieve-global/after/50-after.dovecot.sieve
+    sievec /usr/lib/dovecot/sieve-global/after/50-after.dovecot.sieve
+  else
+    rm -f /usr/lib/dovecot/sieve-global/after/50-after.dovecot.sieve /usr/lib/dovecot/sieve-global/after/50-after.dovecot.svbin
+  fi
 
   # sieve will move spams to .Junk folder when SPAMASSASSIN_SPAM_TO_INBOX=1 and MOVE_SPAM_TO_JUNK=1
-	if [[ $SPAMASSASSIN_SPAM_TO_INBOX -eq 1 ]] && [[ $MOVE_SPAM_TO_JUNK -eq 1 ]]
+  if [[ ${SPAMASSASSIN_SPAM_TO_INBOX} -eq 1 ]] && [[ ${MOVE_SPAM_TO_JUNK} -eq 1 ]]
   then
-	  _notify 'inf' "Spam messages will be moved to the Junk folder."
-	  cp /etc/dovecot/sieve/before/60-spam.sieve /usr/lib/dovecot/sieve-global/before/
-	  sievec /usr/lib/dovecot/sieve-global/before/60-spam.sieve
-	else
-	  rm -f /usr/lib/dovecot/sieve-global/before/60-spam.sieve /usr/lib/dovecot/sieve-global/before/60-spam.svbin
-	fi
+    _notify 'inf' "Spam messages will be moved to the Junk folder."
+    cp /etc/dovecot/sieve/before/60-spam.sieve /usr/lib/dovecot/sieve-global/before/
+    sievec /usr/lib/dovecot/sieve-global/before/60-spam.sieve
+  else
+    rm -f /usr/lib/dovecot/sieve-global/before/60-spam.sieve /usr/lib/dovecot/sieve-global/before/60-spam.svbin
+  fi
 
-	chown docker:docker -R /usr/lib/dovecot/sieve*
-	chmod 550 -R /usr/lib/dovecot/sieve*
-	chmod -f +x /usr/lib/dovecot/sieve-pipe/*
+  chown docker:docker -R /usr/lib/dovecot/sieve*
+  chmod 550 -R /usr/lib/dovecot/sieve*
+  chmod -f +x /usr/lib/dovecot/sieve-pipe/*
 }
 
-# ! IS THERE A BUG HERE? --------------------------------------------------------------------------
-# TODO INVESTIGATE --------------------------------------------------------------------------------
 function _setup_dovecot_quota()
 {
     _notify 'task' 'Setting up Dovecot quota'
 
     # Dovecot quota is disabled when using LDAP or SMTP_ONLY or when explicitly disabled.
-    if [[ $ENABLE_LDAP -eq 1 ]] || [[ $SMTP_ONLY -eq 1 ]] || [[ $ENABLE_QUOTAS -eq 0 ]]
+    if [[ ${ENABLE_LDAP} -eq 1 ]] || [[ ${SMTP_ONLY} -eq 1 ]] || [[ ${ENABLE_QUOTAS} -eq 0 ]]
     then
       # disable dovecot quota in docevot confs
       if [[ -f /etc/dovecot/conf.d/90-quota.conf ]]
@@ -638,13 +640,13 @@ function _setup_dovecot_quota()
       message_size_limit_mb=$((DEFAULT_VARS["POSTFIX_MESSAGE_SIZE_LIMIT"] / 1000000))
       mailbox_limit_mb=$((DEFAULT_VARS["POSTFIX_MAILBOX_SIZE_LIMIT"] / 1000000))
 
-      sed -i "s/quota_max_mail_size =.*/quota_max_mail_size = ${message_size_limit_mb}$([ "$message_size_limit_mb" == 0 ] && echo "" || echo "M")/g" /etc/dovecot/conf.d/90-quota.conf
-      sed -i "s/quota_rule = \*:storage=.*/quota_rule = *:storage=${mailbox_limit_mb}$([ "$mailbox_limit_mb" == 0 ] && echo "" || echo "M")/g" /etc/dovecot/conf.d/90-quota.conf
+      sed -i "s/quota_max_mail_size =.*/quota_max_mail_size = ${message_size_limit_mb}$([[ ${message_size_limit_mb} -eq 0 ]] && echo "" || echo "M")/g" /etc/dovecot/conf.d/90-quota.conf
+      sed -i "s/quota_rule = \*:storage=.*/quota_rule = *:storage=${mailbox_limit_mb}$([[ ${mailbox_limit_mb} -eq 0 ]] && echo "" || echo "M")/g" /etc/dovecot/conf.d/90-quota.conf
 
       if [[ ! -f /tmp/docker-mailserver/dovecot-quotas.cf ]]
       then
         _notify 'inf' "'config/docker-mailserver/dovecot-quotas.cf' is not provided. Using default quotas."
-		    echo -n >/tmp/docker-mailserver/dovecot-quotas.cf
+        echo -n >/tmp/docker-mailserver/dovecot-quotas.cf
       fi
 
       # enable quota policy check in postfix
@@ -654,95 +656,95 @@ function _setup_dovecot_quota()
 
 function _setup_dovecot_local_user()
 {
-	_notify 'task' 'Setting up Dovecot Local User'
-	echo -n > /etc/postfix/vmailbox
-	echo -n > /etc/dovecot/userdb
+  _notify 'task' 'Setting up Dovecot Local User'
+  echo -n > /etc/postfix/vmailbox
+  echo -n > /etc/dovecot/userdb
 
-  if [[ -f /tmp/docker-mailserver/postfix-accounts.cf ]] && [[ $ENABLE_LDAP -ne 1 ]]
+  if [[ -f /tmp/docker-mailserver/postfix-accounts.cf ]] && [[ ${ENABLE_LDAP} -ne 1 ]]
   then
-		_notify 'inf' "Checking file line endings"
-		sed -i 's/\r//g' /tmp/docker-mailserver/postfix-accounts.cf
+    _notify 'inf' "Checking file line endings"
+    sed -i 's/\r//g' /tmp/docker-mailserver/postfix-accounts.cf
 
-		_notify 'inf' "Regenerating postfix user list"
-		echo "# WARNING: this file is auto-generated. Modify config/postfix-accounts.cf to edit user list." > /etc/postfix/vmailbox
+    _notify 'inf' "Regenerating postfix user list"
+    echo "# WARNING: this file is auto-generated. Modify config/postfix-accounts.cf to edit user list." > /etc/postfix/vmailbox
 
-		# checking that /tmp/docker-mailserver/postfix-accounts.cf ends with a newline
+    # checking that /tmp/docker-mailserver/postfix-accounts.cf ends with a newline
     # shellcheck disable=SC1003
-		sed -i -e '$a\' /tmp/docker-mailserver/postfix-accounts.cf
+    sed -i -e '$a\' /tmp/docker-mailserver/postfix-accounts.cf
 
-		chown dovecot:dovecot /etc/dovecot/userdb
-		chmod 640 /etc/dovecot/userdb
+    chown dovecot:dovecot /etc/dovecot/userdb
+    chmod 640 /etc/dovecot/userdb
 
-		sed -i -e '/\!include auth-ldap\.conf\.ext/s/^/#/' /etc/dovecot/conf.d/10-auth.conf
-		sed -i -e '/\!include auth-passwdfile\.inc/s/^#//' /etc/dovecot/conf.d/10-auth.conf
+    sed -i -e '/\!include auth-ldap\.conf\.ext/s/^/#/' /etc/dovecot/conf.d/10-auth.conf
+    sed -i -e '/\!include auth-passwdfile\.inc/s/^#//' /etc/dovecot/conf.d/10-auth.conf
 
-		# creating users ; 'pass' is encrypted
-		# comments and empty lines are ignored
-		grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-accounts.cf | while IFS=$'|' read -r login pass
-		do
-			# Setting variables for better readability
-			user=$(echo "$login" | cut -d @ -f1)
-			domain=$(echo "$login" | cut -d @ -f2)
+    # creating users ; 'pass' is encrypted
+    # comments and empty lines are ignored
+    grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-accounts.cf | while IFS=$'|' read -r login pass
+    do
+      # Setting variables for better readability
+      user=$(echo "${login}" | cut -d @ -f1)
+      domain=$(echo "${login}" | cut -d @ -f2)
 
-			user_attributes=""
-			# test if user has a defined quota
+      user_attributes=""
+      # test if user has a defined quota
       if [[ -f /tmp/docker-mailserver/dovecot-quotas.cf ]]
       then
         declare -a USER_QUOTA
         IFS=':' ; read -r -a USER_QUOTA < <(grep "${user}@${domain}:" -i /tmp/docker-mailserver/dovecot-quotas.cf)
         unset IFS
 
-			  [[ ${#USER_QUOTA[@]} -eq 2 ]] && user_attributes="${user_attributes}userdb_quota_rule=*:bytes=${USER_QUOTA[1]}"
-			fi
+        [[ ${#USER_QUOTA[@]} -eq 2 ]] && user_attributes="${user_attributes}userdb_quota_rule=*:bytes=${USER_QUOTA[1]}"
+      fi
 
-			# Let's go!
-			_notify 'inf' "user '${user}' for domain '${domain}' with password '********', attr=${user_attributes}"
+      # Let's go!
+      _notify 'inf' "user '${user}' for domain '${domain}' with password '********', attr=${user_attributes}"
 
-			echo "${login} ${domain}/${user}/" >> /etc/postfix/vmailbox
-			# User database for dovecot has the following format:
-			# user:password:uid:gid:(gecos):home:(shell):extra_fields
-			# Example :
-			# ${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::userdb_mail=maildir:/var/mail/${domain}/${user}
-			echo "${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::${user_attributes}" >> /etc/dovecot/userdb
-			mkdir -p "/var/mail/${domain}/${user}"
+      echo "${login} ${domain}/${user}/" >> /etc/postfix/vmailbox
+      # User database for dovecot has the following format:
+      # user:password:uid:gid:(gecos):home:(shell):extra_fields
+      # Example :
+      # ${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::userdb_mail=maildir:/var/mail/${domain}/${user}
+      echo "${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::${user_attributes}" >> /etc/dovecot/userdb
+      mkdir -p "/var/mail/${domain}/${user}"
 
-			# Copy user provided sieve file, if present
-		  if [[ -e /tmp/docker-mailserver/${login}.dovecot.sieve ]]
+      # Copy user provided sieve file, if present
+      if [[ -e "/tmp/docker-mailserver/${login}.dovecot.sieve" ]]
       then
         cp "/tmp/docker-mailserver/${login}.dovecot.sieve" "/var/mail/${domain}/${user}/.dovecot.sieve"
       fi
 
-			echo "$domain" >> /tmp/vhost.tmp
-		done
-	else
-		_notify 'inf' "'config/docker-mailserver/postfix-accounts.cf' is not provided. No mail account created."
-	fi
+      echo "${domain}" >> /tmp/vhost.tmp
+    done
+  else
+    _notify 'inf' "'config/docker-mailserver/postfix-accounts.cf' is not provided. No mail account created."
+  fi
 
-	if ! grep '@' /tmp/docker-mailserver/postfix-accounts.cf | grep -q '|'
+  if ! grep '@' /tmp/docker-mailserver/postfix-accounts.cf | grep -q '|'
   then
-		if [[ $ENABLE_LDAP -eq 0 ]]
+    if [[ ${ENABLE_LDAP} -eq 0 ]]
     then
-			_notify 'fatal' "Unless using LDAP, you need at least 1 email account to start Dovecot."
-			_defunc
-		fi
-	fi
+      _notify 'fatal' "Unless using LDAP, you need at least 1 email account to start Dovecot."
+      _defunc
+    fi
+  fi
 }
 
 function _setup_ldap()
 {
-	_notify 'task' 'Setting up Ldap'
-	_notify 'inf' 'Checking for custom configs'
+  _notify 'task' 'Setting up Ldap'
+  _notify 'inf' 'Checking for custom configs'
 
-	for i in 'users' 'groups' 'aliases' 'domains'
+  for i in 'users' 'groups' 'aliases' 'domains'
   do
-	  fpath="/tmp/docker-mailserver/ldap-${i}.cf"
-	  if [[ -f $fpath ]]
+    local FPATH="/tmp/docker-mailserver/ldap-${i}.cf"
+    if [[ -f ${FPATH} ]]
     then
-		  cp ${fpath} /etc/postfix/ldap-${i}.cf
-	  fi
-	done
+      cp "${FPATH}" "/etc/postfix/ldap-${i}.cf"
+    fi
+  done
 
-	_notify 'inf' 'Starting to override configs'
+  _notify 'inf' 'Starting to override configs'
 
   local FILES=(
     /etc/postfix/ldap-users.cf
@@ -752,110 +754,109 @@ function _setup_ldap()
     /etc/postfix/maps/sender_login_maps.ldap
   )
 
-	for f in "${FILES[@]}"
-	do
-		[[ $f =~ ldap-user ]] && export LDAP_QUERY_FILTER="${LDAP_QUERY_FILTER_USER}"
-		[[ $f =~ ldap-group ]] && export LDAP_QUERY_FILTER="${LDAP_QUERY_FILTER_GROUP}"
-		[[ $f =~ ldap-aliases ]] && export LDAP_QUERY_FILTER="${LDAP_QUERY_FILTER_ALIAS}"
-		[[ $f =~ ldap-domains ]] && export LDAP_QUERY_FILTER="${LDAP_QUERY_FILTER_DOMAIN}"
-		configomat.sh "LDAP_" "${f}"
-	done
-
-	_notify 'inf' "Configuring dovecot LDAP"
-
-	declare -A _dovecot_ldap_mapping
-
-	_dovecot_ldap_mapping["DOVECOT_BASE"]="${DOVECOT_BASE:="${LDAP_SEARCH_BASE}"}"
-	_dovecot_ldap_mapping["DOVECOT_DN"]="${DOVECOT_DN:="${LDAP_BIND_DN}"}"
-	_dovecot_ldap_mapping["DOVECOT_DNPASS"]="${DOVECOT_DNPASS:="${LDAP_BIND_PW}"}"
-	_dovecot_ldap_mapping["DOVECOT_HOSTS"]="${DOVECOT_HOSTS:="${LDAP_SERVER_HOST}"}"
-	# Not sure whether this can be the same or not
-	# _dovecot_ldap_mapping["DOVECOT_PASS_FILTER"]="${DOVECOT_PASS_FILTER:="${LDAP_QUERY_FILTER_USER}"}"
-	# _dovecot_ldap_mapping["DOVECOT_USER_FILTER"]="${DOVECOT_USER_FILTER:="${LDAP_QUERY_FILTER_USER}"}"
-
-	for var in "${!_dovecot_ldap_mapping[@]}"
+  for FILE in "${FILES[@]}"
   do
-    # ! "" AROUND $var - MIGHT BREANK THINGS ------------------------------------------------------
-    # TODO TEST -----------------------------------------------------------------------------------
-		export "$var=${_dovecot_ldap_mapping[$var]}"
-	done
+    [[ ${FILE} =~ ldap-user ]] && export LDAP_QUERY_FILTER="${LDAP_QUERY_FILTER_USER}"
+    [[ ${FILE} =~ ldap-group ]] && export LDAP_QUERY_FILTER="${LDAP_QUERY_FILTER_GROUP}"
+    [[ ${FILE} =~ ldap-aliases ]] && export LDAP_QUERY_FILTER="${LDAP_QUERY_FILTER_ALIAS}"
+    [[ ${FILE} =~ ldap-domains ]] && export LDAP_QUERY_FILTER="${LDAP_QUERY_FILTER_DOMAIN}"
+    configomat.sh "LDAP_" "${FILE}"
+  done
 
-	configomat.sh "DOVECOT_" "/etc/dovecot/dovecot-ldap.conf.ext"
+  _notify 'inf' "Configuring dovecot LDAP"
 
-	# add  domainname to vhost
-	echo $DOMAINNAME >> /tmp/vhost.tmp
+  declare -A _dovecot_ldap_mapping
 
-	_notify 'inf' "Enabling dovecot LDAP authentification"
+  _dovecot_ldap_mapping["DOVECOT_BASE"]="${DOVECOT_BASE:="${LDAP_SEARCH_BASE}"}"
+  _dovecot_ldap_mapping["DOVECOT_DN"]="${DOVECOT_DN:="${LDAP_BIND_DN}"}"
+  _dovecot_ldap_mapping["DOVECOT_DNPASS"]="${DOVECOT_DNPASS:="${LDAP_BIND_PW}"}"
+  _dovecot_ldap_mapping["DOVECOT_HOSTS"]="${DOVECOT_HOSTS:="${LDAP_SERVER_HOST}"}"
+  # Not sure whether this can be the same or not
+  # _dovecot_ldap_mapping["DOVECOT_PASS_FILTER"]="${DOVECOT_PASS_FILTER:="${LDAP_QUERY_FILTER_USER}"}"
+  # _dovecot_ldap_mapping["DOVECOT_USER_FILTER"]="${DOVECOT_USER_FILTER:="${LDAP_QUERY_FILTER_USER}"}"
 
-	sed -i -e '/\!include auth-ldap\.conf\.ext/s/^#//' /etc/dovecot/conf.d/10-auth.conf
-	sed -i -e '/\!include auth-passwdfile\.inc/s/^/#/' /etc/dovecot/conf.d/10-auth.conf
+  for VAR in "${!_dovecot_ldap_mapping[@]}"
+  do
+    export "${VAR}=${_dovecot_ldap_mapping[${VAR}]}"
+  done
 
-	_notify 'inf' "Configuring LDAP"
+  configomat.sh "DOVECOT_" "/etc/dovecot/dovecot-ldap.conf.ext"
 
-	if [[ -f /etc/postfix/ldap-users.cf ]]
+  # add  domainname to vhost
+  echo "${DOMAINNAME}" >>/tmp/vhost.tmp
+
+  _notify 'inf' "Enabling dovecot LDAP authentification"
+
+  sed -i -e '/\!include auth-ldap\.conf\.ext/s/^#//' /etc/dovecot/conf.d/10-auth.conf
+  sed -i -e '/\!include auth-passwdfile\.inc/s/^/#/' /etc/dovecot/conf.d/10-auth.conf
+
+  _notify 'inf' "Configuring LDAP"
+
+  if [[ -f /etc/postfix/ldap-users.cf ]]
   then
-		postconf -e "virtual_mailbox_maps = ldap:/etc/postfix/ldap-users.cf" || \
-		_notify 'inf' "==> Warning: /etc/postfix/ldap-user.cf not found"
+    postconf -e "virtual_mailbox_maps = ldap:/etc/postfix/ldap-users.cf" || \
+    _notify 'inf' "==> Warning: /etc/postfix/ldap-user.cf not found"
   fi
 
-	if [[ -f /etc/postfix/ldap-domains.cf ]]
+  if [[ -f /etc/postfix/ldap-domains.cf ]]
   then
-		postconf -e "virtual_mailbox_domains = /etc/postfix/vhost, ldap:/etc/postfix/ldap-domains.cf" || \
-		_notify 'inf' "==> Warning: /etc/postfix/ldap-domains.cf not found"
+    postconf -e "virtual_mailbox_domains = /etc/postfix/vhost, ldap:/etc/postfix/ldap-domains.cf" || \
+    _notify 'inf' "==> Warning: /etc/postfix/ldap-domains.cf not found"
   fi
 
-	if [[ -f /etc/postfix/ldap-aliases.cf ]] && [[ -f /etc/postfix/ldap-groups.cf ]]
+  if [[ -f /etc/postfix/ldap-aliases.cf ]] && [[ -f /etc/postfix/ldap-groups.cf ]]
   then
-		postconf -e "virtual_alias_maps = ldap:/etc/postfix/ldap-aliases.cf, ldap:/etc/postfix/ldap-groups.cf" || \
-		_notify 'inf' "==> Warning: /etc/postfix/ldap-aliases.cf or /etc/postfix/ldap-groups.cf not found"
+    postconf -e "virtual_alias_maps = ldap:/etc/postfix/ldap-aliases.cf, ldap:/etc/postfix/ldap-groups.cf" || \
+    _notify 'inf' "==> Warning: /etc/postfix/ldap-aliases.cf or /etc/postfix/ldap-groups.cf not found"
   fi
 
-	return 0
+  return 0
 }
 
 function _setup_postgrey()
 {
-	_notify 'inf' "Configuring postgrey"
+  _notify 'inf' "Configuring postgrey"
 
-	sed -i -e 's/, reject_rbl_client bl.spamcop.net$/, reject_rbl_client bl.spamcop.net, check_policy_service inet:127.0.0.1:10023/' /etc/postfix/main.cf
-	sed -i -e "s/\"--inet=127.0.0.1:10023\"/\"--inet=127.0.0.1:10023 --delay=$POSTGREY_DELAY --max-age=$POSTGREY_MAX_AGE --auto-whitelist-clients=$POSTGREY_AUTO_WHITELIST_CLIENTS\"/" /etc/default/postgrey
+  sed -i -e 's/, reject_rbl_client bl.spamcop.net$/, reject_rbl_client bl.spamcop.net, check_policy_service inet:127.0.0.1:10023/' /etc/postfix/main.cf
+  # shellcheck disable=SC2250
+  sed -i -e "s/\"--inet=127.0.0.1:10023\"/\"--inet=127.0.0.1:10023 --delay=$POSTGREY_DELAY --max-age=$POSTGREY_MAX_AGE --auto-whitelist-clients=$POSTGREY_AUTO_WHITELIST_CLIENTS\"/" /etc/default/postgrey
 
   TEXT_FOUND=$(grep -c -i "POSTGREY_TEXT" /etc/default/postgrey)
 
-	if [[ $TEXT_FOUND -eq 0 ]]
+  if [[ ${TEXT_FOUND} -eq 0 ]]
   then
-		printf "POSTGREY_TEXT=\"%s\"\n\n" "$POSTGREY_TEXT" >> /etc/default/postgrey
-	fi
+    printf "POSTGREY_TEXT=\"%s\"\n\n" "${POSTGREY_TEXT}" >> /etc/default/postgrey
+  fi
 
-	if [[ -f /tmp/docker-mailserver/whitelist_clients.local ]]
+  if [[ -f /tmp/docker-mailserver/whitelist_clients.local ]]
   then
-		cp -f /tmp/docker-mailserver/whitelist_clients.local /etc/postgrey/whitelist_clients.local
-	fi
+    cp -f /tmp/docker-mailserver/whitelist_clients.local /etc/postgrey/whitelist_clients.local
+  fi
 
-	if [[ -f /tmp/docker-mailserver/whitelist_recipients ]]
+  if [[ -f /tmp/docker-mailserver/whitelist_recipients ]]
   then
-		cp -f /tmp/docker-mailserver/whitelist_recipients /etc/postgrey/whitelist_recipients
-	fi
+    cp -f /tmp/docker-mailserver/whitelist_recipients /etc/postgrey/whitelist_recipients
+  fi
 }
 
 function _setup_postfix_postscreen()
 {
-	_notify 'inf' "Configuring postscreen"
-	sed -i -e "s/postscreen_dnsbl_action = enforce/postscreen_dnsbl_action = $POSTSCREEN_ACTION/" \
-	  -e "s/postscreen_greet_action = enforce/postscreen_greet_action = $POSTSCREEN_ACTION/" \
-	  -e "s/postscreen_bare_newline_action = enforce/postscreen_bare_newline_action = $POSTSCREEN_ACTION/" /etc/postfix/main.cf
+  _notify 'inf' "Configuring postscreen"
+  sed -i -e "s/postscreen_dnsbl_action = enforce/postscreen_dnsbl_action = ${POSTSCREEN_ACTION}/" \
+    -e "s/postscreen_greet_action = enforce/postscreen_greet_action = ${POSTSCREEN_ACTION}/" \
+    -e "s/postscreen_bare_newline_action = enforce/postscreen_bare_newline_action = ${POSTSCREEN_ACTION}/" /etc/postfix/main.cf
 }
 
 function _setup_postfix_sizelimits()
 {
-	_notify 'inf' "Configuring postfix message size limit"
-	postconf -e "message_size_limit = ${DEFAULT_VARS["POSTFIX_MESSAGE_SIZE_LIMIT"]}"
+  _notify 'inf' "Configuring postfix message size limit"
+  postconf -e "message_size_limit = ${DEFAULT_VARS["POSTFIX_MESSAGE_SIZE_LIMIT"]}"
 
-	_notify 'inf' "Configuring postfix mailbox size limit"
-	postconf -e "mailbox_size_limit = ${DEFAULT_VARS["POSTFIX_MAILBOX_SIZE_LIMIT"]}"
+  _notify 'inf' "Configuring postfix mailbox size limit"
+  postconf -e "mailbox_size_limit = ${DEFAULT_VARS["POSTFIX_MAILBOX_SIZE_LIMIT"]}"
 
-	_notify 'inf' "Configuring postfix virtual mailbox size limit"
-	postconf -e "virtual_mailbox_limit = ${DEFAULT_VARS["POSTFIX_MAILBOX_SIZE_LIMIT"]}"
+  _notify 'inf' "Configuring postfix virtual mailbox size limit"
+  postconf -e "virtual_mailbox_limit = ${DEFAULT_VARS["POSTFIX_MAILBOX_SIZE_LIMIT"]}"
 }
 
 function _setup_postfix_smtputf8()
@@ -866,10 +867,11 @@ function _setup_postfix_smtputf8()
 
 function _setup_spoof_protection()
 {
-	_notify 'inf' "Configuring Spoof Protection"
-	sed -i 's|smtpd_sender_restrictions =|smtpd_sender_restrictions = reject_authenticated_sender_login_mismatch,|' /etc/postfix/main.cf
+  _notify 'inf' "Configuring Spoof Protection"
+  sed -i 's|smtpd_sender_restrictions =|smtpd_sender_restrictions = reject_authenticated_sender_login_mismatch,|' /etc/postfix/main.cf
 
-	[[ $ENABLE_LDAP -eq 1 ]] && postconf -e "smtpd_sender_login_maps=ldap:/etc/postfix/ldap-users.cf ldap:/etc/postfix/ldap-aliases.cf ldap:/etc/postfix/ldap-groups.cf" || postconf -e "smtpd_sender_login_maps=texthash:/etc/postfix/virtual, hash:/etc/aliases, pcre:/etc/postfix/regexp, pcre:/etc/postfix/maps/sender_login_maps.pcre"
+  # shellcheck disable=SC2015
+  [[ ${ENABLE_LDAP} -eq 1 ]] && postconf -e "smtpd_sender_login_maps=ldap:/etc/postfix/ldap-users.cf ldap:/etc/postfix/ldap-aliases.cf ldap:/etc/postfix/ldap-groups.cf" || postconf -e "smtpd_sender_login_maps=texthash:/etc/postfix/virtual, hash:/etc/aliases, pcre:/etc/postfix/regexp, pcre:/etc/postfix/maps/sender_login_maps.pcre"
 }
 
 function _setup_postfix_access_control()
@@ -889,20 +891,20 @@ function _setup_postfix_access_control()
 
 function _setup_postfix_sasl()
 {
-  if [[ $ENABLE_SASLAUTHD -eq 1 ]]
+  if [[ ${ENABLE_SASLAUTHD} -eq 1 ]]
   then
-	  [[ ! -f /etc/postfix/sasl/smtpd.conf ]] && cat > /etc/postfix/sasl/smtpd.conf << EOF
+    [[ ! -f /etc/postfix/sasl/smtpd.conf ]] && cat > /etc/postfix/sasl/smtpd.conf << EOF
 pwcheck_method: saslauthd
 mech_list: plain login
 EOF
   fi
 
   # cyrus sasl or dovecot sasl
-  if [[ $ENABLE_SASLAUTHD -eq 1 ]] || [[ $SMTP_ONLY -eq 0 ]]
+  if [[ ${ENABLE_SASLAUTHD} -eq 1 ]] || [[ ${SMTP_ONLY} -eq 0 ]]
   then
-	  sed -i -e 's|^smtpd_sasl_auth_enable[[:space:]]\+.*|smtpd_sasl_auth_enable = yes|g' /etc/postfix/main.cf
+    sed -i -e 's|^smtpd_sasl_auth_enable[[:space:]]\+.*|smtpd_sasl_auth_enable = yes|g' /etc/postfix/main.cf
   else
-	  sed -i -e 's|^smtpd_sasl_auth_enable[[:space:]]\+.*|smtpd_sasl_auth_enable = no|g' /etc/postfix/main.cf
+    sed -i -e 's|^smtpd_sasl_auth_enable[[:space:]]\+.*|smtpd_sasl_auth_enable = no|g' /etc/postfix/main.cf
   fi
 
   return 0
@@ -910,35 +912,37 @@ EOF
 
 function _setup_saslauthd()
 {
-	_notify 'task' "Setting up Saslauthd"
-	_notify 'inf' "Configuring Cyrus SASL"
+  _notify 'task' "Setting up Saslauthd"
+  _notify 'inf' "Configuring Cyrus SASL"
 
-	# checking env vars and setting defaults
-	[[ -z $SASLAUTHD_MECHANISMS ]] && SASLAUTHD_MECHANISMS=pam
-	[[ $SASLAUTHD_MECHANISMS = ldap ]] && [[ -z $SASLAUTHD_LDAP_SEARCH_BASE ]] && SASLAUTHD_MECHANISMS=pam
-	[[ -z $SASLAUTHD_LDAP_SERVER ]] && SASLAUTHD_LDAP_SERVER=localhost
-	[[ -z $SASLAUTHD_LDAP_FILTER ]] && SASLAUTHD_LDAP_FILTER='(&(uniqueIdentifier=%u)(mailEnabled=TRUE))'
+  # checking env vars and setting defaults
+  [[ -z ${SASLAUTHD_MECHANISMS} ]] && SASLAUTHD_MECHANISMS=pam
+  [[ ${SASLAUTHD_MECHANISMS} == ldap ]] && [[ -z ${SASLAUTHD_LDAP_SEARCH_BASE} ]] && SASLAUTHD_MECHANISMS=pam
+  [[ -z ${SASLAUTHD_LDAP_SERVER} ]] && SASLAUTHD_LDAP_SERVER=localhost
+  [[ -z ${SASLAUTHD_LDAP_FILTER} ]] && SASLAUTHD_LDAP_FILTER='(&(uniqueIdentifier=%u)(mailEnabled=TRUE))'
 
-	if [[ -z $SASLAUTHD_LDAP_SSL ]] || [[ $SASLAUTHD_LDAP_SSL -eq 0 ]]
+  if [[ -z ${SASLAUTHD_LDAP_SSL} ]] || [[ ${SASLAUTHD_LDAP_SSL} -eq 0 ]]
   then
     SASLAUTHD_LDAP_PROTO='ldap://' || SASLAUTHD_LDAP_PROTO='ldaps://'
   fi
 
-	[[ -z $SASLAUTHD_LDAP_START_TLS ]] && SASLAUTHD_LDAP_START_TLS=no
-	[[ -z $SASLAUTHD_LDAP_TLS_CHECK_PEER ]] && SASLAUTHD_LDAP_TLS_CHECK_PEER=no
+  [[ -z ${SASLAUTHD_LDAP_START_TLS} ]] && SASLAUTHD_LDAP_START_TLS=no
+  [[ -z ${SASLAUTHD_LDAP_TLS_CHECK_PEER} ]] && SASLAUTHD_LDAP_TLS_CHECK_PEER=no
 
-	if [[ ! -f /etc/saslauthd.conf ]]
+  if [[ ! -f /etc/saslauthd.conf ]]
   then
-		_notify 'inf' "Creating /etc/saslauthd.conf"
-		cat > /etc/saslauthd.conf << EOF
-ldap_servers: ${SASLAUTHD_LDAP_PROTO}${SASLAUTHD_LDAP_SERVER}
+    _notify 'inf' "Creating /etc/saslauthd.conf"
+
+    # shellcheck disable=SC2250
+    cat > /etc/saslauthd.conf << EOF
+ldap_servers: $SASLAUTHD_LDAP_PROTO$SASLAUTHD_LDAP_SERVER
 
 ldap_auth_method: bind
-ldap_bind_dn: ${SASLAUTHD_LDAP_BIND_DN}
-ldap_bind_pw: ${SASLAUTHD_LDAP_PASSWORD}
+ldap_bind_dn: $SASLAUTHD_LDAP_BIND_DN
+ldap_bind_pw: $SASLAUTHD_LDAP_PASSWORD
 
-ldap_search_base: ${SASLAUTHD_LDAP_SEARCH_BASE}
-ldap_filter: ${SASLAUTHD_LDAP_FILTER}
+ldap_search_base: $SASLAUTHD_LDAP_SEARCH_BASE
+ldap_filter: $SASLAUTHD_LDAP_FILTER
 
 ldap_start_tls: $SASLAUTHD_LDAP_START_TLS
 ldap_tls_check_peer: $SASLAUTHD_LDAP_TLS_CHECK_PEER
@@ -946,128 +950,128 @@ ldap_tls_check_peer: $SASLAUTHD_LDAP_TLS_CHECK_PEER
 ldap_referrals: yes
 log_level: 10
 EOF
-	fi
+  fi
 
-	sed -i \
-	  -e "/^[^#].*smtpd_sasl_type.*/s/^/#/g" \
-		-e "/^[^#].*smtpd_sasl_path.*/s/^/#/g" \
-		/etc/postfix/master.cf
+  sed -i \
+    -e "/^[^#].*smtpd_sasl_type.*/s/^/#/g" \
+    -e "/^[^#].*smtpd_sasl_path.*/s/^/#/g" \
+    /etc/postfix/master.cf
 
-	sed -i \
-		-e "/smtpd_sasl_path =.*/d" \
-		-e "/smtpd_sasl_type =.*/d" \
-		-e "/dovecot_destination_recipient_limit =.*/d" \
-		/etc/postfix/main.cf
+  sed -i \
+    -e "/smtpd_sasl_path =.*/d" \
+    -e "/smtpd_sasl_type =.*/d" \
+    -e "/dovecot_destination_recipient_limit =.*/d" \
+    /etc/postfix/main.cf
 
-	gpasswd -a postfix sasl
+  gpasswd -a postfix sasl
 }
 
 function _setup_postfix_aliases()
 {
-	_notify 'task' 'Setting up Postfix Aliases'
+  _notify 'task' 'Setting up Postfix Aliases'
 
-	echo -n > /etc/postfix/virtual
-	echo -n > /etc/postfix/regexp
+  echo -n > /etc/postfix/virtual
+  echo -n > /etc/postfix/regexp
 
-	if [[ -f /tmp/docker-mailserver/postfix-virtual.cf ]]
+  if [[ -f /tmp/docker-mailserver/postfix-virtual.cf ]]
   then
-	  # fixing old virtual user file
-	  if grep -q ",$" /tmp/docker-mailserver/postfix-virtual.cf
+    # fixing old virtual user file
+    if grep -q ",$" /tmp/docker-mailserver/postfix-virtual.cf
     then
       sed -i -e "s/, /,/g" -e "s/,$//g" /tmp/docker-mailserver/postfix-virtual.cf
     fi
 
-		cp -f /tmp/docker-mailserver/postfix-virtual.cf /etc/postfix/virtual
+    cp -f /tmp/docker-mailserver/postfix-virtual.cf /etc/postfix/virtual
 
     # the `to` seems to be important; don't delete it
     # shellcheck disable=SC2034
-		(grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-virtual.cf || true) | while read -r from to
-		do
-			# Setting variables for better readability
-			uname=$(echo "$from" | cut -d @ -f1)
-			domain=$(echo "$from" | cut -d @ -f2)
+    (grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-virtual.cf || true) | while read -r from to
+    do
+      # Setting variables for better readability
+      uname=$(echo "${from}" | cut -d @ -f1)
+      domain=$(echo "${from}" | cut -d @ -f2)
 
-			# if they are equal it means the line looks like: "user1     other@domain.tld"
-			[ "$uname" != "$domain" ] && echo "$domain" >> /tmp/vhost.tmp
-		done
-	else
-		_notify 'inf' "Warning 'config/postfix-virtual.cf' is not provided. No mail alias/forward created."
-	fi
+      # if they are equal it means the line looks like: "user1     other@domain.tld"
+      [ "${uname}" != "${domain}" ] && echo "${domain}" >> /tmp/vhost.tmp
+    done
+  else
+    _notify 'inf' "Warning 'config/postfix-virtual.cf' is not provided. No mail alias/forward created."
+  fi
 
-	if [[ -f /tmp/docker-mailserver/postfix-regexp.cf ]]
+  if [[ -f /tmp/docker-mailserver/postfix-regexp.cf ]]
   then
-		_notify 'inf' "Adding regexp alias file postfix-regexp.cf"
+    _notify 'inf' "Adding regexp alias file postfix-regexp.cf"
 
-		cp -f /tmp/docker-mailserver/postfix-regexp.cf /etc/postfix/regexp
-		sed -i -e '/^virtual_alias_maps/{
+    cp -f /tmp/docker-mailserver/postfix-regexp.cf /etc/postfix/regexp
+    sed -i -e '/^virtual_alias_maps/{
 s/ pcre:.*//
 s/$/ pcre:\/etc\/postfix\/regexp/
 }' /etc/postfix/main.cf
-	fi
+  fi
 
-	_notify 'inf' "Configuring root alias"
+  _notify 'inf' "Configuring root alias"
 
-	echo "root: ${POSTMASTER_ADDRESS}" > /etc/aliases
+  echo "root: ${POSTMASTER_ADDRESS}" > /etc/aliases
 
-	if [[ -f /tmp/docker-mailserver/postfix-aliases.cf ]]
+  if [[ -f /tmp/docker-mailserver/postfix-aliases.cf ]]
   then
-		cat /tmp/docker-mailserver/postfix-aliases.cf >> /etc/aliases
-	else
-		_notify 'inf' "'config/postfix-aliases.cf' is not provided and will be auto created."
-		echo -n >/tmp/docker-mailserver/postfix-aliases.cf
-	fi
+    cat /tmp/docker-mailserver/postfix-aliases.cf >> /etc/aliases
+  else
+    _notify 'inf' "'config/postfix-aliases.cf' is not provided and will be auto created."
+    echo -n >/tmp/docker-mailserver/postfix-aliases.cf
+  fi
 
-	postalias /etc/aliases
+  postalias /etc/aliases
 }
 
 function _setup_SRS()
 {
-	_notify 'task' 'Setting up SRS'
+  _notify 'task' 'Setting up SRS'
 
-	postconf -e "sender_canonical_maps = tcp:localhost:10001"
-	postconf -e "sender_canonical_classes = $SRS_SENDER_CLASSES"
-	postconf -e "recipient_canonical_maps = tcp:localhost:10002"
-	postconf -e "recipient_canonical_classes = envelope_recipient,header_recipient"
+  postconf -e "sender_canonical_maps = tcp:localhost:10001"
+  postconf -e "sender_canonical_classes = ${SRS_SENDER_CLASSES}"
+  postconf -e "recipient_canonical_maps = tcp:localhost:10002"
+  postconf -e "recipient_canonical_classes = envelope_recipient,header_recipient"
 }
 
 function _setup_dkim()
 {
-	_notify 'task' 'Setting up DKIM'
+  _notify 'task' 'Setting up DKIM'
 
-	mkdir -p /etc/opendkim && touch /etc/opendkim/SigningTable
+  mkdir -p /etc/opendkim && touch /etc/opendkim/SigningTable
 
-	# Check if keys are already available
-	if [[ -e "/tmp/docker-mailserver/opendkim/KeyTable" ]]
+  # Check if keys are already available
+  if [[ -e "/tmp/docker-mailserver/opendkim/KeyTable" ]]
   then
-		cp -a /tmp/docker-mailserver/opendkim/* /etc/opendkim/
+    cp -a /tmp/docker-mailserver/opendkim/* /etc/opendkim/
 
-		_notify 'inf' "DKIM keys added for: $(ls -C /etc/opendkim/keys/)"
-		_notify 'inf' "Changing permissions on /etc/opendkim"
+    _notify 'inf' "DKIM keys added for: $(ls -C /etc/opendkim/keys/)"
+    _notify 'inf' "Changing permissions on /etc/opendkim"
 
-		chown -R opendkim:opendkim /etc/opendkim/
-		chmod -R 0700 /etc/opendkim/keys/ # make sure permissions are right
-	else
-		_notify 'warn' "No DKIM key provided. Check the documentation to find how to get your keys."
+    chown -R opendkim:opendkim /etc/opendkim/
+    chmod -R 0700 /etc/opendkim/keys/ # make sure permissions are right
+  else
+    _notify 'warn' "No DKIM key provided. Check the documentation to find how to get your keys."
 
-		local _f_keytable="/etc/opendkim/KeyTable"
-		[[ ! -f $_f_keytable ]] && touch "$_f_keytable"
-	fi
+    local KEYTABLE_FILE="/etc/opendkim/KeyTable"
+    [[ ! -f ${KEYTABLE_FILE} ]] && touch "${KEYTABLE_FILE}"
+  fi
 
-	# setup nameservers paramater from /etc/resolv.conf if not defined
-	if ! grep '^Nameservers' /etc/opendkim.conf
+  # setup nameservers paramater from /etc/resolv.conf if not defined
+  if ! grep '^Nameservers' /etc/opendkim.conf
   then
-		echo "Nameservers $(grep '^nameserver' /etc/resolv.conf | awk -F " " '{print $2}' | paste -sd ',' -)" >> /etc/opendkim.conf
+    echo "Nameservers $(grep '^nameserver' /etc/resolv.conf | awk -F " " '{print $2}' | paste -sd ',' -)" >> /etc/opendkim.conf
 
-		_notify 'inf' "Nameservers added to /etc/opendkim.conf"
-	fi
+    _notify 'inf' "Nameservers added to /etc/opendkim.conf"
+  fi
 }
 
 function _setup_ssl()
 {
-	_notify 'task' 'Setting up SSL'
+  _notify 'task' 'Setting up SSL'
 
   # TLS strength/level configuration
-  case $TLS_LEVEL in
+  case "${TLS_LEVEL}" in
     "modern" )
       # Postfix configuration
       sed -i -r 's/^smtpd_tls_mandatory_protocols =.*$/smtpd_tls_mandatory_protocols = !SSLv2,!SSLv3,!TLSv1,!TLSv1.1/' /etc/postfix/main.cf
@@ -1097,137 +1101,150 @@ function _setup_ssl()
     * ) _notify 'err' 'TLS_LEVEL not found _setup_ssl' ;;
   esac
 
-	# SSL certificate Configuration
-	case $SSL_TYPE in
-		"letsencrypt" )
+  # SSL certificate Configuration
+  case "${SSL_TYPE}" in
+    "letsencrypt" )
       _notify 'inf' "Configuring SSL using 'letsencrypt'"
       # letsencrypt folders and files mounted in /etc/letsencrypt
       local LETSENCRYPT_DOMAIN=""
       local LETSENCRYPT_KEY=""
 
-      [[ -f /etc/letsencrypt/acme.json ]] && (_extract_certs_from_acme "$HOSTNAME" || _extract_certs_from_acme "$DOMAINNAME")
+      [[ -f /etc/letsencrypt/acme.json ]] && (_extract_certs_from_acme "${HOSTNAME}" || _extract_certs_from_acme "${DOMAINNAME}")
 
       # first determine the letsencrypt domain by checking both the full hostname or just the domainname if a SAN is used in the cert
-      if [[ -e /etc/letsencrypt/live/$HOSTNAME/fullchain.pem ]]
+      if [[ -e /etc/letsencrypt/live/${HOSTNAME}/fullchain.pem ]]
       then
-        LETSENCRYPT_DOMAIN=$HOSTNAME
-      elif [[ -e /etc/letsencrypt/live/$DOMAINNAME/fullchain.pem ]]
+        LETSENCRYPT_DOMAIN=${HOSTNAME}
+      elif [[ -e /etc/letsencrypt/live/${DOMAINNAME}/fullchain.pem ]]
       then
-        LETSENCRYPT_DOMAIN=$DOMAINNAME
-			else
-				_notify 'err' "Cannot access '/etc/letsencrypt/live/$HOSTNAME/fullchain.pem' or '/etc/letsencrypt/live/$DOMAINNAME/fullchain.pem'"
+        LETSENCRYPT_DOMAIN=${DOMAINNAME}
+      else
+        _notify 'err' "Cannot access '/etc/letsencrypt/live/${HOSTNAME}/fullchain.pem' or '/etc/letsencrypt/live/${DOMAINNAME}/fullchain.pem'"
         return 1
-			fi
+      fi
 
       # then determine the keyfile to use
-			if [[ -n $LETSENCRYPT_DOMAIN ]]
+      if [[ -n ${LETSENCRYPT_DOMAIN} ]]
       then
-				if [[ -e /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem ]]
+        if [[ -e /etc/letsencrypt/live/${LETSENCRYPT_DOMAIN}/privkey.pem ]]
         then
-					LETSENCRYPT_KEY="privkey"
-				elif [[ -e /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/key.pem ]]
+          LETSENCRYPT_KEY="privkey"
+        elif [[ -e /etc/letsencrypt/live/${LETSENCRYPT_DOMAIN}/key.pem ]]
         then
-					LETSENCRYPT_KEY="key"
-				else
-					_notify 'err' "Cannot access '/etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem' nor 'key.pem'"
+          LETSENCRYPT_KEY="key"
+        else
+          _notify 'err' "Cannot access '/etc/letsencrypt/live/${LETSENCRYPT_DOMAIN}/privkey.pem' nor 'key.pem'"
           return 1
-				fi
+        fi
       fi
 
       # finally, make the changes to the postfix and dovecot configurations
-      if [[ -n $LETSENCRYPT_KEY ]]
+      if [[ -n ${LETSENCRYPT_KEY} ]]
       then
-        _notify 'inf' "Adding $LETSENCRYPT_DOMAIN SSL certificate to the postfix and dovecot configuration"
+        _notify 'inf' "Adding ${LETSENCRYPT_DOMAIN} SSL certificate to the postfix and dovecot configuration"
 
         # Postfix configuration
+        # shellcheck disable=SC2248,SC2250
         sed -i -r 's~smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem~smtpd_tls_cert_file=/etc/letsencrypt/live/'$LETSENCRYPT_DOMAIN'/fullchain.pem~g' /etc/postfix/main.cf
-        sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/letsencrypt/live/'$LETSENCRYPT_DOMAIN'/'"$LETSENCRYPT_KEY"'\.pem~g' /etc/postfix/main.cf
+        # shellcheck disable=SC2248,SC2250
+        sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/letsencrypt/live/'$LETSENCRYPT_DOMAIN'/'$LETSENCRYPT_KEY'\.pem~g' /etc/postfix/main.cf
 
         # Dovecot configuration
+        # shellcheck disable=SC2248,SC2250
         sed -i -e 's~ssl_cert = </etc/dovecot/ssl/dovecot\.pem~ssl_cert = </etc/letsencrypt/live/'$LETSENCRYPT_DOMAIN'/fullchain\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
-        sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/letsencrypt/live/'$LETSENCRYPT_DOMAIN'/'"$LETSENCRYPT_KEY"'\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
+        # shellcheck disable=SC2248,SC2250
+        sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/letsencrypt/live/'$LETSENCRYPT_DOMAIN'/'$LETSENCRYPT_KEY'\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
 
         _notify 'inf' "SSL configured with 'letsencrypt' certificates"
       fi
       return 0
-		  ;;
-	  "custom" )
-		  # Adding CA signed SSL certificate if provided in 'postfix/ssl' folder
-		  if [[ -e /tmp/docker-mailserver/ssl/$HOSTNAME-full.pem ]]
+      ;;
+    "custom" )
+      # Adding CA signed SSL certificate if provided in 'postfix/ssl' folder
+      if [[ -e /tmp/docker-mailserver/ssl/${HOSTNAME}-full.pem ]]
       then
-			  _notify 'inf' "Adding $HOSTNAME SSL certificate"
+        _notify 'inf' "Adding ${HOSTNAME} SSL certificate"
 
-			  mkdir -p /etc/postfix/ssl
-			  cp "/tmp/docker-mailserver/ssl/$HOSTNAME-full.pem" /etc/postfix/ssl
+        mkdir -p /etc/postfix/ssl
+        cp "/tmp/docker-mailserver/ssl/${HOSTNAME}-full.pem" /etc/postfix/ssl
 
-			  # Postfix configuration
-			  sed -i -r 's~smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem~smtpd_tls_cert_file=/etc/postfix/ssl/'$HOSTNAME'-full.pem~g' /etc/postfix/main.cf
-			  sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/postfix/ssl/'$HOSTNAME'-full.pem~g' /etc/postfix/main.cf
+        # Postfix configuration
+        # shellcheck disable=SC2248,SC2250
+        sed -i -r 's~smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem~smtpd_tls_cert_file=/etc/postfix/ssl/'$HOSTNAME'-full.pem~g' /etc/postfix/main.cf
+        # shellcheck disable=SC2248,SC2250
+        sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/postfix/ssl/'$HOSTNAME'-full.pem~g' /etc/postfix/main.cf
 
-			  # Dovecot configuration
-			  sed -i -e 's~ssl_cert = </etc/dovecot/ssl/dovecot\.pem~ssl_cert = </etc/postfix/ssl/'$HOSTNAME'-full\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
-			  sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/postfix/ssl/'$HOSTNAME'-full\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
+        # Dovecot configuration
+        # shellcheck disable=SC2248,SC2250
+        sed -i -e 's~ssl_cert = </etc/dovecot/ssl/dovecot\.pem~ssl_cert = </etc/postfix/ssl/'$HOSTNAME'-full\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
+        # shellcheck disable=SC2248,SC2250
+        sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/postfix/ssl/'$HOSTNAME'-full\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
 
-			  _notify 'inf' "SSL configured with 'CA signed/custom' certificates"
-		  fi
-		  ;;
-	  "manual" )
-		  # Lets you manually specify the location of the SSL Certs to use. This gives you some more control over this whole  processes (like using kube-lego to generate certs)
-		  if [[ -n $SSL_CERT_PATH ]] && [[ -n $SSL_KEY_PATH ]]
+        _notify 'inf' "SSL configured with 'CA signed/custom' certificates"
+      fi
+      ;;
+    "manual" )
+      # Lets you manually specify the location of the SSL Certs to use. This gives you some more control over this whole  processes (like using kube-lego to generate certs)
+      if [[ -n ${SSL_CERT_PATH} ]] && [[ -n ${SSL_KEY_PATH} ]]
       then
-		  	_notify 'inf' "Configuring certificates using cert $SSL_CERT_PATH and key $SSL_KEY_PATH"
+        _notify 'inf' "Configuring certificates using cert ${SSL_CERT_PATH} and key ${SSL_KEY_PATH}"
 
-			  mkdir -p /etc/postfix/ssl
-			  cp "$SSL_CERT_PATH" /etc/postfix/ssl/cert
-			  cp "$SSL_KEY_PATH" /etc/postfix/ssl/key
-			  chmod 600 /etc/postfix/ssl/cert
-			  chmod 600 /etc/postfix/ssl/key
+        mkdir -p /etc/postfix/ssl
+        cp "${SSL_CERT_PATH}" /etc/postfix/ssl/cert
+        cp "${SSL_KEY_PATH}" /etc/postfix/ssl/key
+        chmod 600 /etc/postfix/ssl/cert
+        chmod 600 /etc/postfix/ssl/key
 
-			  # Postfix configuration
-			  sed -i -r 's~smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem~smtpd_tls_cert_file=/etc/postfix/ssl/cert~g' /etc/postfix/main.cf
-			  sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/postfix/ssl/key~g' /etc/postfix/main.cf
+        # Postfix configuration
+        sed -i -r 's~smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem~smtpd_tls_cert_file=/etc/postfix/ssl/cert~g' /etc/postfix/main.cf
+        sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/postfix/ssl/key~g' /etc/postfix/main.cf
 
-			  # Dovecot configuration
-			  sed -i -e 's~ssl_cert = </etc/dovecot/ssl/dovecot\.pem~ssl_cert = </etc/postfix/ssl/cert~g' /etc/dovecot/conf.d/10-ssl.conf
-			  sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/postfix/ssl/key~g' /etc/dovecot/conf.d/10-ssl.conf
+        # Dovecot configuration
+        sed -i -e 's~ssl_cert = </etc/dovecot/ssl/dovecot\.pem~ssl_cert = </etc/postfix/ssl/cert~g' /etc/dovecot/conf.d/10-ssl.conf
+        sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/postfix/ssl/key~g' /etc/dovecot/conf.d/10-ssl.conf
 
-			  _notify 'inf' "SSL configured with 'Manual' certificates"
-		  fi
-	    ;;
+        _notify 'inf' "SSL configured with 'Manual' certificates"
+      fi
+      ;;
     "self-signed" )
-	    # Adding self-signed SSL certificate if provided in 'postfix/ssl' folder
-	    if [[ -e /tmp/docker-mailserver/ssl/$HOSTNAME-cert.pem ]] \
-	    && [[ -e /tmp/docker-mailserver/ssl/$HOSTNAME-key.pem ]] \
-	    && [[ -e /tmp/docker-mailserver/ssl/$HOSTNAME-combined.pem ]] \
-	    && [[ -e /tmp/docker-mailserver/ssl/demoCA/cacert.pem ]]
+      # Adding self-signed SSL certificate if provided in 'postfix/ssl' folder
+      if [[ -e /tmp/docker-mailserver/ssl/${HOSTNAME}-cert.pem ]] \
+      && [[ -e /tmp/docker-mailserver/ssl/${HOSTNAME}-key.pem ]] \
+      && [[ -e /tmp/docker-mailserver/ssl/${HOSTNAME}-combined.pem ]] \
+      && [[ -e /tmp/docker-mailserver/ssl/demoCA/cacert.pem ]]
       then
-	  	  _notify 'inf' "Adding $HOSTNAME SSL certificate"
+        _notify 'inf' "Adding ${HOSTNAME} SSL certificate"
 
-		    mkdir -p /etc/postfix/ssl
-		    cp "/tmp/docker-mailserver/ssl/$HOSTNAME-cert.pem" /etc/postfix/ssl
-		    cp "/tmp/docker-mailserver/ssl/$HOSTNAME-key.pem" /etc/postfix/ssl
+        mkdir -p /etc/postfix/ssl
+        cp "/tmp/docker-mailserver/ssl/${HOSTNAME}-cert.pem" /etc/postfix/ssl
+        cp "/tmp/docker-mailserver/ssl/${HOSTNAME}-key.pem" /etc/postfix/ssl
 
         # Force permission on key file
-		    chmod 600 "/etc/postfix/ssl/$HOSTNAME-key.pem"
-		    cp "/tmp/docker-mailserver/ssl/$HOSTNAME-combined.pem" /etc/postfix/ssl
-		    cp /tmp/docker-mailserver/ssl/demoCA/cacert.pem /etc/postfix/ssl
+        chmod 600 "/etc/postfix/ssl/${HOSTNAME}-key.pem"
+        cp "/tmp/docker-mailserver/ssl/${HOSTNAME}-combined.pem" /etc/postfix/ssl
+        cp /tmp/docker-mailserver/ssl/demoCA/cacert.pem /etc/postfix/ssl
 
-		    # Postfix configuration
-		    sed -i -r 's~smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem~smtpd_tls_cert_file=/etc/postfix/ssl/'$HOSTNAME'-cert.pem~g' /etc/postfix/main.cf
-		    sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/postfix/ssl/'$HOSTNAME'-key.pem~g' /etc/postfix/main.cf
-		    sed -i -r 's~#smtpd_tls_CAfile=~smtpd_tls_CAfile=/etc/postfix/ssl/cacert.pem~g' /etc/postfix/main.cf
-		    sed -i -r 's~#smtp_tls_CAfile=~smtp_tls_CAfile=/etc/postfix/ssl/cacert.pem~g' /etc/postfix/main.cf
-		    ln -s /etc/postfix/ssl/cacert.pem "/etc/ssl/certs/cacert-$HOSTNAME.pem"
+        # Postfix configuration
+        # shellcheck disable=SC2248,SC2250
+        sed -i -r 's~smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem~smtpd_tls_cert_file=/etc/postfix/ssl/'$HOSTNAME'-cert.pem~g' /etc/postfix/main.cf
+        # shellcheck disable=SC2248,SC2250
+        sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/postfix/ssl/'$HOSTNAME'-key.pem~g' /etc/postfix/main.cf
+        sed -i -r 's~#smtpd_tls_CAfile=~smtpd_tls_CAfile=/etc/postfix/ssl/cacert.pem~g' /etc/postfix/main.cf
+        sed -i -r 's~#smtp_tls_CAfile=~smtp_tls_CAfile=/etc/postfix/ssl/cacert.pem~g' /etc/postfix/main.cf
+        # shellcheck disable=SC2250
+        ln -s /etc/postfix/ssl/cacert.pem "/etc/ssl/certs/cacert-$HOSTNAME.pem"
 
-		    # Dovecot configuration
-		    sed -i -e 's~ssl_cert = </etc/dovecot/ssl/dovecot\.pem~ssl_cert = </etc/postfix/ssl/'$HOSTNAME'-combined\.pem~g' /etc/  dovecot/conf.d/10-ssl.conf
-		    sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/postfix/ssl/'$HOSTNAME'-key\.pem~g' /etc/dovecot/ conf.d/10-ssl.conf
+        # Dovecot configuration
+        # shellcheck disable=SC2248,SC2250
+        sed -i -e 's~ssl_cert = </etc/dovecot/ssl/dovecot\.pem~ssl_cert = </etc/postfix/ssl/'$HOSTNAME'-combined\.pem~g' /etc/  dovecot/conf.d/10-ssl.conf
+        # shellcheck disable=SC2248,SC2250
+        sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/postfix/ssl/'$HOSTNAME'-key\.pem~g' /etc/dovecot/ conf.d/10-ssl.conf
 
-		    _notify 'inf' "SSL configured with 'self-signed' certificates"
-	    fi
-	    ;;
+        _notify 'inf' "SSL configured with 'self-signed' certificates"
+      fi
+      ;;
     '' )
-      # $SSL_TYPE=empty, no SSL certificate, plain text access
+      # ${SSL_TYPE}=empty, no SSL certificate, plain text access
 
       # Dovecot configuration
       sed -i -e 's~#disable_plaintext_auth = yes~disable_plaintext_auth = no~g' /etc/dovecot/conf.d/10-auth.conf
@@ -1239,113 +1256,113 @@ function _setup_ssl()
       # Unknown option, default behavior, no action is required
       _notify 'warn' "SSL configured by default"
       ;;
-	esac
+  esac
 }
 
 function _setup_postfix_vhost()
 {
-	_notify 'task' "Setting up Postfix vhost"
+  _notify 'task' "Setting up Postfix vhost"
 
-	if [[ -f /tmp/vhost.tmp ]]
+  if [[ -f /tmp/vhost.tmp ]]
   then
     # shellcheck disable=SC2002
-		cat /tmp/vhost.tmp | sort | uniq > /etc/postfix/vhost && rm /tmp/vhost.tmp
+    cat /tmp/vhost.tmp | sort | uniq > /etc/postfix/vhost && rm /tmp/vhost.tmp
   elif [[ ! -f /etc/postfix/vhost ]]
   then
     touch /etc/postfix/vhost
-	fi
+  fi
 }
 
 function _setup_inet_protocols()
 {
   _notify 'task' 'Setting up POSTFIX_INET_PROTOCOLS option'
-  postconf -e "inet_protocols = $POSTFIX_INET_PROTOCOLS"
+  postconf -e "inet_protocols = ${POSTFIX_INET_PROTOCOLS}"
 }
 
 function _setup_docker_permit()
 {
-	_notify 'task' 'Setting up PERMIT_DOCKER Option'
+  _notify 'task' 'Setting up PERMIT_DOCKER Option'
 
-	container_ip=$(ip addr show eth0 | grep 'inet ' | sed 's/[^0-9\.\/]*//g' | cut -d '/' -f 1)
-	container_network="$(echo "$container_ip" | cut -d '.' -f1-2).0.0"
-	container_networks=$(ip -o -4 addr show type veth | grep -E -o '[0-9\.]+/[0-9]+')
+  container_ip=$(ip addr show eth0 | grep 'inet ' | sed 's/[^0-9\.\/]*//g' | cut -d '/' -f 1)
+  container_network="$(echo "${container_ip}" | cut -d '.' -f1-2).0.0"
+  container_networks=$(ip -o -4 addr show type veth | grep -E -o '[0-9\.]+/[0-9]+')
 
-	case $PERMIT_DOCKER in
-		"host" )
-			_notify 'inf' "Adding $container_network/16 to my networks"
-			postconf -e "$(postconf | grep '^mynetworks =') $container_network/16"
-			echo "$container_network/16" >> /etc/opendmarc/ignore.hosts
-			echo "$container_network/16" >> /etc/opendkim/TrustedHosts
-			;;
+  case ${PERMIT_DOCKER} in
+    "host" )
+      _notify 'inf' "Adding ${container_network}/16 to my networks"
+      postconf -e "$(postconf | grep '^mynetworks =') ${container_network}/16"
+      echo "${container_network}/16" >> /etc/opendmarc/ignore.hosts
+      echo "${container_network}/16" >> /etc/opendkim/TrustedHosts
+      ;;
 
-		"network" )
-			_notify 'inf' "Adding docker network in my networks"
-			postconf -e "$(postconf | grep '^mynetworks =') 172.16.0.0/12"
-			echo 172.16.0.0/12 >> /etc/opendmarc/ignore.hosts
-			echo 172.16.0.0/12 >> /etc/opendkim/TrustedHosts
-			;;
-		"connected-networks" )
-			for network in $container_networks
+    "network" )
+      _notify 'inf' "Adding docker network in my networks"
+      postconf -e "$(postconf | grep '^mynetworks =') 172.16.0.0/12"
+      echo 172.16.0.0/12 >> /etc/opendmarc/ignore.hosts
+      echo 172.16.0.0/12 >> /etc/opendkim/TrustedHosts
+      ;;
+    "connected-networks" )
+      for network in ${container_networks}
       do
-				network=$(_sanitize_ipv4_to_subnet_cidr "$network")
-				_notify 'inf' "Adding docker network $network in my networks"
-				postconf -e "$(postconf | grep '^mynetworks =') $network"
-				echo "$network" >> /etc/opendmarc/ignore.hosts
-				echo "$network" >> /etc/opendkim/TrustedHosts
-			done
-			;;
-		* )
-			_notify 'inf' "Adding container ip in my networks"
-			postconf -e "$(postconf | grep '^mynetworks =') $container_ip/32"
-			echo "$container_ip/32" >> /etc/opendmarc/ignore.hosts
-			echo "$container_ip/32" >> /etc/opendkim/TrustedHosts
-			;;
-	esac
+        network=$(_sanitize_ipv4_to_subnet_cidr "${network}")
+        _notify 'inf' "Adding docker network ${network} in my networks"
+        postconf -e "$(postconf | grep '^mynetworks =') ${network}"
+        echo "${network}" >> /etc/opendmarc/ignore.hosts
+        echo "${network}" >> /etc/opendkim/TrustedHosts
+      done
+      ;;
+    * )
+      _notify 'inf' "Adding container ip in my networks"
+      postconf -e "$(postconf | grep '^mynetworks =') ${container_ip}/32"
+      echo "${container_ip}/32" >> /etc/opendmarc/ignore.hosts
+      echo "${container_ip}/32" >> /etc/opendkim/TrustedHosts
+      ;;
+  esac
 }
 
 function _setup_postfix_virtual_transport()
 {
-	_notify 'task' 'Setting up Postfix virtual transport'
+  _notify 'task' 'Setting up Postfix virtual transport'
 
-	[[ -z $POSTFIX_DAGENT ]] && echo "$POSTFIX_DAGENT not set." && \
-		kill -15 "$(cat /var/run/supervisord.pid)" && return 1
+  [[ -z ${POSTFIX_DAGENT} ]] && echo "${POSTFIX_DAGENT} not set." && \
+    kill -15 "$(cat /var/run/supervisord.pid)" && return 1
 
-	postconf -e "virtual_transport = $POSTFIX_DAGENT"
+  postconf -e "virtual_transport = ${POSTFIX_DAGENT}"
 }
 
 function _setup_postfix_override_configuration()
 {
-	_notify 'task' 'Setting up Postfix Override configuration'
+  _notify 'task' 'Setting up Postfix Override configuration'
 
-	if [[ -f /tmp/docker-mailserver/postfix-main.cf ]]
+  if [[ -f /tmp/docker-mailserver/postfix-main.cf ]]
   then
-		while read -r line
+    while read -r line
     do
-		  # all valid postfix options start with a lower case letter
-		  # http://www.postfix.org/postconf.5.html
-		  if [[ $line =~ ^[a-z] ]]
+      # all valid postfix options start with a lower case letter
+      # http://www.postfix.org/postconf.5.html
+      if [[ ${line} =~ ^[a-z] ]]
       then
-		  	postconf -e "$line"
-		  fi
-		done < /tmp/docker-mailserver/postfix-main.cf
-		_notify 'inf' "Loaded 'config/postfix-main.cf'"
-	else
-		_notify 'inf' "No extra postfix settings loaded because optional '/tmp/docker-mailserver/postfix-main.cf' not provided."
-	fi
+        postconf -e "${line}"
+      fi
+    done < /tmp/docker-mailserver/postfix-main.cf
+    _notify 'inf' "Loaded 'config/postfix-main.cf'"
+  else
+    _notify 'inf' "No extra postfix settings loaded because optional '/tmp/docker-mailserver/postfix-main.cf' not provided."
+  fi
 
-	if [[ -f /tmp/docker-mailserver/postfix-master.cf ]]
+  if [[ -f /tmp/docker-mailserver/postfix-master.cf ]]
   then
-		while read -r line
+    while read -r line
     do
-		  if [[ "$line" =~ ^[0-9a-z] ]]
+      if [[ "${line}" =~ ^[0-9a-z] ]]
       then
-		  	postconf -P "$line"
-		  fi
-		done < /tmp/docker-mailserver/postfix-master.cf
-		_notify 'inf' "Loaded 'config/postfix-master.cf'"
-	else
-		_notify 'inf' "No extra postfix settings loaded because optional '/tmp/docker-mailserver/postfix-master.cf' not provided."
-	fi
+        postconf -P "${line}"
+      fi
+    done < /tmp/docker-mailserver/postfix-master.cf
+    _notify 'inf' "Loaded 'config/postfix-master.cf'"
+  else
+    _notify 'inf' "No extra postfix settings loaded because optional '/tmp/docker-mailserver/postfix-master.cf' not provided."
+  fi
 
   _notify 'inf' "set the compatibility level to 2"
   postconf compatibility_level=2
@@ -1353,144 +1370,144 @@ function _setup_postfix_override_configuration()
 
 function _setup_postfix_sasl_password()
 {
-	_notify 'task' 'Setting up Postfix SASL Password'
+  _notify 'task' 'Setting up Postfix SASL Password'
 
-	# support general SASL password
-	rm -f /etc/postfix/sasl_passwd
-	if [[ -n $SASL_PASSWD ]]
+  # support general SASL password
+  rm -f /etc/postfix/sasl_passwd
+  if [[ -n ${SASL_PASSWD} ]]
   then
-		echo "$SASL_PASSWD" >> /etc/postfix/sasl_passwd
-	fi
+    echo "${SASL_PASSWD}" >> /etc/postfix/sasl_passwd
+  fi
 
-	# install SASL passwords
-	if [[ -f /etc/postfix/sasl_passwd ]]
+  # install SASL passwords
+  if [[ -f /etc/postfix/sasl_passwd ]]
   then
-		chown root:root /etc/postfix/sasl_passwd
-		chmod 0600 /etc/postfix/sasl_passwd
-		_notify 'inf' "Loaded SASL_PASSWD"
-	else
-		_notify 'inf' "Warning: 'SASL_PASSWD' is not provided. /etc/postfix/sasl_passwd not created."
-	fi
+    chown root:root /etc/postfix/sasl_passwd
+    chmod 0600 /etc/postfix/sasl_passwd
+    _notify 'inf' "Loaded SASL_PASSWD"
+  else
+    _notify 'inf' "Warning: 'SASL_PASSWD' is not provided. /etc/postfix/sasl_passwd not created."
+  fi
 }
 
 function _setup_postfix_default_relay_host()
 {
-	_notify 'task' 'Applying default relay host to Postfix'
+  _notify 'task' 'Applying default relay host to Postfix'
 
-	_notify 'inf' "Applying default relay host $DEFAULT_RELAY_HOST to /etc/postfix/main.cf"
-	postconf -e "relayhost = $DEFAULT_RELAY_HOST"
+  _notify 'inf' "Applying default relay host ${DEFAULT_RELAY_HOST} to /etc/postfix/main.cf"
+  postconf -e "relayhost = ${DEFAULT_RELAY_HOST}"
 }
 
 function _setup_postfix_relay_hosts()
 {
-	_notify 'task' 'Setting up Postfix Relay Hosts'
+  _notify 'task' 'Setting up Postfix Relay Hosts'
 
-	# copy old AWS_SES variables to new variables
-	if [[ -z $RELAY_HOST ]]
+  # copy old AWS_SES variables to new variables
+  if [[ -z ${RELAY_HOST} ]]
   then
-		if [[ -n $AWS_SES_HOST ]]
+    if [[ -n ${AWS_SES_HOST} ]]
     then
-			_notify 'inf' "Using deprecated AWS_SES environment variables"
-			RELAY_HOST="$AWS_SES_HOST"
-		fi
-	fi
+      _notify 'inf' "Using deprecated AWS_SES environment variables"
+      RELAY_HOST="${AWS_SES_HOST}"
+    fi
+  fi
 
-	if [[ -z $RELAY_PORT ]]
+  if [[ -z ${RELAY_PORT} ]]
   then
-		if [[ -z $AWS_SES_PORT ]]
+    if [[ -z ${AWS_SES_PORT} ]]
     then
-			RELAY_PORT=25
-		else
-			RELAY_PORT=$AWS_SES_PORT
-		fi
-	fi
+      RELAY_PORT=25
+    else
+      RELAY_PORT=${AWS_SES_PORT}
+    fi
+  fi
 
-	if [[ -z $RELAY_USER ]]
+  if [[ -z ${RELAY_USER} ]]
   then
-		if [[ -n $AWS_SES_USERPASS ]]
+    if [[ -n ${AWS_SES_USERPASS} ]]
     then
-			# NB this will fail if the password contains a colon!
-			RELAY_USER=$(echo "$AWS_SES_USERPASS" | cut -f 1 -d ":")
-			RELAY_PASSWORD=$(echo "$AWS_SES_USERPASS" | cut -f 2 -d ":")
-		fi
-	fi
+      # NB this will fail if the password contains a colon!
+      RELAY_USER=$(echo "${AWS_SES_USERPASS}" | cut -f 1 -d ":")
+      RELAY_PASSWORD=$(echo "${AWS_SES_USERPASS}" | cut -f 2 -d ":")
+    fi
+  fi
 
-	_notify 'inf' "Setting up outgoing email relaying via $RELAY_HOST:$RELAY_PORT"
+  _notify 'inf' "Setting up outgoing email relaying via ${RELAY_HOST}:${RELAY_PORT}"
 
-	# setup /etc/postfix/sasl_passwd
-	# --
-	# @domain1.com        postmaster@domain1.com:your-password-1
-	# @domain2.com        postmaster@domain2.com:your-password-2
-	# @domain3.com        postmaster@domain3.com:your-password-3
-	#
-	# [smtp.mailgun.org]:587  postmaster@domain2.com:your-password-2
+  # setup /etc/postfix/sasl_passwd
+  # --
+  # @domain1.com        postmaster@domain1.com:your-password-1
+  # @domain2.com        postmaster@domain2.com:your-password-2
+  # @domain3.com        postmaster@domain3.com:your-password-3
+  #
+  # [smtp.mailgun.org]:587  postmaster@domain2.com:your-password-2
 
-	if [[ -f /tmp/docker-mailserver/postfix-sasl-password.cf ]]
+  if [[ -f /tmp/docker-mailserver/postfix-sasl-password.cf ]]
   then
-		_notify 'inf' "Adding relay authentication from postfix-sasl-password.cf"
+    _notify 'inf' "Adding relay authentication from postfix-sasl-password.cf"
 
-		while read -r line
+    while read -r line
     do
-			if ! echo "$line" | grep -q -e "^\s*#"
+      if ! echo "${line}" | grep -q -e "^\s*#"
       then
-				echo "$line" >> /etc/postfix/sasl_passwd
-			fi
-		done < /tmp/docker-mailserver/postfix-sasl-password.cf
-	fi
+        echo "${line}" >> /etc/postfix/sasl_passwd
+      fi
+    done < /tmp/docker-mailserver/postfix-sasl-password.cf
+  fi
 
-	# add default relay
-	if [[ -n $RELAY_USER ]] && [[ -n $RELAY_PASSWORD ]]
+  # add default relay
+  if [[ -n ${RELAY_USER} ]] && [[ -n ${RELAY_PASSWORD} ]]
   then
-		echo "[$RELAY_HOST]:$RELAY_PORT		$RELAY_USER:$RELAY_PASSWORD" >> /etc/postfix/sasl_passwd
-	else
-		if [[ ! -f /tmp/docker-mailserver/postfix-sasl-password.cf ]]
+    echo "[${RELAY_HOST}]:${RELAY_PORT}		${RELAY_USER}:${RELAY_PASSWORD}" >> /etc/postfix/sasl_passwd
+  else
+    if [[ ! -f /tmp/docker-mailserver/postfix-sasl-password.cf ]]
     then
-			_notify 'warn' "No relay auth file found and no default set"
-		fi
-	fi
+      _notify 'warn' "No relay auth file found and no default set"
+    fi
+  fi
 
-	if [[ -f /etc/postfix/sasl_passwd ]]
+  if [[ -f /etc/postfix/sasl_passwd ]]
   then
-		chown root:root /etc/postfix/sasl_passwd
-		chmod 0600 /etc/postfix/sasl_passwd
-	fi
-	# end /etc/postfix/sasl_passwd
+    chown root:root /etc/postfix/sasl_passwd
+    chmod 0600 /etc/postfix/sasl_passwd
+  fi
+  # end /etc/postfix/sasl_passwd
 
-	_populate_relayhost_map
+  _populate_relayhost_map
 
-	postconf -e \
-		"smtp_sasl_auth_enable = yes" \
-		"smtp_sasl_security_options = noanonymous" \
-		"smtp_sasl_password_maps = texthash:/etc/postfix/sasl_passwd" \
-		"smtp_use_tls = yes" \
-		"smtp_tls_security_level = encrypt" \
-		"smtp_tls_note_starttls_offer = yes" \
-		"smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt" \
-		"sender_dependent_relayhost_maps = texthash:/etc/postfix/relayhost_map" \
-		"smtp_sender_dependent_authentication = yes"
+  postconf -e \
+    "smtp_sasl_auth_enable = yes" \
+    "smtp_sasl_security_options = noanonymous" \
+    "smtp_sasl_password_maps = texthash:/etc/postfix/sasl_passwd" \
+    "smtp_use_tls = yes" \
+    "smtp_tls_security_level = encrypt" \
+    "smtp_tls_note_starttls_offer = yes" \
+    "smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt" \
+    "sender_dependent_relayhost_maps = texthash:/etc/postfix/relayhost_map" \
+    "smtp_sender_dependent_authentication = yes"
 }
 
 function _setup_postfix_dhparam()
 {
-	_notify 'task' 'Setting up Postfix dhparam'
+  _notify 'task' 'Setting up Postfix dhparam'
 
-	if [[ $ONE_DIR -eq 1 ]]
+  if [[ ${ONE_DIR} -eq 1 ]]
   then
-		DHPARAMS_FILE=/var/mail-state/lib-shared/dhparams.pem
+    DHPARAMS_FILE=/var/mail-state/lib-shared/dhparams.pem
 
-    if [[ ! -f $DHPARAMS_FILE ]]
+    if [[ ! -f ${DHPARAMS_FILE} ]]
     then
-			_notify 'inf' "Use ffdhe4096 for dhparams (postfix)"
+      _notify 'inf' "Use ffdhe4096 for dhparams (postfix)"
       rm -f /etc/postfix/dhparams.pem && cp /etc/postfix/shared/ffdhe4096.pem /etc/postfix/dhparams.pem
-		else
-			_notify 'inf' "Use postfix dhparams that was generated previously"
+    else
+      _notify 'inf' "Use postfix dhparams that was generated previously"
       _notify 'warn' "Using self-generated dhparams is considered as insecure."
       _notify 'warn' "Unless you known what you are doing, please remove /var/mail-state/lib-shared/dhparams.pem."
 
       # Copy from the state directory to the working location
-      rm -f /etc/postfix/dhparams.pem && cp "$DHPARAMS_FILE" /etc/postfix/dhparams.pem
-		fi
-	else
+      rm -f /etc/postfix/dhparams.pem && cp "${DHPARAMS_FILE}" /etc/postfix/dhparams.pem
+    fi
+  else
     if [[ ! -f /etc/postfix/dhparams.pem ]]
     then
       if [[ -f /etc/dovecot/dh.pem ]]
@@ -1504,7 +1521,7 @@ function _setup_postfix_dhparam()
         _notify 'warn' "Unless you known what you are doing, please remove /var/mail-state/lib-shared/dhparams.pem."
         cp /tmp/docker-mailserver/dhparams.pem /etc/postfix/dhparams.pem
       else
-		    _notify 'inf' "Use ffdhe4096 for dhparams (postfix)"
+        _notify 'inf' "Use ffdhe4096 for dhparams (postfix)"
         cp /etc/postfix/shared/ffdhe4096.pem /etc/postfix/dhparams.pem
       fi
     else
@@ -1512,18 +1529,18 @@ function _setup_postfix_dhparam()
       _notify 'warn' "Using self-generated dhparams is considered insecure."
       _notify 'warn' "Unless you known what you are doing, please remove /etc/postfix/dhparams.pem."
     fi
-	fi
+  fi
 }
 
 function _setup_dovecot_dhparam()
 {
   _notify 'task' 'Setting up Dovecot dhparam'
 
-  if [[ $ONE_DIR -eq 1 ]]
+  if [[ ${ONE_DIR} -eq 1 ]]
   then
     DHPARAMS_FILE=/var/mail-state/lib-shared/dhparams.pem
 
-    if [[ ! -f $DHPARAMS_FILE ]]
+    if [[ ! -f ${DHPARAMS_FILE} ]]
     then
       _notify 'inf' "Use ffdhe4096 for dhparams (dovecot)"
       rm -f /etc/dovecot/dh.pem && cp /etc/postfix/shared/ffdhe4096.pem /etc/dovecot/dh.pem
@@ -1533,7 +1550,7 @@ function _setup_dovecot_dhparam()
       _notify 'warn' "Unless you known what you are doing, please remove /var/mail-state/lib-shared/dhparams.pem."
 
       # Copy from the state directory to the working location
-      rm -f /etc/dovecot/dh.pem && cp "$DHPARAMS_FILE" /etc/dovecot/dh.pem
+      rm -f /etc/dovecot/dh.pem && cp "${DHPARAMS_FILE}" /etc/dovecot/dh.pem
     fi
   else
     if [[ ! -f /etc/dovecot/dh.pem ]]
@@ -1543,15 +1560,15 @@ function _setup_dovecot_dhparam()
         _notify 'inf' "Copy postfix dhparams to dovecot"
         cp /etc/postfix/dhparams.pem /etc/dovecot/dh.pem
       elif [[ -f /tmp/docker-mailserver/dhparams.pem ]]
-	  then
+    then
         _notify 'inf' "Copy pre-generated dhparams to dovecot"
         _notify 'warn' "Using self-generated dhparams is considered as insecure."
         _notify 'warn' "Unless you known what you are doing, please remove /tmp/docker-mailserver/dhparams.pem."
 
         cp /tmp/docker-mailserver/dhparams.pem /etc/dovecot/dh.pem
       else
-		_notify 'inf' "Use ffdhe4096 for dhparams (dovecot)"
-      	cp /etc/postfix/shared/ffdhe4096.pem /etc/dovecot/dh.pem
+    _notify 'inf' "Use ffdhe4096 for dhparams (dovecot)"
+        cp /etc/postfix/shared/ffdhe4096.pem /etc/dovecot/dh.pem
       fi
     else
       _notify 'inf' "Use existing dovecot dhparams"
@@ -1563,100 +1580,100 @@ function _setup_dovecot_dhparam()
 
 function _setup_security_stack()
 {
-	_notify 'task' "Setting up Security Stack"
+  _notify 'task' "Setting up Security Stack"
 
-	# recreate auto-generated file
-	dms_amavis_file="/etc/amavis/conf.d/61-dms_auto_generated"
+  # recreate auto-generated file
+  local DMS_AMAVIS_FILE=/etc/amavis/conf.d/61-dms_auto_generated
 
-  echo "# WARNING: this file is auto-generated." > $dms_amavis_file
-	echo "use strict;" >> $dms_amavis_file
+  echo "# WARNING: this file is auto-generated." >"${DMS_AMAVIS_FILE}"
+  echo "use strict;" >>"${DMS_AMAVIS_FILE}"
 
-	# Spamassassin
-	if [[ $ENABLE_SPAMASSASSIN -eq 0 ]]
+  # Spamassassin
+  if [[ ${ENABLE_SPAMASSASSIN} -eq 0 ]]
   then
-		_notify 'warn' "Spamassassin is disabled. You can enable it with 'ENABLE_SPAMASSASSIN=1'"
-		echo "@bypass_spam_checks_maps = (1);" >> $dms_amavis_file
-	elif [[ $ENABLE_SPAMASSASSIN -eq 1 ]]
+    _notify 'warn' "Spamassassin is disabled. You can enable it with 'ENABLE_SPAMASSASSIN=1'"
+    echo "@bypass_spam_checks_maps = (1);" >>"${DMS_AMAVIS_FILE}"
+  elif [[ ${ENABLE_SPAMASSASSIN} -eq 1 ]]
   then
-		_notify 'inf' "Enabling and configuring spamassassin"
+    _notify 'inf' "Enabling and configuring spamassassin"
 
-    # shellcheck disable=SC2016
-		SA_TAG=${SA_TAG:="2.0"} && sed -i -r 's/^\$sa_tag_level_deflt (.*);/\$sa_tag_level_deflt = '$SA_TAG';/g' /etc/amavis/conf.d/20-debian_defaults
+    # shellcheck disable=SC2016,SC2248,SC2250
+    SA_TAG=${SA_TAG:="2.0"} && sed -i -r 's/^\$sa_tag_level_deflt (.*);/\$sa_tag_level_deflt = '$SA_TAG';/g' /etc/amavis/conf.d/20-debian_defaults
 
-    # shellcheck disable=SC2016
-		SA_TAG2=${SA_TAG2:="6.31"} && sed -i -r 's/^\$sa_tag2_level_deflt (.*);/\$sa_tag2_level_deflt = '$SA_TAG2';/g' /etc/amavis/conf.d/20-debian_defaults
+    # shellcheck disable=SC2016,SC2248,SC2250
+    SA_TAG2=${SA_TAG2:="6.31"} && sed -i -r 's/^\$sa_tag2_level_deflt (.*);/\$sa_tag2_level_deflt = '$SA_TAG2';/g' /etc/amavis/conf.d/20-debian_defaults
 
-    # shellcheck disable=SC2016
-		SA_KILL=${SA_KILL:="6.31"} && sed -i -r 's/^\$sa_kill_level_deflt (.*);/\$sa_kill_level_deflt = '$SA_KILL';/g' /etc/amavis/conf.d/20-debian_defaults
+    # shellcheck disable=SC2016,SC2248,SC2250
+    SA_KILL=${SA_KILL:="6.31"} && sed -i -r 's/^\$sa_kill_level_deflt (.*);/\$sa_kill_level_deflt = '$SA_KILL';/g' /etc/amavis/conf.d/20-debian_defaults
 
-		SA_SPAM_SUBJECT=${SA_SPAM_SUBJECT:="***SPAM*** "}
+    SA_SPAM_SUBJECT=${SA_SPAM_SUBJECT:="***SPAM*** "}
 
-    if [[ $SA_SPAM_SUBJECT == "undef" ]]
+    if [[ ${SA_SPAM_SUBJECT} == "undef" ]]
     then
       # shellcheck disable=SC2016
-			sed -i -r 's/^\$sa_spam_subject_tag (.*);/\$sa_spam_subject_tag = undef;/g' /etc/amavis/conf.d/20-debian_defaults
-		else
-      # shellcheck disable=SC2016
-			sed -i -r 's/^\$sa_spam_subject_tag (.*);/\$sa_spam_subject_tag = '"'$SA_SPAM_SUBJECT'"';/g' /etc/amavis/conf.d/20-debian_defaults
-		fi
+      sed -i -r 's/^\$sa_spam_subject_tag (.*);/\$sa_spam_subject_tag = undef;/g' /etc/amavis/conf.d/20-debian_defaults
+    else
+      # shellcheck disable=SC2016,SC2248,SC2250
+      sed -i -r 's/^\$sa_spam_subject_tag (.*);/\$sa_spam_subject_tag = '"'$SA_SPAM_SUBJECT'"';/g' /etc/amavis/conf.d/20-debian_defaults
+    fi
 
     # activate short circuits when SA BAYES is certain it has spam or ham.
-    if [[ $SA_SHORTCIRCUIT_BAYES_SPAM -eq 1 ]]
+    if [[ ${SA_SHORTCIRCUIT_BAYES_SPAM} -eq 1 ]]
     then
-			# automatically activate the Shortcircuit Plugin
-			sed -i -r 's/^# loadplugin Mail::SpamAssassin::Plugin::Shortcircuit/loadplugin Mail::SpamAssassin::Plugin::Shortcircuit/g' /etc/spamassassin/v320.pre
+      # automatically activate the Shortcircuit Plugin
+      sed -i -r 's/^# loadplugin Mail::SpamAssassin::Plugin::Shortcircuit/loadplugin Mail::SpamAssassin::Plugin::Shortcircuit/g' /etc/spamassassin/v320.pre
       sed -i -r 's/^# shortcircuit BAYES_99/shortcircuit BAYES_99/g' /etc/spamassassin/local.cf
     fi
 
-    if [[ $SA_SHORTCIRCUIT_BAYES_HAM -eq 1 ]]
+    if [[ ${SA_SHORTCIRCUIT_BAYES_HAM} -eq 1 ]]
     then
-			# automatically activate the Shortcircuit Plugin
-			sed -i -r 's/^# loadplugin Mail::SpamAssassin::Plugin::Shortcircuit/loadplugin Mail::SpamAssassin::Plugin::Shortcircuit/g' /etc/spamassassin/v320.pre
+      # automatically activate the Shortcircuit Plugin
+      sed -i -r 's/^# loadplugin Mail::SpamAssassin::Plugin::Shortcircuit/loadplugin Mail::SpamAssassin::Plugin::Shortcircuit/g' /etc/spamassassin/v320.pre
       sed -i -r 's/^# shortcircuit BAYES_00/shortcircuit BAYES_00/g' /etc/spamassassin/local.cf
     fi
 
-		if [[ -e /tmp/docker-mailserver/spamassassin-rules.cf ]]
+    if [[ -e /tmp/docker-mailserver/spamassassin-rules.cf ]]
     then
       cp /tmp/docker-mailserver/spamassassin-rules.cf /etc/spamassassin/
     fi
 
 
-		if [[ $SPAMASSASSIN_SPAM_TO_INBOX -eq 1 ]]
+    if [[ ${SPAMASSASSIN_SPAM_TO_INBOX} -eq 1 ]]
     then
-			_notify 'inf' "Configure Spamassassin/Amavis to put SPAM inbox"
+      _notify 'inf' "Configure Spamassassin/Amavis to put SPAM inbox"
 
-			sed -i "s/\$final_spam_destiny.*=.*$/\$final_spam_destiny = D_PASS;/g" /etc/amavis/conf.d/49-docker-mailserver
-			sed -i "s/\$final_bad_header_destiny.*=.*$/\$final_bad_header_destiny = D_PASS;/g" /etc/amavis/conf.d/49-docker-mailserver
-		else
-		  sed -i "s/\$final_spam_destiny.*=.*$/\$final_spam_destiny = D_BOUNCE;/g" /etc/amavis/conf.d/49-docker-mailserver
-			sed -i "s/\$final_bad_header_destiny.*=.*$/\$final_bad_header_destiny = D_BOUNCE;/g" /etc/amavis/conf.d/49-docker-mailserver
+      sed -i "s/\$final_spam_destiny.*=.*$/\$final_spam_destiny = D_PASS;/g" /etc/amavis/conf.d/49-docker-mailserver
+      sed -i "s/\$final_bad_header_destiny.*=.*$/\$final_bad_header_destiny = D_PASS;/g" /etc/amavis/conf.d/49-docker-mailserver
+    else
+      sed -i "s/\$final_spam_destiny.*=.*$/\$final_spam_destiny = D_BOUNCE;/g" /etc/amavis/conf.d/49-docker-mailserver
+      sed -i "s/\$final_bad_header_destiny.*=.*$/\$final_bad_header_destiny = D_BOUNCE;/g" /etc/amavis/conf.d/49-docker-mailserver
 
-			if [[ ${DEFAULT_VARS['EXPLICITLY_DEFINED_SPAMASSASSIN_SPAM_TO_INBOX']} == "0" ]]
+      if [[ ${DEFAULT_VARS['EXPLICITLY_DEFINED_SPAMASSASSIN_SPAM_TO_INBOX']} == "0" ]]
       then
          _notify 'warn' "Spam messages WILL NOT BE DELIVERED, you will NOT be notified of ANY message bounced. Please define SPAMASSASSIN_SPAM_TO_INBOX explicitly."
       fi
-		fi
-	fi
+    fi
+  fi
 
-	# Clamav
-	if [[ $ENABLE_CLAMAV -eq 0 ]]
+  # Clamav
+  if [[ ${ENABLE_CLAMAV} -eq 0 ]]
   then
-		_notify 'warn' "Clamav is disabled. You can enable it with 'ENABLE_CLAMAV=1'"
-		echo "@bypass_virus_checks_maps = (1);" >> $dms_amavis_file
-	elif [[ $ENABLE_CLAMAV -eq 1 ]]
+    _notify 'warn' "Clamav is disabled. You can enable it with 'ENABLE_CLAMAV=1'"
+    echo "@bypass_virus_checks_maps = (1);" >>"${DMS_AMAVIS_FILE}"
+  elif [[ ${ENABLE_CLAMAV} -eq 1 ]]
   then
-		_notify 'inf' "Enabling clamav"
-	fi
+    _notify 'inf' "Enabling clamav"
+  fi
 
-	echo "1;  # ensure a defined return" >> $dms_amavis_file
-	chmod 444 $dms_amavis_file
+  echo "1;  # ensure a defined return" >>"${DMS_AMAVIS_FILE}"
+  chmod 444 "${DMS_AMAVIS_FILE}"
 
-	# Fail2ban
-	if [[ $ENABLE_FAIL2BAN -eq 1 ]]
+  # Fail2ban
+  if [[ ${ENABLE_FAIL2BAN} -eq 1 ]]
   then
-		_notify 'inf' "Fail2ban enabled"
+    _notify 'inf' "Fail2ban enabled"
 
-	  if [[ -e /tmp/docker-mailserver/fail2ban-fail2ban.cf ]]
+    if [[ -e /tmp/docker-mailserver/fail2ban-fail2ban.cf ]]
     then
       cp /tmp/docker-mailserver/fail2ban-fail2ban.cf /etc/fail2ban/fail2ban.local
     fi
@@ -1665,63 +1682,64 @@ function _setup_security_stack()
     then
       cp /tmp/docker-mailserver/fail2ban-jail.cf /etc/fail2ban/jail.local
     fi
-	else
-	  # disable logrotate config for fail2ban if not enabled
-	  rm -f /etc/logrotate.d/fail2ban
-	fi
+  else
+    # disable logrotate config for fail2ban if not enabled
+    rm -f /etc/logrotate.d/fail2ban
+  fi
 
-	# fix cron.daily for spamassassin
-	sed -i -e 's~invoke-rc.d spamassassin reload~/etc/init\.d/spamassassin reload~g' /etc/cron.daily/spamassassin
+  # fix cron.daily for spamassassin
+  sed -i -e 's~invoke-rc.d spamassassin reload~/etc/init\.d/spamassassin reload~g' /etc/cron.daily/spamassassin
 
-	# copy user provided configuration files if provided
-	if [[ -f /tmp/docker-mailserver/amavis.cf ]]
+  # copy user provided configuration files if provided
+  if [[ -f /tmp/docker-mailserver/amavis.cf ]]
   then
-		cp /tmp/docker-mailserver/amavis.cf /etc/amavis/conf.d/50-user
-	fi
+    cp /tmp/docker-mailserver/amavis.cf /etc/amavis/conf.d/50-user
+  fi
 }
 
 function _setup_logrotate()
 {
-	_notify 'inf' "Setting up logrotate"
+  _notify 'inf' "Setting up logrotate"
 
-	LOGROTATE='/var/log/mail/mail.log\n{\n  compress\n  copytruncate\n  delaycompress\n'
+  LOGROTATE='/var/log/mail/mail.log\n{\n  compress\n  copytruncate\n  delaycompress\n'
 
-	case "$LOGROTATE_INTERVAL" in
-		"daily" )
-			_notify 'inf' "Setting postfix logrotate interval to daily"
-			LOGROTATE="$LOGROTATE  rotate 1\n  daily\n"
-			;;
-		"weekly" )
-			_notify 'inf' "Setting postfix logrotate interval to weekly"
-			LOGROTATE="$LOGROTATE  rotate 1\n  weekly\n"
-			;;
-		"monthly" )
-			_notify 'inf' "Setting postfix logrotate interval to monthly"
-			LOGROTATE="$LOGROTATE  rotate 1\n  monthly\n"
-			;;
+  case "${LOGROTATE_INTERVAL}" in
+    "daily" )
+      _notify 'inf' "Setting postfix logrotate interval to daily"
+      LOGROTATE="${LOGROTATE}  rotate 1\n  daily\n"
+      ;;
+    "weekly" )
+      _notify 'inf' "Setting postfix logrotate interval to weekly"
+      LOGROTATE="${LOGROTATE}  rotate 1\n  weekly\n"
+      ;;
+    "monthly" )
+      _notify 'inf' "Setting postfix logrotate interval to monthly"
+      LOGROTATE="${LOGROTATE}  rotate 1\n  monthly\n"
+      ;;
     * ) _notify 'warn' 'LOGROTATE_INTERVAL not found in _setup_logrotate' ;;
-	esac
+  esac
 
-	LOGROTATE="${LOGROTATE}}"
-	echo -e "$LOGROTATE" > /etc/logrotate.d/maillog
+  LOGROTATE="${LOGROTATE}}"
+  echo -e "${LOGROTATE}" > /etc/logrotate.d/maillog
 }
 
 function _setup_mail_summary()
 {
-	_notify 'inf' "Enable postfix summary with recipient $PFLOGSUMM_RECIPIENT"
+  _notify 'inf' "Enable postfix summary with recipient ${PFLOGSUMM_RECIPIENT}"
 
-  case "$PFLOGSUMM_TRIGGER" in
+  case "${PFLOGSUMM_TRIGGER}" in
     "daily_cron" )
       _notify 'inf' "Creating daily cron job for pflogsumm report"
 
-			echo "#!/bin/bash" > /etc/cron.daily/postfix-summary
-			echo "/usr/local/bin/report-pflogsumm-yesterday $HOSTNAME $PFLOGSUMM_RECIPIENT $PFLOGSUMM_SENDER" >> /etc/cron.daily/postfix-summary
+      echo "#!/bin/bash" > /etc/cron.daily/postfix-summary
+      echo "/usr/local/bin/report-pflogsumm-yesterday ${HOSTNAME} ${PFLOGSUMM_RECIPIENT} ${PFLOGSUMM_SENDER}" >> /etc/cron.daily/postfix-summary
 
-			chmod +x /etc/cron.daily/postfix-summary
+      chmod +x /etc/cron.daily/postfix-summary
       ;;
     "logrotate" )
       _notify 'inf' "Add postrotate action for pflogsumm report"
-			sed -i "s|}|  postrotate\n    /usr/local/bin/postfix-summary $HOSTNAME $PFLOGSUMM_RECIPIENT $PFLOGSUMM_SENDER\n  endscript\n}\n|" /etc/logrotate.d/maillog
+      # shellcheck disable=SC2248,SC2250
+      sed -i "s|}|  postrotate\n    /usr/local/bin/postfix-summary $HOSTNAME $PFLOGSUMM_RECIPIENT $PFLOGSUMM_SENDER\n  endscript\n}\n|" /etc/logrotate.d/maillog
       ;;
     * ) _notify 'err' 'PFLOGSUMM_TRIGGER not found in _setup_mail_summery' ;;
   esac
@@ -1729,41 +1747,41 @@ function _setup_mail_summary()
 
 function _setup_logwatch()
 {
-	_notify 'inf' "Enable logwatch reports with recipient $LOGWATCH_RECIPIENT"
+  _notify 'inf' "Enable logwatch reports with recipient ${LOGWATCH_RECIPIENT}"
 
   echo "LogFile = /var/log/mail/freshclam.log" >> /etc/logwatch/conf/logfiles/clam-update.conf
 
-	case "$LOGWATCH_INTERVAL" in
-		"daily" )
-			_notify 'inf' "Creating daily cron job for logwatch reports"
-			echo "#!/bin/bash" > /etc/cron.daily/logwatch
-			echo "/usr/sbin/logwatch --range Yesterday --hostname $HOSTNAME --mailto $LOGWATCH_RECIPIENT" \
-			>> /etc/cron.daily/logwatch
-			chmod 744 /etc/cron.daily/logwatch
-			;;
-		"weekly" )
-			_notify 'inf' "Creating weekly cron job for logwatch reports"
-			echo "#!/bin/bash" > /etc/cron.weekly/logwatch
-			echo "/usr/sbin/logwatch --range 'between -7 days and -1 days' --hostname $HOSTNAME --mailto $LOGWATCH_RECIPIENT" \
-			>> /etc/cron.weekly/logwatch
-			chmod 744 /etc/cron.weekly/logwatch
-			;;
+  case "${LOGWATCH_INTERVAL}" in
+    "daily" )
+      _notify 'inf' "Creating daily cron job for logwatch reports"
+      echo "#!/bin/bash" > /etc/cron.daily/logwatch
+      echo "/usr/sbin/logwatch --range Yesterday --hostname ${HOSTNAME} --mailto ${LOGWATCH_RECIPIENT}" \
+      >> /etc/cron.daily/logwatch
+      chmod 744 /etc/cron.daily/logwatch
+      ;;
+    "weekly" )
+      _notify 'inf' "Creating weekly cron job for logwatch reports"
+      echo "#!/bin/bash" > /etc/cron.weekly/logwatch
+      echo "/usr/sbin/logwatch --range 'between -7 days and -1 days' --hostname ${HOSTNAME} --mailto ${LOGWATCH_RECIPIENT}" \
+      >> /etc/cron.weekly/logwatch
+      chmod 744 /etc/cron.weekly/logwatch
+      ;;
     * ) _notify 'warn' 'LOGWATCH_INTERVAL not found in _setup_logwatch' ;;
-	esac
+  esac
 }
 
 function _setup_user_patches()
 {
-	_notify 'inf' 'Executing user-patches.sh'
+  _notify 'inf' 'Executing user-patches.sh'
 
-	if [[ -f /tmp/docker-mailserver/user-patches.sh ]]
+  if [[ -f /tmp/docker-mailserver/user-patches.sh ]]
   then
-		chmod +x /tmp/docker-mailserver/user-patches.sh
-		/tmp/docker-mailserver/user-patches.sh
-		_notify 'inf' "Executed 'config/user-patches.sh'"
-	else
-		_notify 'inf' "No user patches executed because optional '/tmp/docker-mailserver/user-patches.sh' is not provided."
-	fi
+    chmod +x /tmp/docker-mailserver/user-patches.sh
+    /tmp/docker-mailserver/user-patches.sh
+    _notify 'inf' "Executed 'config/user-patches.sh'"
+  else
+    _notify 'inf' "No user patches executed because optional '/tmp/docker-mailserver/user-patches.sh' is not provided."
+  fi
 }
 
 function _setup_environment() {
@@ -1772,9 +1790,9 @@ function _setup_environment() {
   local banner="# docker environment"
   local var
 
-  if ! grep -q "$banner" /etc/environment
+  if ! grep -q "${banner}" /etc/environment
   then
-      echo "$banner" >> /etc/environment
+      echo "${banner}" >> /etc/environment
       echo "VIRUSMAILS_DELETE_DELAY=${DEFAULT_VARS["VIRUSMAILS_DELETE_DELAY"]}" >> /etc/environment
   fi
 }
@@ -1793,14 +1811,14 @@ function _setup_environment() {
 
 function fix()
 {
-	_notify 'taskgrg' "Post-configuration checks..."
-	for _func in "${FUNCS_FIX[@]}"
+  _notify 'taskgrg' "Post-configuration checks..."
+  for FUNC in "${FUNCS_FIX[@]}"
   do
-		if ! $_func
+    if ! ${FUNC}
     then
       _defunc
     fi
-	done
+  done
 
   _notify 'taskgrg' "Remove leftover pid files from a stop/start"
   rm -rf /var/run/*.pid /var/run/*/*.pid
@@ -1809,41 +1827,41 @@ function fix()
 
 function _fix_var_mail_permissions()
 {
-	_notify 'task' 'Checking /var/mail permissions'
+  _notify 'task' 'Checking /var/mail permissions'
 
-	# dix permissions, but skip this if 3 levels deep the user id is already set
-	if [[ $(find /var/mail -maxdepth 3 -a \( \! -user 5000 -o \! -group 5000 \) | grep -c .) -ne 0 ]]
+  # dix permissions, but skip this if 3 levels deep the user id is already set
+  if [[ $(find /var/mail -maxdepth 3 -a \( \! -user 5000 -o \! -group 5000 \) | grep -c .) -ne 0 ]]
   then
-		_notify 'inf' "Fixing /var/mail permissions"
-		chown -R 5000:5000 /var/mail
-	else
-		_notify 'inf' "Permissions in /var/mail look OK"
-		return 0
-	fi
+    _notify 'inf' "Fixing /var/mail permissions"
+    chown -R 5000:5000 /var/mail
+  else
+    _notify 'inf' "Permissions in /var/mail look OK"
+    return 0
+  fi
 }
 
 function _fix_var_amavis_permissions()
 {
-	if [[ $ONE_DIR -eq 0 ]]
+  if [[ ${ONE_DIR} -eq 0 ]]
   then
-		amavis_state_dir=/var/lib/amavis
-	else
-		amavis_state_dir=/var/mail-state/lib-amavis
-	fi
+    amavis_state_dir=/var/lib/amavis
+  else
+    amavis_state_dir=/var/mail-state/lib-amavis
+  fi
 
   # shellcheck disable=SC2016
-	_notify 'task' 'Checking $amavis_state_dir permissions'
+  _notify 'task' 'Checking $amavis_state_dir permissions'
 
-	amavis_permissions_status=$(find -H $amavis_state_dir -maxdepth 3 -a \( \! -user amavis -o \! -group amavis \))
+  amavis_permissions_status=$(find -H "${amavis_state_dir}" -maxdepth 3 -a \( \! -user amavis -o \! -group amavis \))
 
-	if [[ -n $amavis_permissions_status ]]
+  if [[ -n ${amavis_permissions_status} ]]
   then
-		_notify 'inf' "Fixing $amavis_state_dir permissions"
-		chown -hR amavis:amavis $amavis_state_dir
-	else
-		_notify 'inf' "Permissions in $amavis_state_dir look OK"
-		return 0
-	fi
+    _notify 'inf' "Fixing ${amavis_state_dir} permissions"
+    chown -hR amavis:amavis "${amavis_state_dir}"
+  else
+    _notify 'inf' "Permissions in ${amavis_state_dir} look OK"
+    return 0
+  fi
 }
 
 function _fix_cleanup_clamav()
@@ -1872,25 +1890,25 @@ function _fix_cleanup_spamassassin()
 
 function misc()
 {
-	_notify 'taskgrp' 'Starting Misc'
+  _notify 'taskgrp' 'Starting Misc'
 
-	for _func in "${FUNCS_MISC[@]}"
+  for FUNC in "${FUNCS_MISC[@]}"
   do
-		if ! $_func
+    if ! ${FUNC}
     then
       _defunc
     fi
-	done
+  done
 }
 
 function _misc_save_states()
 {
-	# consolidate all states into a single directory (`/var/mail-state`) to allow persistence using docker volumes
-	statedir=/var/mail-state
+  # consolidate all states into a single directory (`/var/mail-state`) to allow persistence using docker volumes
+  statedir=/var/mail-state
 
-	if [[ $ONE_DIR -eq 1 ]] && [[ -d $statedir ]]
+  if [[ ${ONE_DIR} -eq 1 ]] && [[ -d ${statedir} ]]
   then
-		_notify 'inf' "Consolidating all state onto $statedir"
+    _notify 'inf' "Consolidating all state onto ${statedir}"
 
     local FILES=(
       /var/spool/postfix
@@ -1903,35 +1921,35 @@ function _misc_save_states()
       /var/lib/dovecot
     )
 
-		for d in "${FILES[@]}"
+    for d in "${FILES[@]}"
     do
-			dest="$statedir/$(echo "$d" | sed -e 's/.var.//; s/\//-/g')"
+      dest="${statedir}/$(echo "${d}" | sed -e 's/.var.//; s/\//-/g')"
 
-			if [[ -d $dest ]]
+      if [[ -d ${dest} ]]
       then
-				_notify 'inf' "  Destination $dest exists, linking $d to it"
-				rm -rf "$d"
-				ln -s "$dest" "$d"
-			elif [[ -d $d ]]
+        _notify 'inf' "  Destination ${dest} exists, linking ${d} to it"
+        rm -rf "${d}"
+        ln -s "${dest}" "${d}"
+      elif [[ -d ${d} ]]
       then
-				_notify 'inf' "  Moving contents of $d to $dest:" "$(ls "$d")"
-				mv "$d" "$dest"
-				ln -s "$dest" "$d"
-			else
-				_notify 'inf' "  Linking $d to $dest"
-				mkdir -p "$dest"
-				ln -s "$dest" "$d"
-			fi
-		done
+        _notify 'inf' "  Moving contents of ${d} to ${dest}:" "$(ls "${d}")"
+        mv "${d}" "${dest}"
+        ln -s "${dest}" "${d}"
+      else
+        _notify 'inf' "  Linking ${d} to ${dest}"
+        mkdir -p "${dest}"
+        ln -s "${dest}" "${d}"
+      fi
+    done
 
-		_notify 'inf' 'Fixing /var/mail-state/* permissions'
-		chown -R clamav /var/mail-state/lib-clamav
-		chown -R postfix /var/mail-state/lib-postfix
-		chown -R postgrey /var/mail-state/lib-postgrey
-		chown -R debian-spamd /var/mail-state/lib-spamassassin
-		chown -R postfix /var/mail-state/spool-postfix
+    _notify 'inf' 'Fixing /var/mail-state/* permissions'
+    chown -R clamav /var/mail-state/lib-clamav
+    chown -R postfix /var/mail-state/lib-postfix
+    chown -R postgrey /var/mail-state/lib-postgrey
+    chown -R debian-spamd /var/mail-state/lib-spamassassin
+    chown -R postfix /var/mail-state/spool-postfix
 
-	fi
+  fi
 }
 
 ##########################################################################
@@ -1940,125 +1958,125 @@ function _misc_save_states()
 
 function start_daemons()
 {
-	_notify 'taskgrp' 'Starting mail server'
+  _notify 'taskgrp' 'Starting mail server'
 
-	for _func in "${DAEMONS_START[@]}"
+  for FUNC in "${DAEMONS_START[@]}"
   do
-		if ! $_func
+    if ! ${FUNC}
     then
       _defunc
     fi
-	done
+  done
 }
 
 function _start_daemons_cron()
 {
-	_notify 'task' 'Starting cron' 'n'
-	supervisorctl start cron
+  _notify 'task' 'Starting cron' 'n'
+  supervisorctl start cron
 }
 
 function _start_daemons_rsyslog()
 {
-	_notify 'task' 'Starting rsyslog ' 'n'
+  _notify 'task' 'Starting rsyslog ' 'n'
   supervisorctl start rsyslog
 }
 
 function _start_daemons_saslauthd()
 {
-	_notify 'task' 'Starting saslauthd' 'n'
+  _notify 'task' 'Starting saslauthd' 'n'
   supervisorctl start "saslauthd_${SASLAUTHD_MECHANISMS}"
 }
 
 function _start_daemons_fail2ban()
 {
-	_notify 'task' 'Starting fail2ban ' 'n'
-	touch /var/log/auth.log
+  _notify 'task' 'Starting fail2ban ' 'n'
+  touch /var/log/auth.log
 
-	# delete fail2ban.sock that probably was left here after container restart
-	if [[ -e /var/run/fail2ban/fail2ban.sock ]]
+  # delete fail2ban.sock that probably was left here after container restart
+  if [[ -e /var/run/fail2ban/fail2ban.sock ]]
   then
-		rm /var/run/fail2ban/fail2ban.sock
-	fi
+    rm /var/run/fail2ban/fail2ban.sock
+  fi
 
   supervisorctl start fail2ban
 }
 
 function _start_daemons_opendkim()
 {
-	_notify 'task' 'Starting opendkim ' 'n'
+  _notify 'task' 'Starting opendkim ' 'n'
   supervisorctl start opendkim
 }
 
 function _start_daemons_opendmarc()
 {
-	_notify 'task' 'Starting opendmarc ' 'n'
+  _notify 'task' 'Starting opendmarc ' 'n'
   supervisorctl start opendmarc
 }
 
 function _start_daemons_postsrsd()
 {
-	_notify 'task' 'Starting postsrsd ' 'n'
-	supervisorctl start postsrsd
+  _notify 'task' 'Starting postsrsd ' 'n'
+  supervisorctl start postsrsd
 }
 
 function _start_daemons_postfix()
 {
-	_notify 'task' 'Starting postfix' 'n'
+  _notify 'task' 'Starting postfix' 'n'
   supervisorctl start postfix
 }
 
 function _start_daemons_dovecot()
 {
-	# Here we are starting sasl and imap, not pop3 because it's disabled by default
-	_notify 'task' 'Starting dovecot services' 'n'
+  # Here we are starting sasl and imap, not pop3 because it's disabled by default
+  _notify 'task' 'Starting dovecot services' 'n'
 
-	if [[ $ENABLE_POP3 -eq 1 ]]
+  if [[ ${ENABLE_POP3} -eq 1 ]]
   then
-		_notify 'task' 'Starting pop3 services' 'n'
-		mv /etc/dovecot/protocols.d/pop3d.protocol.disab /etc/dovecot/protocols.d/pop3d.protocol
-	fi
+    _notify 'task' 'Starting pop3 services' 'n'
+    mv /etc/dovecot/protocols.d/pop3d.protocol.disab /etc/dovecot/protocols.d/pop3d.protocol
+  fi
 
-	if [[ -f /tmp/docker-mailserver/dovecot.cf ]]
+  if [[ -f /tmp/docker-mailserver/dovecot.cf ]]
   then
-		cp /tmp/docker-mailserver/dovecot.cf /etc/dovecot/local.conf
-	fi
+    cp /tmp/docker-mailserver/dovecot.cf /etc/dovecot/local.conf
+  fi
 
   supervisorctl start dovecot
 
-	# TODO fix: on integration test
-	# doveadm: Error: userdb lookup: connect(/var/run/dovecot/auth-userdb) failed: No such file or directory
-	# doveadm: Fatal: user listing failed
+  # TODO fix: on integration test
+  # doveadm: Error: userdb lookup: connect(/var/run/dovecot/auth-userdb) failed: No such file or directory
+  # doveadm: Fatal: user listing failed
 
-	# if [[ $ENABLE_LDAP -ne 1 ]]
+  # if [[ ${ENABLE_LDAP} -ne 1 ]]
   # then
-	#   echo "Listing users"
-	#   /usr/sbin/dovecot user '*'
-	# fi
+  #   echo "Listing users"
+  #   /usr/sbin/dovecot user '*'
+  # fi
 }
 
 function _start_daemons_fetchmail()
 {
-	_notify 'task' 'Starting fetchmail' 'n'
-	/usr/local/bin/setup-fetchmail
-	supervisorctl start fetchmail
+  _notify 'task' 'Starting fetchmail' 'n'
+  /usr/local/bin/setup-fetchmail
+  supervisorctl start fetchmail
 }
 
 function _start_daemons_clamav()
 {
-	_notify 'task' 'Starting clamav' 'n'
+  _notify 'task' 'Starting clamav' 'n'
   supervisorctl start clamav
 }
 
 function _start_daemons_postgrey()
 {
-	_notify 'task' 'Starting postgrey' 'n'
-	rm -f /var/run/postgrey/postgrey.pid
+  _notify 'task' 'Starting postgrey' 'n'
+  rm -f /var/run/postgrey/postgrey.pid
   supervisorctl start postgrey
 }
 
 function _start_daemons_amavis()
 {
-	_notify 'task' 'Starting amavis' 'n'
+  _notify 'task' 'Starting amavis' 'n'
   supervisorctl start amavis
 }
 
@@ -2073,7 +2091,7 @@ function _start_daemons_amavis()
 
 function _start_changedetector()
 {
-	_notify 'task' 'Starting changedetector' 'n'
+  _notify 'task' 'Starting changedetector' 'n'
   supervisorctl start changedetector
 }
 
@@ -2114,7 +2132,7 @@ start_daemons
 
 _notify 'taskgrp' ""
 _notify 'taskgrp' "#"
-_notify 'taskgrp' "# $HOSTNAME is up and running"
+_notify 'taskgrp' "# ${HOSTNAME} is up and running"
 _notify 'taskgrp' "#"
 _notify 'taskgrp' ""
 
@@ -2126,4 +2144,3 @@ tail -fn 0 /var/log/mail/mail.log
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 exit 0
-

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1,52 +1,59 @@
 #!/bin/bash
 
+# version  0.2.0
+#
+# Starts the mailserver.
+
 ##########################################################################
 # >> DEFAULT VARS
 #
 # add them here.
 # Example: DEFAULT_VARS["KEY"]="VALUE"
 ##########################################################################
+
 declare -A DEFAULT_VARS
-DEFAULT_VARS["ENABLE_CLAMAV"]="${ENABLE_CLAMAV:="0"}"
-DEFAULT_VARS["ENABLE_SPAMASSASSIN"]="${ENABLE_SPAMASSASSIN:="0"}"
-DEFAULT_VARS["ENABLE_POP3"]="${ENABLE_POP3:="0"}"
-DEFAULT_VARS["ENABLE_FAIL2BAN"]="${ENABLE_FAIL2BAN:="0"}"
-DEFAULT_VARS["ENABLE_MANAGESIEVE"]="${ENABLE_MANAGESIEVE:="0"}"
-DEFAULT_VARS["ENABLE_FETCHMAIL"]="${ENABLE_FETCHMAIL:="0"}"
-DEFAULT_VARS["FETCHMAIL_POLL"]="${FETCHMAIL_POLL:="300"}"
-DEFAULT_VARS["ENABLE_LDAP"]="${ENABLE_LDAP:="0"}"
-DEFAULT_VARS["ENABLE_QUOTAS"]="${ENABLE_QUOTAS:="1"}"
+
+DEFAULT_VARS["ENABLE_CLAMAV"]="${ENABLE_CLAMAV:=0}"
+DEFAULT_VARS["ENABLE_SPAMASSASSIN"]="${ENABLE_SPAMASSASSIN:=0}"
+DEFAULT_VARS["ENABLE_POP3"]="${ENABLE_POP3:=0}"
+DEFAULT_VARS["ENABLE_FAIL2BAN"]="${ENABLE_FAIL2BAN:=0}"
+DEFAULT_VARS["ENABLE_MANAGESIEVE"]="${ENABLE_MANAGESIEVE:=0}"
+DEFAULT_VARS["ENABLE_FETCHMAIL"]="${ENABLE_FETCHMAIL:=0}"
+DEFAULT_VARS["FETCHMAIL_POLL"]="${FETCHMAIL_POLL:=300}"
+DEFAULT_VARS["ENABLE_LDAP"]="${ENABLE_LDAP:=0}"
+DEFAULT_VARS["ENABLE_QUOTAS"]="${ENABLE_QUOTAS:=1}"
 DEFAULT_VARS["LDAP_START_TLS"]="${LDAP_START_TLS:="no"}"
 DEFAULT_VARS["DOVECOT_TLS"]="${DOVECOT_TLS:="no"}"
 DEFAULT_VARS["DOVECOT_MAILBOX_FORMAT"]="${DOVECOT_MAILBOX_FORMAT:="maildir"}"
-DEFAULT_VARS["ENABLE_POSTGREY"]="${ENABLE_POSTGREY:="0"}"
-DEFAULT_VARS["POSTGREY_DELAY"]="${POSTGREY_DELAY:="300"}"
-DEFAULT_VARS["POSTGREY_MAX_AGE"]="${POSTGREY_MAX_AGE:="35"}"
-DEFAULT_VARS["POSTGREY_AUTO_WHITELIST_CLIENTS"]="${POSTGREY_AUTO_WHITELIST_CLIENTS:="5"}"
+DEFAULT_VARS["ENABLE_POSTGREY"]="${ENABLE_POSTGREY:=0}"
+DEFAULT_VARS["POSTGREY_DELAY"]="${POSTGREY_DELAY:=300}"
+DEFAULT_VARS["POSTGREY_MAX_AGE"]="${POSTGREY_MAX_AGE:=35}"
+DEFAULT_VARS["POSTGREY_AUTO_WHITELIST_CLIENTS"]="${POSTGREY_AUTO_WHITELIST_CLIENTS:=5}"
 DEFAULT_VARS["POSTGREY_TEXT"]="${POSTGREY_TEXT:="Delayed by postgrey"}"
-DEFAULT_VARS["POSTFIX_MESSAGE_SIZE_LIMIT"]="${POSTFIX_MESSAGE_SIZE_LIMIT:="10240000"}"  # ~10 MB by default
-DEFAULT_VARS["POSTFIX_MAILBOX_SIZE_LIMIT"]="${POSTFIX_MAILBOX_SIZE_LIMIT:="0"}"        # no limit by default
+DEFAULT_VARS["POSTFIX_MESSAGE_SIZE_LIMIT"]="${POSTFIX_MESSAGE_SIZE_LIMIT:=10240000}"  # ~10 MB by default
+DEFAULT_VARS["POSTFIX_MAILBOX_SIZE_LIMIT"]="${POSTFIX_MAILBOX_SIZE_LIMIT:=0}"        # no limit by default
 DEFAULT_VARS["POSTFIX_INET_PROTOCOLS"]="${POSTFIX_INET_PROTOCOLS:="all"}"
-DEFAULT_VARS["ENABLE_SASLAUTHD"]="${ENABLE_SASLAUTHD:="0"}"
-DEFAULT_VARS["SMTP_ONLY"]="${SMTP_ONLY:="0"}"
-# DEFAULT_VARS["DMS_DEBUG"] defined in helper_functions.sh
+DEFAULT_VARS["ENABLE_SASLAUTHD"]="${ENABLE_SASLAUTHD:=0}"
+DEFAULT_VARS["SMTP_ONLY"]="${SMTP_ONLY:=0}"
 DEFAULT_VARS["OVERRIDE_HOSTNAME"]="${OVERRIDE_HOSTNAME}"
 DEFAULT_VARS["POSTSCREEN_ACTION"]="${POSTSCREEN_ACTION:="enforce"}"
-DEFAULT_VARS["SPOOF_PROTECTION"]="${SPOOF_PROTECTION:="0"}"
+DEFAULT_VARS["SPOOF_PROTECTION"]="${SPOOF_PROTECTION:=0}"
 DEFAULT_VARS["TLS_LEVEL"]="${TLS_LEVEL:="modern"}"
-DEFAULT_VARS["ENABLE_SRS"]="${ENABLE_SRS:="0"}"
+DEFAULT_VARS["ENABLE_SRS"]="${ENABLE_SRS:=0}"
 DEFAULT_VARS["SRS_SENDER_CLASSES"]="${SRS_SENDER_CLASSES:="envelope_sender"}"
-DEFAULT_VARS["REPORT_RECIPIENT"]="${REPORT_RECIPIENT:="0"}"
+DEFAULT_VARS["REPORT_RECIPIENT"]="${REPORT_RECIPIENT:=0}"
 DEFAULT_VARS["LOGROTATE_INTERVAL"]="${LOGROTATE_INTERVAL:=${REPORT_INTERVAL:-"daily"}}"
 DEFAULT_VARS["LOGWATCH_INTERVAL"]="${LOGWATCH_INTERVAL:="none"}"
 DEFAULT_VARS["EXPLICITLY_DEFINED_SPAMASSASSIN_SPAM_TO_INBOX"]="$( [ -z "${SPAMASSASSIN_SPAM_TO_INBOX}" ] && echo "0" || echo "1" )" # used for backward compatibility
-DEFAULT_VARS["SPAMASSASSIN_SPAM_TO_INBOX"]="${SPAMASSASSIN_SPAM_TO_INBOX:="0"}"
-DEFAULT_VARS["MOVE_SPAM_TO_JUNK"]="${MOVE_SPAM_TO_JUNK:="1"}"
-DEFAULT_VARS["VIRUSMAILS_DELETE_DELAY"]="${VIRUSMAILS_DELETE_DELAY:="7"}"
+DEFAULT_VARS["SPAMASSASSIN_SPAM_TO_INBOX"]="${SPAMASSASSIN_SPAM_TO_INBOX:=0}"
+DEFAULT_VARS["MOVE_SPAM_TO_JUNK"]="${MOVE_SPAM_TO_JUNK:=1}"
+DEFAULT_VARS["VIRUSMAILS_DELETE_DELAY"]="${VIRUSMAILS_DELETE_DELAY:=7}"
+# DEFAULT_VARS["DMS_DEBUG"] defined in helper_functions.sh
 
 ##########################################################################
 # << DEFAULT VARS
 ##########################################################################
+
 
 ##########################################################################
 # >> GLOBAL VARS
@@ -55,9 +62,11 @@ DEFAULT_VARS["VIRUSMAILS_DELETE_DELAY"]="${VIRUSMAILS_DELETE_DELAY:="7"}"
 #
 # Example: KEY="VALUE"
 ##########################################################################
+
 HOSTNAME="$(hostname -f)"
 DOMAINNAME="$(hostname -d)"
 CHKSUM_FILE=/tmp/docker-mailserver-config-chksum
+
 ##########################################################################
 # << GLOBAL VARS
 ##########################################################################
@@ -77,13 +86,16 @@ CHKSUM_FILE=/tmp/docker-mailserver-config-chksum
 # 			> start-daemons
 #
 # Example:
-# if [ CONDITION IS MET ]; then
+# if [[ CONDITION IS MET ]]
+# then
 #   _register_{setup,fix,check,start}_{functions,daemons} "$FUNCNAME"
 # fi
 #
 # Implement them in the section-group: {check,setup,fix,start}
 ##########################################################################
-function register_functions() {
+
+function register_functions()
+{
 	_notify 'taskgrp' 'Initializing setup'
 	_notify 'task' 'Registering check,setup,fix,misc and start-daemons functions'
 
@@ -99,30 +111,23 @@ function register_functions() {
 	_register_setup_function "_setup_default_vars"
 	_register_setup_function "_setup_file_permissions"
 
-	if [ "$SMTP_ONLY" != 1 ]; then
+	if [[ $SMTP_ONLY -ne 1 ]]
+  then
 		_register_setup_function "_setup_dovecot"
     _register_setup_function "_setup_dovecot_dhparam"
 		_register_setup_function "_setup_dovecot_quota"
 		_register_setup_function "_setup_dovecot_local_user"
 	fi
 
-	if [ "$ENABLE_LDAP" = 1 ];then
-		_register_setup_function "_setup_ldap"
-	fi
-
-	if [ "$ENABLE_SASLAUTHD" = 1 ];then
-		_register_setup_function "_setup_saslauthd"
-	fi
-
-	if [ "$ENABLE_POSTGREY" = 1 ];then
-		_register_setup_function "_setup_postgrey"
-	fi
+	[[ $ENABLE_LDAP -eq 1 ]] && _register_setup_function "_setup_ldap"
+	[[ $ENABLE_SASLAUTHD -eq 1 ]] && _register_setup_function "_setup_saslauthd"
+	[[ $ENABLE_POSTGREY -eq 1 ]] && _register_setup_function "_setup_postgrey"
 
 	_register_setup_function "_setup_dkim"
 	_register_setup_function "_setup_ssl"
-	if [ "$POSTFIX_INET_PROTOCOLS" != "all" ]; then
-    _register_setup_function "_setup_inet_protocols"
-  fi
+
+	[[ $POSTFIX_INET_PROTOCOLS != "all" ]] && _register_setup_function "_setup_inet_protocols"
+
 	_register_setup_function "_setup_docker_permit"
 
 	_register_setup_function "_setup_mailname"
@@ -141,50 +146,36 @@ function register_functions() {
 	_register_setup_function "_setup_postfix_postscreen"
 	_register_setup_function "_setup_postfix_sizelimits"
 
-  if [ "$SPOOF_PROTECTION" = 1  ]; then
-		_register_setup_function "_setup_spoof_protection"
-	fi
+  [[ $SPOOF_PROTECTION -eq 1 ]] && _register_setup_function "_setup_spoof_protection"
 
-	if [ "$ENABLE_SRS" = 1 ];  then
+	if [[ $ENABLE_SRS -eq 1  ]]
+  then
 		_register_setup_function "_setup_SRS"
 		_register_start_daemon "_start_daemons_postsrsd"
 	fi
 
   _register_setup_function "_setup_postfix_access_control"
 
-	if [ ! -z "$AWS_SES_HOST" -a ! -z "$AWS_SES_USERPASS" ]; then
+	if [[ -n $AWS_SES_HOST ]] && [[ -n $AWS_SES_USERPASS ]]
+  then
 		_register_setup_function "_setup_postfix_relay_hosts"
 	fi
 
-	if [ ! -z "$DEFAULT_RELAY_HOST" ]; then
-		_register_setup_function "_setup_postfix_default_relay_host"
-	fi
-
-	if [ ! -z "$RELAY_HOST" ]; then
-		_register_setup_function "_setup_postfix_relay_hosts"
-	fi
-
-	if [ "$ENABLE_POSTFIX_VIRTUAL_TRANSPORT" = 1  ]; then
-		_register_setup_function "_setup_postfix_virtual_transport"
-	fi
+	[[ -n $DEFAULT_RELAY_HOST ]] && _register_setup_function "_setup_postfix_default_relay_host"
+	[[ -n $RELAY_HOST ]] && _register_setup_function "_setup_postfix_relay_hosts"
+	[[ $ENABLE_POSTFIX_VIRTUAL_TRANSPORT -eq 1 ]] && _register_setup_function "_setup_postfix_virtual_transport"
 
 	_register_setup_function "_setup_postfix_override_configuration"
-
   _register_setup_function "_setup_environment"
   _register_setup_function "_setup_logrotate"
 
-	if [ "$PFLOGSUMM_TRIGGER" != "none" ]; then
-		_register_setup_function "_setup_mail_summary"
-	fi
-
-	if [ "$LOGWATCH_TRIGGER" != "none" ]; then
-		_register_setup_function "_setup_logwatch"
-	fi
+  [[ $PFLOGSUMM_TRIGGER != "none" ]] && _register_setup_function "_setup_mail_summary"
+	[[ $LOGWATCH_TRIGGER != "none" ]] && _register_setup_function "_setup_logwatch"
 
 	_register_setup_function "_setup_user_patches"
 
-        # Compute last as the config files are modified in-place
-        _register_setup_function "_setup_chksum_file"
+  # Compute last as the config files are modified in-place
+  _register_setup_function "_setup_chksum_file"
 
 	################### << setup funcs
 
@@ -192,12 +183,9 @@ function register_functions() {
 
 	_register_fix_function "_fix_var_mail_permissions"
 	_register_fix_function "_fix_var_amavis_permissions"
-	if [ "$ENABLE_CLAMAV" = 0 ]; then
-        	_register_fix_function "_fix_cleanup_clamav"
-	fi
-	if [ "$ENABLE_SPAMASSASSIN" = 0 ]; then
-		_register_fix_function "_fix_cleanup_spamassassin"
-	fi
+
+	[[ $ENABLE_CLAMAV -eq 0 ]] && _register_fix_function "_fix_cleanup_clamav"
+	[[ $ENABLE_SPAMASSASSIN -eq 0 ]] &&	_register_fix_function "_fix_cleanup_spamassassin"
 
 	################### << fix funcs
 
@@ -212,66 +200,49 @@ function register_functions() {
 	_register_start_daemon "_start_daemons_cron"
 	_register_start_daemon "_start_daemons_rsyslog"
 
-	if [ "$SMTP_ONLY" != 1 ]; then
-		_register_start_daemon "_start_daemons_dovecot"
-	fi
+	[[ $SMTP_ONLY -ne 1 ]] && _register_start_daemon "_start_daemons_dovecot"
 
 	# needs to be started before saslauthd
 	_register_start_daemon "_start_daemons_opendkim"
 	_register_start_daemon "_start_daemons_opendmarc"
 
 	#postfix uses postgrey, needs to be started before postfix
-	if [ "$ENABLE_POSTGREY" = 1 ]; then
-		_register_start_daemon "_start_daemons_postgrey"
-	fi
+	[[ $ENABLE_POSTGREY -eq 1 ]] &&	_register_start_daemon "_start_daemons_postgrey"
 
 	_register_start_daemon "_start_daemons_postfix"
 
-	if [ "$ENABLE_SASLAUTHD" = 1 ];then
-		_register_start_daemon "_start_daemons_saslauthd"
-	fi
-
-	# care needs to run after postfix
-	if [ "$ENABLE_FAIL2BAN" = 1 ]; then
-		_register_start_daemon "_start_daemons_fail2ban"
-	fi
-
-	if [ "$ENABLE_FETCHMAIL" = 1 ]; then
-		_register_start_daemon "_start_daemons_fetchmail"
-	fi
-
-	if [ "$ENABLE_CLAMAV" = 1 ]; then
-		_register_start_daemon "_start_daemons_clamav"
-	fi
-    # Change detector
-    if [ "$ENABLE_LDAP" = 0 ]; then
-	    _register_start_daemon "_start_changedetector"
-    fi
+	[[ $ENABLE_SASLAUTHD -eq 1 ]] && _register_start_daemon "_start_daemons_saslauthd"
+	[[ $ENABLE_FAIL2BAN -eq 1 ]] &&	_register_start_daemon "_start_daemons_fail2ban" # care :: needs to run after postfix
+	[[ $ENABLE_FETCHMAIL -eq 1 ]] && _register_start_daemon "_start_daemons_fetchmail"
+	[[ $ENABLE_CLAMAV -eq 1 ]] &&	_register_start_daemon "_start_daemons_clamav"
+  [[ $ENABLE_LDAP -eq 0 ]] && _register_start_daemon "_start_changedetector"
 
 	_register_start_daemon "_start_daemons_amavis"
+
 	################### << daemon funcs
 }
+
 ##########################################################################
 # << REGISTER FUNCTIONS
 ##########################################################################
 
 
-
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # !  CARE --> DON'T CHANGE, unless you exactly know what you are doing
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-# >>
 
 
 ##########################################################################
 # >> CONSTANTS
 ##########################################################################
+
 declare -a FUNCS_SETUP
 declare -a FUNCS_FIX
 declare -a FUNCS_CHECK
 declare -a FUNCS_MISC
 declare -a DAEMONS_START
-declare -A HELPERS_EXEC_STATE
+# declare -A HELPERS_EXEC_STATE
+
 ##########################################################################
 # << CONSTANTS
 ##########################################################################
@@ -280,59 +251,69 @@ declare -A HELPERS_EXEC_STATE
 ##########################################################################
 # >> protected register_functions
 ##########################################################################
-function _register_start_daemon() {
-	DAEMONS_START+=($1)
+
+function _register_start_daemon()
+{
+	DAEMONS_START+=("$1")
 	_notify 'inf' "$1() registered"
 }
 
-function _register_setup_function() {
-	FUNCS_SETUP+=($1)
+function _register_setup_function()
+{
+	FUNCS_SETUP+=("$1")
 	_notify 'inf' "$1() registered"
 }
 
-function _register_fix_function() {
-	FUNCS_FIX+=($1)
+function _register_fix_function()
+{
+	FUNCS_FIX+=("$1")
 	_notify 'inf' "$1() registered"
 }
 
-function _register_check_function() {
-	FUNCS_CHECK+=($1)
+function _register_check_function()
+{
+	FUNCS_CHECK+=("$1")
 	_notify 'inf' "$1() registered"
 }
 
-function _register_misc_function() {
-	FUNCS_MISC+=($1)
+function _register_misc_function()
+{
+	FUNCS_MISC+=("$1")
 	_notify 'inf' "$1() registered"
 }
+
 ##########################################################################
 # << protected register_functions
 ##########################################################################
 
-
-function defunc() {
+function _defunc()
+{
 	_notify 'fatal' "Please fix your configuration. Exiting..."
 	exit 1
 }
 
-function display_startup_daemon() {
+function display_startup_daemon()
+{
   $1 &>/dev/null
   res=$?
-  if [[ ${DEFAULT_VARS["DMS_DEBUG"]} == 1 ]]; then
-	  if [ $res = 0 ]; then
+
+  if [[ ${DEFAULT_VARS["DMS_DEBUG"]} -eq 1 ]]
+  then
+	  if [[ $res -eq 0 ]]
+    then
 			_notify 'started' " [ OK ]"
 		else
 	  	echo "false"
 			_notify 'err' " [ FAILED ]"
 		fi
   fi
+
 	return $res
 }
 
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # !  CARE --> DON'T CHANGE, except you know exactly what you are doing
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-# <<
-
 
 
 ##########################################################################
@@ -340,37 +321,50 @@ function display_startup_daemon() {
 #
 # Description: Place functions for initial check of container sanity
 ##########################################################################
-function check() {
+
+function check()
+{
 	_notify 'taskgrp' 'Checking configuration'
-	for _func in "${FUNCS_CHECK[@]}";do
-		$_func
-		[ $? != 0 ] && defunc
+
+	for _func in "${FUNCS_CHECK[@]}"
+  do
+		if ! $_func
+    then
+      _defunc
+    fi
 	done
 }
 
-function _check_hostname() {
+function _check_hostname()
+{
+  # shellcheck disable=SC2128
 	_notify "task" "Check that hostname/domainname is provided or overridden (no default docker hostname/kubernetes) [$FUNCNAME]"
 
-	if [[ ! -z ${DEFAULT_VARS["OVERRIDE_HOSTNAME"]} ]]; then
+	if [[ -n ${DEFAULT_VARS["OVERRIDE_HOSTNAME"]} ]]
+  then
 		export HOSTNAME=${DEFAULT_VARS["OVERRIDE_HOSTNAME"]}
-		export DOMAINNAME=$(echo $HOSTNAME | sed s/[^.]*.//)
+		export DOMAINNAME="${HOSTNAME#*.}"
 	fi
 
 	_notify 'inf' "Domain has been set to $DOMAINNAME"
 	_notify 'inf' "Hostname has been set to $HOSTNAME"
 
-	if ( ! echo $HOSTNAME | grep -E '^(\S+[.]\S+)$' > /dev/null ); then
+	if ( ! echo $HOSTNAME | grep -E '^(\S+[.]\S+)$' > /dev/null )
+  then
 		_notify 'err' "Setting hostname/domainname is required"
-		kill `cat /var/run/supervisord.pid` && return 1
+		kill "$(cat /var/run/supervisord.pid)" && return 1
 	else
 		return 0
 	fi
 }
 
-function _check_environment_variables() {
+function _check_environment_variables()
+{
+  # shellcheck disable=SC2128
 	_notify "task" "Check that there are no conflicts with env variables [$FUNCNAME]"
 	return 0
 }
+
 ##########################################################################
 # << Check Stack
 ##########################################################################
@@ -381,42 +375,56 @@ function _check_environment_variables() {
 #
 # Description: Place functions for functional configurations here
 ##########################################################################
-function setup() {
+
+function setup()
+{
 	_notify 'taskgrp' 'Configuring mail server'
-	for _func in "${FUNCS_SETUP[@]}";do
+	for _func in "${FUNCS_SETUP[@]}"
+  do
 		$_func
 	done
 }
 
-function _setup_default_vars() {
+function _setup_default_vars()
+{
+  # shellcheck disable=SC2128
 	_notify 'task' "Setting up default variables [$FUNCNAME]"
 
-	# update POSTMASTER_ADDRESS - must be done done after _check_hostname()
+	# update POSTMASTER_ADDRESS - must be done done after _check_hostname
 	DEFAULT_VARS["POSTMASTER_ADDRESS"]="${POSTMASTER_ADDRESS:=postmaster@${DOMAINNAME}}"
 
-	# update REPORT_SENDER - must be done done after _check_hostname()
+	# update REPORT_SENDER - must be done done after _check_hostname
 	DEFAULT_VARS["REPORT_SENDER"]="${REPORT_SENDER:=mailserver-report@${HOSTNAME}}"
 	DEFAULT_VARS["PFLOGSUMM_SENDER"]="${PFLOGSUMM_SENDER:=${REPORT_SENDER}}"
 
 	# set PFLOGSUMM_TRIGGER here for backwards compatibility
 	# when REPORT_RECIPIENT is on the old method should be used
-	if [ "$REPORT_RECIPIENT" == "0" ]; then
+	if [[ "$REPORT_RECIPIENT" == "0" ]]
+  then
 		DEFAULT_VARS["PFLOGSUMM_TRIGGER"]="${PFLOGSUMM_TRIGGER:="none"}"
 	else
 		DEFAULT_VARS["PFLOGSUMM_TRIGGER"]="${PFLOGSUMM_TRIGGER:="logrotate"}"
 	fi
 
-	# Expand address to simplify the rest of the script
-	if [ "$REPORT_RECIPIENT" == "0" ] || [ "$REPORT_RECIPIENT" == "1" ]; then
+	# expand address to simplify the rest of the script
+	if [[ "$REPORT_RECIPIENT" == "0" ]] || [[ "$REPORT_RECIPIENT" == "1" ]]
+  then
 		REPORT_RECIPIENT="$POSTMASTER_ADDRESS"
 		DEFAULT_VARS["REPORT_RECIPIENT"]="${REPORT_RECIPIENT}"
 	fi
+
 	DEFAULT_VARS["PFLOGSUMM_RECIPIENT"]="${PFLOGSUMM_RECIPIENT:=${REPORT_RECIPIENT}}"
 	DEFAULT_VARS["LOGWATCH_RECIPIENT"]="${LOGWATCH_RECIPIENT:=${REPORT_RECIPIENT}}"
 
-	for var in ${!DEFAULT_VARS[@]}; do
-		echo "export $var=\"${DEFAULT_VARS[$var]}\"" >> /root/.bashrc
-		[ $? != 0 ] && _notify 'err' "Unable to set $var=${DEFAULT_VARS[$var]}" && kill -15 `cat /var/run/supervisord.pid` && return 1
+	for var in "${!DEFAULT_VARS[@]}"
+  do
+		if ! echo "export $var=\"${DEFAULT_VARS[$var]}\"" >> /root/.bashrc
+    then
+      _notify 'err' "Unable to set $var=${DEFAULT_VARS[$var]}"
+      kill -15 "$(cat /var/run/supervisord.pid)"
+      return 1
+    fi
+
 		_notify 'inf' "Set $var=${DEFAULT_VARS[$var]}"
 	done
 }
@@ -424,7 +432,8 @@ function _setup_default_vars() {
 # File/folder permissions are fine when using docker volumes, but may be wrong
 # when file system folders are mounted into the container.
 # Set the expected values and create missing folders/files just in case.
-function _setup_file_permissions() {
+function _setup_file_permissions()
+{
 	_notify 'task' "Setting file/folder permissions"
 
 	mkdir -p /var/log/supervisor
@@ -441,43 +450,50 @@ function _setup_file_permissions() {
 	chmod 640 /var/log/mail/freshclam.log
 }
 
-function _setup_chksum_file() {
-        _notify 'task' "Setting up configuration checksum file"
+function _setup_chksum_file()
+{
+  _notify 'task' "Setting up configuration checksum file"
 
-        if [ -d /tmp/docker-mailserver ]; then
-          _notify 'inf' "Creating $CHKSUM_FILE"
-          _monitored_files_checksums >"$CHKSUM_FILE"
-        else
-          # We could just skip the file, but perhaps config can be added later?
-          # If so it must be processed by the check for changes script
-          _notify 'inf' "Creating empty $CHKSUM_FILE (no config)"
-          touch $CHKSUM_FILE
-        fi
+  if [[ -d /tmp/docker-mailserver ]]
+  then
+    _notify 'inf' "Creating $CHKSUM_FILE"
+    _monitored_files_checksums >"$CHKSUM_FILE"
+  else
+    # We could just skip the file, but perhaps config can be added later?
+    # If so it must be processed by the check for changes script
+    _notify 'inf' "Creating empty $CHKSUM_FILE (no config)"
+    touch $CHKSUM_FILE
+  fi
 }
 
-function _setup_mailname() {
+function _setup_mailname()
+{
 	_notify 'task' 'Setting up Mailname'
 
 	_notify 'inf' "Creating /etc/mailname"
 	echo $DOMAINNAME > /etc/mailname
 }
 
-function _setup_amavis() {
+function _setup_amavis()
+{
 	_notify 'task' 'Setting up Amavis'
 
 	_notify 'inf' "Applying hostname to /etc/amavis/conf.d/05-node_id"
+  # shellcheck disable=SC2016
 	sed -i 's/^#\$myhostname = "mail.example.com";/\$myhostname = "'$HOSTNAME'";/' /etc/amavis/conf.d/05-node_id
 }
 
-function _setup_dmarc_hostname() {
+function _setup_dmarc_hostname()
+{
 	_notify 'task' 'Setting up dmarc'
 
 	_notify 'inf' "Applying hostname to /etc/opendmarc.conf"
 	sed -i -e 's/^AuthservID.*$/AuthservID          '$HOSTNAME'/g' \
-	       -e 's/^TrustedAuthservIDs.*$/TrustedAuthservIDs  '$HOSTNAME'/g' /etc/opendmarc.conf
+	  -e 's/^TrustedAuthservIDs.*$/TrustedAuthservIDs  '$HOSTNAME'/g' /etc/opendmarc.conf
 }
 
-function _setup_postfix_hostname() {
+function _setup_postfix_hostname()
+{
 	_notify 'task' 'Applying hostname and domainname to Postfix'
 
 	_notify 'inf' "Applying hostname to /etc/postfix/main.cf"
@@ -485,37 +501,44 @@ function _setup_postfix_hostname() {
 	postconf -e "mydomain = $DOMAINNAME"
 }
 
-function _setup_dovecot_hostname() {
+function _setup_dovecot_hostname()
+{
 	_notify 'task' 'Applying hostname to Dovecot'
 
 	_notify 'inf' "Applying hostname to /etc/dovecot/conf.d/15-lda.conf"
 	sed -i 's/^#hostname =.*$/hostname = '$HOSTNAME'/g' /etc/dovecot/conf.d/15-lda.conf
 }
 
-function _setup_dovecot() {
+function _setup_dovecot()
+{
 	_notify 'task' 'Setting up Dovecot'
 
-        # Moved from docker file, copy or generate default self-signed cert
-        if [ -f /var/mail-state/lib-dovecot/dovecot.pem -a "$ONE_DIR" = 1 ]; then
-                _notify 'inf' "Copying default dovecot cert"
-                cp /var/mail-state/lib-dovecot/dovecot.key /etc/dovecot/ssl/
-                cp /var/mail-state/lib-dovecot/dovecot.pem /etc/dovecot/ssl/
-        fi
-        if [ ! -f /etc/dovecot/ssl/dovecot.pem ]; then
-                _notify 'inf' "Generating default dovecot cert"
-                pushd /usr/share/dovecot
-                ./mkcert.sh
-                popd
+  # moved from docker file, copy or generate default self-signed cert
+  if [[ -f /var/mail-state/lib-dovecot/dovecot.pem ]] && [[ $ONE_DIR -eq 1 ]]
+  then
+    _notify 'inf' "Copying default dovecot cert"
+    cp /var/mail-state/lib-dovecot/dovecot.key /etc/dovecot/ssl/
+    cp /var/mail-state/lib-dovecot/dovecot.pem /etc/dovecot/ssl/
+  fi
 
-                if [ "$ONE_DIR" = 1 ];then
-                        mkdir -p /var/mail-state/lib-dovecot
-                        cp /etc/dovecot/ssl/dovecot.key /var/mail-state/lib-dovecot/
-                        cp /etc/dovecot/ssl/dovecot.pem /var/mail-state/lib-dovecot/
-                fi
-        fi
+  if [[ ! -f /etc/dovecot/ssl/dovecot.pem ]]
+  then
+    _notify 'inf' "Generating default dovecot cert"
+
+    pushd /usr/share/dovecot || return 1
+    ./mkcert.sh
+    popd || return 1
+
+    if [[ $ONE_DIR -eq 1 ]]
+    then
+      mkdir -p /var/mail-state/lib-dovecot
+      cp /etc/dovecot/ssl/dovecot.key /var/mail-state/lib-dovecot/
+      cp /etc/dovecot/ssl/dovecot.pem /var/mail-state/lib-dovecot/
+    fi
+  fi
 
 	cp -a /usr/share/dovecot/protocols.d /etc/dovecot/
-	# Disable pop3 (it will be eventually enabled later in the script, if requested)
+	# disable pop3 (it will be eventually enabled later in the script, if requested)
 	mv /etc/dovecot/protocols.d/pop3d.protocol /etc/dovecot/protocols.d/pop3d.protocol.disab
 	mv /etc/dovecot/protocols.d/managesieved.protocol /etc/dovecot/protocols.d/managesieved.protocol.disab
 	sed -i -e 's/#ssl = yes/ssl = yes/g' /etc/dovecot/conf.d/10-master.conf
@@ -524,43 +547,46 @@ function _setup_dovecot() {
 	sed -i -e 's/#ssl = yes/ssl = required/g' /etc/dovecot/conf.d/10-ssl.conf
 	sed -i 's/^postmaster_address = .*$/postmaster_address = '$POSTMASTER_ADDRESS'/g' /etc/dovecot/conf.d/15-lda.conf
 
-    # Set mail_location according to mailbox format
-    case "$DOVECOT_MAILBOX_FORMAT" in
-        sdbox|mdbox|maildir )
-            _notify 'inf' "Dovecot $DOVECOT_MAILBOX_FORMAT format configured"
-            sed -i -e 's/^mail_location = .*$/mail_location = '$DOVECOT_MAILBOX_FORMAT':\/var\/mail\/%d\/%n/g' /etc/dovecot/conf.d/10-mail.conf
-            ;;
-        * )
-            _notify 'inf' "Dovecot maildir format configured (default)"
-            sed -i -e 's/^mail_location = .*$/mail_location = maildir:\/var\/mail\/%d\/%n/g' /etc/dovecot/conf.d/10-mail.conf
-            ;;
-    esac
+  # set mail_location according to mailbox format
+  case "$DOVECOT_MAILBOX_FORMAT" in
+    sdbox|mdbox|maildir )
+      _notify 'inf' "Dovecot $DOVECOT_MAILBOX_FORMAT format configured"
+      sed -i -e 's/^mail_location = .*$/mail_location = '$DOVECOT_MAILBOX_FORMAT':\/var\/mail\/%d\/%n/g' /etc/dovecot/conf.d/10-mail.conf
+      ;;
+    * )
+      _notify 'inf' "Dovecot maildir format configured (default)"
+      sed -i -e 's/^mail_location = .*$/mail_location = maildir:\/var\/mail\/%d\/%n/g' /etc/dovecot/conf.d/10-mail.conf
+      ;;
+  esac
 
-	# Enable Managesieve service by setting the symlink
+	# enable Managesieve service by setting the symlink
 	# to the configuration file Dovecot will actually find
-	if [ "$ENABLE_MANAGESIEVE" = 1 ]; then
+	if [[ $ENABLE_MANAGESIEVE -eq 1 ]]
+  then
 		_notify 'inf' "Sieve management enabled"
 		mv /etc/dovecot/protocols.d/managesieved.protocol.disab /etc/dovecot/protocols.d/managesieved.protocol
 	fi
 
-	# Copy pipe and filter programs, if any
+	# copy pipe and filter programs, if any
 	rm -f /usr/lib/dovecot/sieve-filter/*
 	rm -f /usr/lib/dovecot/sieve-pipe/*
-	[ -d /tmp/docker-mailserver/sieve-filter ] && cp /tmp/docker-mailserver/sieve-filter/* /usr/lib/dovecot/sieve-filter/
-	[ -d /tmp/docker-mailserver/sieve-pipe ] && cp /tmp/docker-mailserver/sieve-pipe/* /usr/lib/dovecot/sieve-pipe/
+	[[ -d /tmp/docker-mailserver/sieve-filter ]] && cp /tmp/docker-mailserver/sieve-filter/* /usr/lib/dovecot/sieve-filter/
+	[[ -d /tmp/docker-mailserver/sieve-pipe ]] && cp /tmp/docker-mailserver/sieve-pipe/* /usr/lib/dovecot/sieve-pipe/
 
   # create global sieve directories
 	mkdir -p /usr/lib/dovecot/sieve-global/before
 	mkdir -p /usr/lib/dovecot/sieve-global/after
 
-	if [ -f /tmp/docker-mailserver/before.dovecot.sieve ]; then
+	if [[ -f /tmp/docker-mailserver/before.dovecot.sieve ]]
+  then
 		cp /tmp/docker-mailserver/before.dovecot.sieve /usr/lib/dovecot/sieve-global/before/50-before.dovecot.sieve
 		sievec /usr/lib/dovecot/sieve-global/before/50-before.dovecot.sieve
 	else
 	  rm -f /usr/lib/dovecot/sieve-global/before/50-before.dovecot.sieve /usr/lib/dovecot/sieve-global/before/50-before.dovecot.svbin
 	fi
 
-	if [ -f /tmp/docker-mailserver/after.dovecot.sieve ]; then
+	if [[ -f /tmp/docker-mailserver/after.dovecot.sieve ]]
+  then
 		cp /tmp/docker-mailserver/after.dovecot.sieve /usr/lib/dovecot/sieve-global/after/50-after.dovecot.sieve
 		sievec /usr/lib/dovecot/sieve-global/after/50-after.dovecot.sieve
 	else
@@ -568,7 +594,8 @@ function _setup_dovecot() {
 	fi
 
   # sieve will move spams to .Junk folder when SPAMASSASSIN_SPAM_TO_INBOX=1 and MOVE_SPAM_TO_JUNK=1
-	if [ "$SPAMASSASSIN_SPAM_TO_INBOX" = 1 ] && [ "$MOVE_SPAM_TO_JUNK" = 1 ]; then
+	if [[ $SPAMASSASSIN_SPAM_TO_INBOX -eq 1 ]] && [[ $MOVE_SPAM_TO_JUNK -eq 1 ]]
+  then
 	  _notify 'inf' "Spam messages will be moved to the Junk folder."
 	  cp /etc/dovecot/sieve/before/60-spam.sieve /usr/lib/dovecot/sieve-global/before/
 	  sievec /usr/lib/dovecot/sieve-global/before/60-spam.sieve
@@ -581,14 +608,18 @@ function _setup_dovecot() {
 	chmod -f +x /usr/lib/dovecot/sieve-pipe/*
 }
 
-function _setup_dovecot_quota() {
+# ! IS THERE A BUG HERE? --------------------------------------------------------------------------
+# TODO INVESTIGATE --------------------------------------------------------------------------------
+function _setup_dovecot_quota()
+{
     _notify 'task' 'Setting up Dovecot quota'
 
-    if [ "$ENABLE_LDAP" = 1 ] || [ "$SMTP_ONLY" = 1 ] || [ "$ENABLE_QUOTAS" = 0 ]; then
-      # Dovecot quota is disabled when using LDAP or SMTP_ONLY or when explicitly disabled
-
+    # Dovecot quota is disabled when using LDAP or SMTP_ONLY or when explicitly disabled.
+    if [[ $ENABLE_LDAP -eq 1 ]] || [[ $SMTP_ONLY -eq 1 ]] || [[ $ENABLE_QUOTAS -eq 0 ]]
+    then
       # disable dovecot quota in docevot confs
-      if [ -f /etc/dovecot/conf.d/90-quota.conf ]; then
+      if [[ -f /etc/dovecot/conf.d/90-quota.conf ]]
+      then
         mv /etc/dovecot/conf.d/90-quota.conf /etc/dovecot/conf.d/90-quota.conf.disab
         sed -i "s/mail_plugins = \$mail_plugins quota/mail_plugins = \$mail_plugins/g" /etc/dovecot/conf.d/10-mail.conf
         sed -i "s/mail_plugins = \$mail_plugins imap_quota/mail_plugins = \$mail_plugins/g" /etc/dovecot/conf.d/20-imap.conf
@@ -597,7 +628,8 @@ function _setup_dovecot_quota() {
       # disable quota policy check in postfix
       sed -i "s/check_policy_service inet:localhost:65265//g" /etc/postfix/main.cf
     else
-      if [ -f /etc/dovecot/conf.d/90-quota.conf.disab ]; then
+      if [[ -f /etc/dovecot/conf.d/90-quota.conf.disab ]]
+      then
         mv /etc/dovecot/conf.d/90-quota.conf.disab /etc/dovecot/conf.d/90-quota.conf
         sed -i "s/mail_plugins = \$mail_plugins/mail_plugins = \$mail_plugins quota/g" /etc/dovecot/conf.d/10-mail.conf
         sed -i "s/mail_plugins = \$mail_plugin/mail_plugins = \$mail_plugins imap_quota/g" /etc/dovecot/conf.d/20-imap.conf
@@ -609,7 +641,8 @@ function _setup_dovecot_quota() {
       sed -i "s/quota_max_mail_size =.*/quota_max_mail_size = ${message_size_limit_mb}$([ "$message_size_limit_mb" == 0 ] && echo "" || echo "M")/g" /etc/dovecot/conf.d/90-quota.conf
       sed -i "s/quota_rule = \*:storage=.*/quota_rule = *:storage=${mailbox_limit_mb}$([ "$mailbox_limit_mb" == 0 ] && echo "" || echo "M")/g" /etc/dovecot/conf.d/90-quota.conf
 
-      if [ ! -f /tmp/docker-mailserver/dovecot-quotas.cf ]; then
+      if [[ ! -f /tmp/docker-mailserver/dovecot-quotas.cf ]]
+      then
         _notify 'inf' "'config/docker-mailserver/dovecot-quotas.cf' is not provided. Using default quotas."
 		    echo -n >/tmp/docker-mailserver/dovecot-quotas.cf
       fi
@@ -619,17 +652,22 @@ function _setup_dovecot_quota() {
     fi
 }
 
-function _setup_dovecot_local_user() {
+function _setup_dovecot_local_user()
+{
 	_notify 'task' 'Setting up Dovecot Local User'
 	echo -n > /etc/postfix/vmailbox
 	echo -n > /etc/dovecot/userdb
-	if [ -f /tmp/docker-mailserver/postfix-accounts.cf -a "$ENABLE_LDAP" != 1 ]; then
+
+  if [[ -f /tmp/docker-mailserver/postfix-accounts.cf ]] && [[ $ENABLE_LDAP -ne 1 ]]
+  then
 		_notify 'inf' "Checking file line endings"
 		sed -i 's/\r//g' /tmp/docker-mailserver/postfix-accounts.cf
+
 		_notify 'inf' "Regenerating postfix user list"
 		echo "# WARNING: this file is auto-generated. Modify config/postfix-accounts.cf to edit user list." > /etc/postfix/vmailbox
 
-		# Checking that /tmp/docker-mailserver/postfix-accounts.cf ends with a newline
+		# checking that /tmp/docker-mailserver/postfix-accounts.cf ends with a newline
+    # shellcheck disable=SC1003
 		sed -i -e '$a\' /tmp/docker-mailserver/postfix-accounts.cf
 
 		chown dovecot:dovecot /etc/dovecot/userdb
@@ -638,23 +676,23 @@ function _setup_dovecot_local_user() {
 		sed -i -e '/\!include auth-ldap\.conf\.ext/s/^/#/' /etc/dovecot/conf.d/10-auth.conf
 		sed -i -e '/\!include auth-passwdfile\.inc/s/^#//' /etc/dovecot/conf.d/10-auth.conf
 
-		# Creating users
-		# 'pass' is encrypted
+		# creating users ; 'pass' is encrypted
 		# comments and empty lines are ignored
-		grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-accounts.cf | while IFS=$'|' read login pass
+		grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-accounts.cf | while IFS=$'|' read -r login pass
 		do
 			# Setting variables for better readability
-			user=$(echo ${login} | cut -d @ -f1)
-			domain=$(echo ${login} | cut -d @ -f2)
+			user=$(echo "$login" | cut -d @ -f1)
+			domain=$(echo "$login" | cut -d @ -f2)
 
 			user_attributes=""
 			# test if user has a defined quota
-      if [ -f /tmp/docker-mailserver/dovecot-quotas.cf ]; then
-			  user_quota=($(grep "${user}@${domain}:" -i /tmp/docker-mailserver/dovecot-quotas.cf | tr ':' '\n'))
+      if [[ -f /tmp/docker-mailserver/dovecot-quotas.cf ]]
+      then
+        declare -a USER_QUOTA
+        IFS=':' ; read -r -a USER_QUOTA < <(grep "${user}@${domain}:" -i /tmp/docker-mailserver/dovecot-quotas.cf)
+        unset IFS
 
-			  if [ ${#user_quota[@]} -eq 2 ]; then
-			    user_attributes="${user_attributes}userdb_quota_rule=*:bytes=${user_quota[1]}"
-			  fi
+			  [[ ${#USER_QUOTA[@]} -eq 2 ]] && user_attributes="${user_attributes}userdb_quota_rule=*:bytes=${USER_QUOTA[1]}"
 			fi
 
 			# Let's go!
@@ -666,39 +704,55 @@ function _setup_dovecot_local_user() {
 			# Example :
 			# ${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::userdb_mail=maildir:/var/mail/${domain}/${user}
 			echo "${login}:${pass}:5000:5000::/var/mail/${domain}/${user}::${user_attributes}" >> /etc/dovecot/userdb
-			mkdir -p /var/mail/${domain}/${user}
+			mkdir -p "/var/mail/${domain}/${user}"
 
 			# Copy user provided sieve file, if present
-			test -e /tmp/docker-mailserver/${login}.dovecot.sieve && cp /tmp/docker-mailserver/${login}.dovecot.sieve /var/mail/${domain}/${user}/.dovecot.sieve
-			echo ${domain} >> /tmp/vhost.tmp
+		  if [[ -e /tmp/docker-mailserver/${login}.dovecot.sieve ]]
+      then
+        cp "/tmp/docker-mailserver/${login}.dovecot.sieve" "/var/mail/${domain}/${user}/.dovecot.sieve"
+      fi
+
+			echo "$domain" >> /tmp/vhost.tmp
 		done
 	else
 		_notify 'inf' "'config/docker-mailserver/postfix-accounts.cf' is not provided. No mail account created."
 	fi
 
-	if [[ ! $(grep '@' /tmp/docker-mailserver/postfix-accounts.cf | grep '|') ]]; then
-		if [ $ENABLE_LDAP -eq 0 ]; then
+	if ! grep '@' /tmp/docker-mailserver/postfix-accounts.cf | grep -q '|'
+  then
+		if [[ $ENABLE_LDAP -eq 0 ]]
+    then
 			_notify 'fatal' "Unless using LDAP, you need at least 1 email account to start Dovecot."
-			defunc
+			_defunc
 		fi
 	fi
-
 }
 
-function _setup_ldap() {
+function _setup_ldap()
+{
 	_notify 'task' 'Setting up Ldap'
-
 	_notify 'inf' 'Checking for custom configs'
-	# cp config files if in place
-	for i in 'users' 'groups' 'aliases' 'domains'; do
-	    fpath="/tmp/docker-mailserver/ldap-${i}.cf"
-	    if [ -f $fpath ]; then
-		cp ${fpath} /etc/postfix/ldap-${i}.cf
-	    fi
+
+	for i in 'users' 'groups' 'aliases' 'domains'
+  do
+	  fpath="/tmp/docker-mailserver/ldap-${i}.cf"
+	  if [[ -f $fpath ]]
+    then
+		  cp ${fpath} /etc/postfix/ldap-${i}.cf
+	  fi
 	done
 
 	_notify 'inf' 'Starting to override configs'
-	for f in /etc/postfix/ldap-users.cf /etc/postfix/ldap-groups.cf /etc/postfix/ldap-aliases.cf /etc/postfix/ldap-domains.cf /etc/postfix/maps/sender_login_maps.ldap
+
+  local FILES=(
+    /etc/postfix/ldap-users.cf
+    /etc/postfix/ldap-groups.cf
+    /etc/postfix/ldap-aliases.cf
+    /etc/postfix/ldap-domains.cf
+    /etc/postfix/maps/sender_login_maps.ldap
+  )
+
+	for f in "${FILES[@]}"
 	do
 		[[ $f =~ ldap-user ]] && export LDAP_QUERY_FILTER="${LDAP_QUERY_FILTER_USER}"
 		[[ $f =~ ldap-group ]] && export LDAP_QUERY_FILTER="${LDAP_QUERY_FILTER_GROUP}"
@@ -719,119 +773,162 @@ function _setup_ldap() {
 	# _dovecot_ldap_mapping["DOVECOT_PASS_FILTER"]="${DOVECOT_PASS_FILTER:="${LDAP_QUERY_FILTER_USER}"}"
 	# _dovecot_ldap_mapping["DOVECOT_USER_FILTER"]="${DOVECOT_USER_FILTER:="${LDAP_QUERY_FILTER_USER}"}"
 
-	for var in ${!_dovecot_ldap_mapping[@]}; do
-		export $var="${_dovecot_ldap_mapping[$var]}"
+	for var in "${!_dovecot_ldap_mapping[@]}"
+  do
+    # ! "" AROUND $var - MIGHT BREANK THINGS ------------------------------------------------------
+    # TODO TEST -----------------------------------------------------------------------------------
+		export "$var=${_dovecot_ldap_mapping[$var]}"
 	done
 
 	configomat.sh "DOVECOT_" "/etc/dovecot/dovecot-ldap.conf.ext"
 
-	# Add  domainname to vhost.
+	# add  domainname to vhost
 	echo $DOMAINNAME >> /tmp/vhost.tmp
 
 	_notify 'inf' "Enabling dovecot LDAP authentification"
+
 	sed -i -e '/\!include auth-ldap\.conf\.ext/s/^#//' /etc/dovecot/conf.d/10-auth.conf
 	sed -i -e '/\!include auth-passwdfile\.inc/s/^/#/' /etc/dovecot/conf.d/10-auth.conf
 
 	_notify 'inf' "Configuring LDAP"
-	[ -f /etc/postfix/ldap-users.cf ] && \
+
+	if [[ -f /etc/postfix/ldap-users.cf ]]
+  then
 		postconf -e "virtual_mailbox_maps = ldap:/etc/postfix/ldap-users.cf" || \
 		_notify 'inf' "==> Warning: /etc/postfix/ldap-user.cf not found"
+  fi
 
-	[ -f /etc/postfix/ldap-domains.cf ] && \
+	if [[ -f /etc/postfix/ldap-domains.cf ]]
+  then
 		postconf -e "virtual_mailbox_domains = /etc/postfix/vhost, ldap:/etc/postfix/ldap-domains.cf" || \
 		_notify 'inf' "==> Warning: /etc/postfix/ldap-domains.cf not found"
+  fi
 
-	[ -f /etc/postfix/ldap-aliases.cf -a -f /etc/postfix/ldap-groups.cf ] && \
+	if [[ -f /etc/postfix/ldap-aliases.cf ]] && [[ -f /etc/postfix/ldap-groups.cf ]]
+  then
 		postconf -e "virtual_alias_maps = ldap:/etc/postfix/ldap-aliases.cf, ldap:/etc/postfix/ldap-groups.cf" || \
 		_notify 'inf' "==> Warning: /etc/postfix/ldap-aliases.cf or /etc/postfix/ldap-groups.cf not found"
+  fi
 
 	return 0
 }
 
-function _setup_postgrey() {
+function _setup_postgrey()
+{
 	_notify 'inf' "Configuring postgrey"
+
 	sed -i -e 's/, reject_rbl_client bl.spamcop.net$/, reject_rbl_client bl.spamcop.net, check_policy_service inet:127.0.0.1:10023/' /etc/postfix/main.cf
 	sed -i -e "s/\"--inet=127.0.0.1:10023\"/\"--inet=127.0.0.1:10023 --delay=$POSTGREY_DELAY --max-age=$POSTGREY_MAX_AGE --auto-whitelist-clients=$POSTGREY_AUTO_WHITELIST_CLIENTS\"/" /etc/default/postgrey
-	TEXT_FOUND=`grep -i "POSTGREY_TEXT" /etc/default/postgrey | wc -l`
 
-	if [ $TEXT_FOUND -eq 0 ]; then
-		printf "POSTGREY_TEXT=\"$POSTGREY_TEXT\"\n\n" >> /etc/default/postgrey
+  TEXT_FOUND=$(grep -c -i "POSTGREY_TEXT" /etc/default/postgrey)
+
+	if [[ $TEXT_FOUND -eq 0 ]]
+  then
+		printf "POSTGREY_TEXT=\"%s\"\n\n" "$POSTGREY_TEXT" >> /etc/default/postgrey
 	fi
-	if [ -f /tmp/docker-mailserver/whitelist_clients.local ]; then
+
+	if [[ -f /tmp/docker-mailserver/whitelist_clients.local ]]
+  then
 		cp -f /tmp/docker-mailserver/whitelist_clients.local /etc/postgrey/whitelist_clients.local
 	fi
-	if [ -f /tmp/docker-mailserver/whitelist_recipients ]; then
+
+	if [[ -f /tmp/docker-mailserver/whitelist_recipients ]]
+  then
 		cp -f /tmp/docker-mailserver/whitelist_recipients /etc/postgrey/whitelist_recipients
 	fi
 }
 
-function _setup_postfix_postscreen() {
+function _setup_postfix_postscreen()
+{
 	_notify 'inf' "Configuring postscreen"
 	sed -i -e "s/postscreen_dnsbl_action = enforce/postscreen_dnsbl_action = $POSTSCREEN_ACTION/" \
-	       -e "s/postscreen_greet_action = enforce/postscreen_greet_action = $POSTSCREEN_ACTION/" \
-	       -e "s/postscreen_bare_newline_action = enforce/postscreen_bare_newline_action = $POSTSCREEN_ACTION/" /etc/postfix/main.cf
+	  -e "s/postscreen_greet_action = enforce/postscreen_greet_action = $POSTSCREEN_ACTION/" \
+	  -e "s/postscreen_bare_newline_action = enforce/postscreen_bare_newline_action = $POSTSCREEN_ACTION/" /etc/postfix/main.cf
 }
 
-function _setup_postfix_sizelimits() {
+function _setup_postfix_sizelimits()
+{
 	_notify 'inf' "Configuring postfix message size limit"
 	postconf -e "message_size_limit = ${DEFAULT_VARS["POSTFIX_MESSAGE_SIZE_LIMIT"]}"
+
 	_notify 'inf' "Configuring postfix mailbox size limit"
 	postconf -e "mailbox_size_limit = ${DEFAULT_VARS["POSTFIX_MAILBOX_SIZE_LIMIT"]}"
+
 	_notify 'inf' "Configuring postfix virtual mailbox size limit"
 	postconf -e "virtual_mailbox_limit = ${DEFAULT_VARS["POSTFIX_MAILBOX_SIZE_LIMIT"]}"
 }
 
-function _setup_postfix_smtputf8() {
-        _notify 'inf' "Configuring postfix smtputf8 support (disable)"
-        postconf -e "smtputf8_enable = no"
+function _setup_postfix_smtputf8()
+{
+  _notify 'inf' "Configuring postfix smtputf8 support (disable)"
+  postconf -e "smtputf8_enable = no"
 }
 
-function _setup_spoof_protection () {
+function _setup_spoof_protection()
+{
 	_notify 'inf' "Configuring Spoof Protection"
 	sed -i 's|smtpd_sender_restrictions =|smtpd_sender_restrictions = reject_authenticated_sender_login_mismatch,|' /etc/postfix/main.cf
-	[ "$ENABLE_LDAP" = 1 ] \
-		&& postconf -e "smtpd_sender_login_maps=ldap:/etc/postfix/ldap-users.cf ldap:/etc/postfix/ldap-aliases.cf ldap:/etc/postfix/ldap-groups.cf" \
-		|| postconf -e "smtpd_sender_login_maps=texthash:/etc/postfix/virtual, hash:/etc/aliases, pcre:/etc/postfix/regexp, pcre:/etc/postfix/maps/sender_login_maps.pcre"
+
+	[[ $ENABLE_LDAP -eq 1 ]] && postconf -e "smtpd_sender_login_maps=ldap:/etc/postfix/ldap-users.cf ldap:/etc/postfix/ldap-aliases.cf ldap:/etc/postfix/ldap-groups.cf" || postconf -e "smtpd_sender_login_maps=texthash:/etc/postfix/virtual, hash:/etc/aliases, pcre:/etc/postfix/regexp, pcre:/etc/postfix/maps/sender_login_maps.pcre"
 }
 
-function _setup_postfix_access_control() {
+function _setup_postfix_access_control()
+{
   _notify 'inf' "Configuring user access"
-  [ -f /tmp/docker-mailserver/postfix-send-access.cf ] && sed -i 's|smtpd_sender_restrictions =|smtpd_sender_restrictions = check_sender_access texthash:/tmp/docker-mailserver/postfix-send-access.cf,|' /etc/postfix/main.cf
-  [ -f /tmp/docker-mailserver/postfix-receive-access.cf ] && sed -i 's|smtpd_recipient_restrictions =|smtpd_recipient_restrictions = check_recipient_access texthash:/tmp/docker-mailserver/postfix-receive-access.cf,|' /etc/postfix/main.cf
+
+  if [[ -f /tmp/docker-mailserver/postfix-send-access.cf ]]
+  then
+    sed -i 's|smtpd_sender_restrictions =|smtpd_sender_restrictions = check_sender_access texthash:/tmp/docker-mailserver/postfix-send-access.cf,|' /etc/postfix/main.cf
+  fi
+
+  if [[ -f /tmp/docker-mailserver/postfix-receive-access.cf ]]
+  then
+    sed -i 's|smtpd_recipient_restrictions =|smtpd_recipient_restrictions = check_recipient_access texthash:/tmp/docker-mailserver/postfix-receive-access.cf,|' /etc/postfix/main.cf
+  fi
 }
 
-function _setup_postfix_sasl() {
-    if [[ ${ENABLE_SASLAUTHD} == 1 ]];then
-	[ ! -f /etc/postfix/sasl/smtpd.conf ] && cat > /etc/postfix/sasl/smtpd.conf << EOF
+function _setup_postfix_sasl()
+{
+  if [[ $ENABLE_SASLAUTHD -eq 1 ]]
+  then
+	  [[ ! -f /etc/postfix/sasl/smtpd.conf ]] && cat > /etc/postfix/sasl/smtpd.conf << EOF
 pwcheck_method: saslauthd
 mech_list: plain login
 EOF
-    fi
+  fi
 
-    # cyrus sasl or dovecot sasl
-    if [[ ${ENABLE_SASLAUTHD} == 1 ]] || [[ ${SMTP_ONLY} == 0 ]];then
-	sed -i -e 's|^smtpd_sasl_auth_enable[[:space:]]\+.*|smtpd_sasl_auth_enable = yes|g' /etc/postfix/main.cf
-    else
-	sed -i -e 's|^smtpd_sasl_auth_enable[[:space:]]\+.*|smtpd_sasl_auth_enable = no|g' /etc/postfix/main.cf
-    fi
+  # cyrus sasl or dovecot sasl
+  if [[ $ENABLE_SASLAUTHD -eq 1 ]] || [[ $SMTP_ONLY -eq 0 ]]
+  then
+	  sed -i -e 's|^smtpd_sasl_auth_enable[[:space:]]\+.*|smtpd_sasl_auth_enable = yes|g' /etc/postfix/main.cf
+  else
+	  sed -i -e 's|^smtpd_sasl_auth_enable[[:space:]]\+.*|smtpd_sasl_auth_enable = no|g' /etc/postfix/main.cf
+  fi
 
-    return 0
+  return 0
 }
 
-function _setup_saslauthd() {
+function _setup_saslauthd()
+{
 	_notify 'task' "Setting up Saslauthd"
-
 	_notify 'inf' "Configuring Cyrus SASL"
-	# checking env vars and setting defaults
-	[ -z "$SASLAUTHD_MECHANISMS" ] && SASLAUTHD_MECHANISMS=pam
-	[ "$SASLAUTHD_MECHANISMS" = ldap -a -z "$SASLAUTHD_LDAP_SEARCH_BASE" ] && SASLAUTHD_MECHANISMS=pam
-	[ -z "$SASLAUTHD_LDAP_SERVER" ] && SASLAUTHD_LDAP_SERVER=localhost
-	[ -z "$SASLAUTHD_LDAP_FILTER" ] && SASLAUTHD_LDAP_FILTER='(&(uniqueIdentifier=%u)(mailEnabled=TRUE))'
-	([ -z "$SASLAUTHD_LDAP_SSL" ] || [ $SASLAUTHD_LDAP_SSL == 0 ]) && SASLAUTHD_LDAP_PROTO='ldap://' || SASLAUTHD_LDAP_PROTO='ldaps://'
-	[ -z "$SASLAUTHD_LDAP_START_TLS" ] && SASLAUTHD_LDAP_START_TLS=no
-	[ -z "$SASLAUTHD_LDAP_TLS_CHECK_PEER" ] && SASLAUTHD_LDAP_TLS_CHECK_PEER=no
 
-	if [ ! -f /etc/saslauthd.conf ]; then
+	# checking env vars and setting defaults
+	[[ -z $SASLAUTHD_MECHANISMS ]] && SASLAUTHD_MECHANISMS=pam
+	[[ $SASLAUTHD_MECHANISMS = ldap ]] && [[ -z $SASLAUTHD_LDAP_SEARCH_BASE ]] && SASLAUTHD_MECHANISMS=pam
+	[[ -z $SASLAUTHD_LDAP_SERVER ]] && SASLAUTHD_LDAP_SERVER=localhost
+	[[ -z $SASLAUTHD_LDAP_FILTER ]] && SASLAUTHD_LDAP_FILTER='(&(uniqueIdentifier=%u)(mailEnabled=TRUE))'
+
+	if [[ -z $SASLAUTHD_LDAP_SSL ]] || [[ $SASLAUTHD_LDAP_SSL -eq 0 ]]
+  then
+    SASLAUTHD_LDAP_PROTO='ldap://' || SASLAUTHD_LDAP_PROTO='ldaps://'
+  fi
+
+	[[ -z $SASLAUTHD_LDAP_START_TLS ]] && SASLAUTHD_LDAP_START_TLS=no
+	[[ -z $SASLAUTHD_LDAP_TLS_CHECK_PEER ]] && SASLAUTHD_LDAP_TLS_CHECK_PEER=no
+
+	if [[ ! -f /etc/saslauthd.conf ]]
+  then
 		_notify 'inf' "Creating /etc/saslauthd.conf"
 		cat > /etc/saslauthd.conf << EOF
 ldap_servers: ${SASLAUTHD_LDAP_PROTO}${SASLAUTHD_LDAP_SERVER}
@@ -851,97 +948,122 @@ log_level: 10
 EOF
 	fi
 
-		 sed -i \
-		 -e "/^[^#].*smtpd_sasl_type.*/s/^/#/g" \
-		 -e "/^[^#].*smtpd_sasl_path.*/s/^/#/g" \
-		 /etc/postfix/master.cf
+	sed -i \
+	  -e "/^[^#].*smtpd_sasl_type.*/s/^/#/g" \
+		-e "/^[^#].*smtpd_sasl_path.*/s/^/#/g" \
+		/etc/postfix/master.cf
 
 	sed -i \
 		-e "/smtpd_sasl_path =.*/d" \
 		-e "/smtpd_sasl_type =.*/d" \
 		-e "/dovecot_destination_recipient_limit =.*/d" \
 		/etc/postfix/main.cf
+
 	gpasswd -a postfix sasl
 }
 
-function _setup_postfix_aliases() {
+function _setup_postfix_aliases()
+{
 	_notify 'task' 'Setting up Postfix Aliases'
 
 	echo -n > /etc/postfix/virtual
 	echo -n > /etc/postfix/regexp
-	if [ -f /tmp/docker-mailserver/postfix-virtual.cf ]; then
-	# fixing old virtual user file
-	  [[ $(grep ",$" /tmp/docker-mailserver/postfix-virtual.cf) ]] && sed -i -e "s/, /,/g" -e "s/,$//g" /tmp/docker-mailserver/postfix-virtual.cf
-		# Copying virtual file
+
+	if [[ -f /tmp/docker-mailserver/postfix-virtual.cf ]]
+  then
+	  # fixing old virtual user file
+	  if grep -q ",$" /tmp/docker-mailserver/postfix-virtual.cf
+    then
+      sed -i -e "s/, /,/g" -e "s/,$//g" /tmp/docker-mailserver/postfix-virtual.cf
+    fi
+
 		cp -f /tmp/docker-mailserver/postfix-virtual.cf /etc/postfix/virtual
-		(grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-virtual.cf || true) | while read from to
+
+    # the `to` seems to be important; don't delete it
+    # shellcheck disable=SC2034
+		(grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-virtual.cf || true) | while read -r from to
 		do
 			# Setting variables for better readability
-			uname=$(echo ${from} | cut -d @ -f1)
-			domain=$(echo ${from} | cut -d @ -f2)
+			uname=$(echo "$from" | cut -d @ -f1)
+			domain=$(echo "$from" | cut -d @ -f2)
+
 			# if they are equal it means the line looks like: "user1     other@domain.tld"
-			test "$uname" != "$domain" && echo ${domain} >> /tmp/vhost.tmp
+			[ "$uname" != "$domain" ] && echo "$domain" >> /tmp/vhost.tmp
 		done
 	else
 		_notify 'inf' "Warning 'config/postfix-virtual.cf' is not provided. No mail alias/forward created."
 	fi
-	if [ -f /tmp/docker-mailserver/postfix-regexp.cf ]; then
-		# Copying regexp alias file
+
+	if [[ -f /tmp/docker-mailserver/postfix-regexp.cf ]]
+  then
 		_notify 'inf' "Adding regexp alias file postfix-regexp.cf"
+
 		cp -f /tmp/docker-mailserver/postfix-regexp.cf /etc/postfix/regexp
 		sed -i -e '/^virtual_alias_maps/{
-		s/ pcre:.*//
-		s/$/ pcre:\/etc\/postfix\/regexp/
-		}' /etc/postfix/main.cf
+s/ pcre:.*//
+s/$/ pcre:\/etc\/postfix\/regexp/
+}' /etc/postfix/main.cf
 	fi
 
 	_notify 'inf' "Configuring root alias"
+
 	echo "root: ${POSTMASTER_ADDRESS}" > /etc/aliases
-	if [ -f /tmp/docker-mailserver/postfix-aliases.cf ]; then
-		cat /tmp/docker-mailserver/postfix-aliases.cf>>/etc/aliases
+
+	if [[ -f /tmp/docker-mailserver/postfix-aliases.cf ]]
+  then
+		cat /tmp/docker-mailserver/postfix-aliases.cf >> /etc/aliases
 	else
 		_notify 'inf' "'config/postfix-aliases.cf' is not provided and will be auto created."
 		echo -n >/tmp/docker-mailserver/postfix-aliases.cf
 	fi
+
 	postalias /etc/aliases
 }
 
-function _setup_SRS() {
+function _setup_SRS()
+{
 	_notify 'task' 'Setting up SRS'
+
 	postconf -e "sender_canonical_maps = tcp:localhost:10001"
 	postconf -e "sender_canonical_classes = $SRS_SENDER_CLASSES"
 	postconf -e "recipient_canonical_maps = tcp:localhost:10002"
 	postconf -e "recipient_canonical_classes = envelope_recipient,header_recipient"
 }
 
-function _setup_dkim() {
+function _setup_dkim()
+{
 	_notify 'task' 'Setting up DKIM'
 
 	mkdir -p /etc/opendkim && touch /etc/opendkim/SigningTable
 
 	# Check if keys are already available
-	if [ -e "/tmp/docker-mailserver/opendkim/KeyTable" ]; then
+	if [[ -e "/tmp/docker-mailserver/opendkim/KeyTable" ]]
+  then
 		cp -a /tmp/docker-mailserver/opendkim/* /etc/opendkim/
-		_notify 'inf' "DKIM keys added for: `ls -C /etc/opendkim/keys/`"
+
+		_notify 'inf' "DKIM keys added for: $(ls -C /etc/opendkim/keys/)"
 		_notify 'inf' "Changing permissions on /etc/opendkim"
+
 		chown -R opendkim:opendkim /etc/opendkim/
-		# And make sure permissions are right
-		chmod -R 0700 /etc/opendkim/keys/
+		chmod -R 0700 /etc/opendkim/keys/ # make sure permissions are right
 	else
 		_notify 'warn' "No DKIM key provided. Check the documentation to find how to get your keys."
 
 		local _f_keytable="/etc/opendkim/KeyTable"
-		[ ! -f "$_f_keytable" ] && touch "$_f_keytable"
+		[[ ! -f $_f_keytable ]] && touch "$_f_keytable"
 	fi
 
-	# Setup nameservers paramater from /etc/resolv.conf if not defined
-	if ! grep '^Nameservers' /etc/opendkim.conf; then
+	# setup nameservers paramater from /etc/resolv.conf if not defined
+	if ! grep '^Nameservers' /etc/opendkim.conf
+  then
 		echo "Nameservers $(grep '^nameserver' /etc/resolv.conf | awk -F " " '{print $2}' | paste -sd ',' -)" >> /etc/opendkim.conf
+
 		_notify 'inf' "Nameservers added to /etc/opendkim.conf"
 	fi
 }
 
-function _setup_ssl() {
+function _setup_ssl()
+{
 	_notify 'task' 'Setting up SSL'
 
   # TLS strength/level configuration
@@ -958,7 +1080,7 @@ function _setup_ssl() {
       sed -i -r 's/^ssl_cipher_list =.*$/ssl_cipher_list = ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256/' /etc/dovecot/conf.d/10-ssl.conf
 
       _notify 'inf' "TLS configured with 'modern' ciphers"
-    ;;
+      ;;
     "intermediate" )
       # Postfix configuration
       sed -i -r 's/^smtpd_tls_mandatory_protocols =.*$/smtpd_tls_mandatory_protocols = !SSLv2,!SSLv3/' /etc/postfix/main.cf
@@ -971,7 +1093,8 @@ function _setup_ssl() {
       sed -i -r 's/^ssl_cipher_list = .*$/ssl_cipher_list = ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS/' /etc/dovecot/conf.d/10-ssl.conf
 
       _notify 'inf' "TLS configured with 'intermediate' ciphers"
-    ;;
+      ;;
+    * ) _notify 'err' 'TLS_LEVEL not found _setup_ssl' ;;
   esac
 
 	# SSL certificate Configuration
@@ -985,29 +1108,35 @@ function _setup_ssl() {
       [[ -f /etc/letsencrypt/acme.json ]] && (_extract_certs_from_acme "$HOSTNAME" || _extract_certs_from_acme "$DOMAINNAME")
 
       # first determine the letsencrypt domain by checking both the full hostname or just the domainname if a SAN is used in the cert
-      if [ -e "/etc/letsencrypt/live/$HOSTNAME/fullchain.pem" ]; then
+      if [[ -e /etc/letsencrypt/live/$HOSTNAME/fullchain.pem ]]
+      then
         LETSENCRYPT_DOMAIN=$HOSTNAME
-      elif [ -e "/etc/letsencrypt/live/$DOMAINNAME/fullchain.pem" ]; then
+      elif [[ -e /etc/letsencrypt/live/$DOMAINNAME/fullchain.pem ]]
+      then
         LETSENCRYPT_DOMAIN=$DOMAINNAME
 			else
-				_notify 'err' "Cannot access '/etc/letsencrypt/live/"$HOSTNAME"/fullchain.pem' or '/etc/letsencrypt/live/"$DOMAINNAME"/fullchain.pem'"
+				_notify 'err' "Cannot access '/etc/letsencrypt/live/$HOSTNAME/fullchain.pem' or '/etc/letsencrypt/live/$DOMAINNAME/fullchain.pem'"
         return 1
 			fi
 
       # then determine the keyfile to use
-			if [ -n "$LETSENCRYPT_DOMAIN" ]; then
-				if [ -e "/etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem" ]; then
+			if [[ -n $LETSENCRYPT_DOMAIN ]]
+      then
+				if [[ -e /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem ]]
+        then
 					LETSENCRYPT_KEY="privkey"
-				elif [ -e "/etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/key.pem" ]; then
+				elif [[ -e /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/key.pem ]]
+        then
 					LETSENCRYPT_KEY="key"
 				else
-					_notify 'err' "Cannot access '/etc/letsencrypt/live/"$LETSENCRYPT_DOMAIN"/privkey.pem' nor 'key.pem'"
+					_notify 'err' "Cannot access '/etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem' nor 'key.pem'"
           return 1
 				fi
       fi
 
       # finally, make the changes to the postfix and dovecot configurations
-      if [ -n "$LETSENCRYPT_KEY" ]; then
+      if [[ -n $LETSENCRYPT_KEY ]]
+      then
         _notify 'inf' "Adding $LETSENCRYPT_DOMAIN SSL certificate to the postfix and dovecot configuration"
 
         # Postfix configuration
@@ -1021,120 +1150,132 @@ function _setup_ssl() {
         _notify 'inf' "SSL configured with 'letsencrypt' certificates"
       fi
       return 0
-		;;
-	"custom" )
-		# Adding CA signed SSL certificate if provided in 'postfix/ssl' folder
-		if [ -e "/tmp/docker-mailserver/ssl/$HOSTNAME-full.pem" ]; then
-			_notify 'inf' "Adding $HOSTNAME SSL certificate"
-			mkdir -p /etc/postfix/ssl
-			cp "/tmp/docker-mailserver/ssl/$HOSTNAME-full.pem" /etc/postfix/ssl
+		  ;;
+	  "custom" )
+		  # Adding CA signed SSL certificate if provided in 'postfix/ssl' folder
+		  if [[ -e /tmp/docker-mailserver/ssl/$HOSTNAME-full.pem ]]
+      then
+			  _notify 'inf' "Adding $HOSTNAME SSL certificate"
 
-			# Postfix configuration
-			sed -i -r 's~smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem~smtpd_tls_cert_file=/etc/postfix/ssl/'$HOSTNAME'-full.pem~g' /etc/postfix/main.cf
-			sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/postfix/ssl/'$HOSTNAME'-full.pem~g' /etc/postfix/main.cf
+			  mkdir -p /etc/postfix/ssl
+			  cp "/tmp/docker-mailserver/ssl/$HOSTNAME-full.pem" /etc/postfix/ssl
 
-			# Dovecot configuration
-			sed -i -e 's~ssl_cert = </etc/dovecot/ssl/dovecot\.pem~ssl_cert = </etc/postfix/ssl/'$HOSTNAME'-full\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
-			sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/postfix/ssl/'$HOSTNAME'-full\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
+			  # Postfix configuration
+			  sed -i -r 's~smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem~smtpd_tls_cert_file=/etc/postfix/ssl/'$HOSTNAME'-full.pem~g' /etc/postfix/main.cf
+			  sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/postfix/ssl/'$HOSTNAME'-full.pem~g' /etc/postfix/main.cf
 
-			_notify 'inf' "SSL configured with 'CA signed/custom' certificates"
-		fi
-		;;
-	"manual" )
-		# Lets you manually specify the location of the SSL Certs to use. This gives you some more control over this whole processes (like using kube-lego to generate certs)
-		if [ -n "$SSL_CERT_PATH" ] \
-		&& [ -n "$SSL_KEY_PATH" ]; then
-			_notify 'inf' "Configuring certificates using cert $SSL_CERT_PATH and key $SSL_KEY_PATH"
-			mkdir -p /etc/postfix/ssl
-			cp "$SSL_CERT_PATH" /etc/postfix/ssl/cert
-			cp "$SSL_KEY_PATH" /etc/postfix/ssl/key
-			chmod 600 /etc/postfix/ssl/cert
-			chmod 600 /etc/postfix/ssl/key
+			  # Dovecot configuration
+			  sed -i -e 's~ssl_cert = </etc/dovecot/ssl/dovecot\.pem~ssl_cert = </etc/postfix/ssl/'$HOSTNAME'-full\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
+			  sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/postfix/ssl/'$HOSTNAME'-full\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
 
-			# Postfix configuration
-			sed -i -r 's~smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem~smtpd_tls_cert_file=/etc/postfix/ssl/cert~g' /etc/postfix/main.cf
-			sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/postfix/ssl/key~g' /etc/postfix/main.cf
+			  _notify 'inf' "SSL configured with 'CA signed/custom' certificates"
+		  fi
+		  ;;
+	  "manual" )
+		  # Lets you manually specify the location of the SSL Certs to use. This gives you some more control over this whole  processes (like using kube-lego to generate certs)
+		  if [[ -n $SSL_CERT_PATH ]] && [[ -n $SSL_KEY_PATH ]]
+      then
+		  	_notify 'inf' "Configuring certificates using cert $SSL_CERT_PATH and key $SSL_KEY_PATH"
 
-			# Dovecot configuration
-			sed -i -e 's~ssl_cert = </etc/dovecot/ssl/dovecot\.pem~ssl_cert = </etc/postfix/ssl/cert~g' /etc/dovecot/conf.d/10-ssl.conf
-			sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/postfix/ssl/key~g' /etc/dovecot/conf.d/10-ssl.conf
+			  mkdir -p /etc/postfix/ssl
+			  cp "$SSL_CERT_PATH" /etc/postfix/ssl/cert
+			  cp "$SSL_KEY_PATH" /etc/postfix/ssl/key
+			  chmod 600 /etc/postfix/ssl/cert
+			  chmod 600 /etc/postfix/ssl/key
 
-			_notify 'inf' "SSL configured with 'Manual' certificates"
-		fi
-	;;
-"self-signed" )
-	# Adding self-signed SSL certificate if provided in 'postfix/ssl' folder
-	if [ -e "/tmp/docker-mailserver/ssl/$HOSTNAME-cert.pem" ] \
-	&& [ -e "/tmp/docker-mailserver/ssl/$HOSTNAME-key.pem"  ] \
-	&& [ -e "/tmp/docker-mailserver/ssl/$HOSTNAME-combined.pem" ] \
-	&& [ -e "/tmp/docker-mailserver/ssl/demoCA/cacert.pem" ]; then
-		_notify 'inf' "Adding $HOSTNAME SSL certificate"
-		mkdir -p /etc/postfix/ssl
-		cp "/tmp/docker-mailserver/ssl/$HOSTNAME-cert.pem" /etc/postfix/ssl
-		cp "/tmp/docker-mailserver/ssl/$HOSTNAME-key.pem" /etc/postfix/ssl
-		# Force permission on key file
-		chmod 600 /etc/postfix/ssl/$HOSTNAME-key.pem
-		cp "/tmp/docker-mailserver/ssl/$HOSTNAME-combined.pem" /etc/postfix/ssl
-		cp /tmp/docker-mailserver/ssl/demoCA/cacert.pem /etc/postfix/ssl
+			  # Postfix configuration
+			  sed -i -r 's~smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem~smtpd_tls_cert_file=/etc/postfix/ssl/cert~g' /etc/postfix/main.cf
+			  sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/postfix/ssl/key~g' /etc/postfix/main.cf
 
-		# Postfix configuration
-		sed -i -r 's~smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem~smtpd_tls_cert_file=/etc/postfix/ssl/'$HOSTNAME'-cert.pem~g' /etc/postfix/main.cf
-		sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/postfix/ssl/'$HOSTNAME'-key.pem~g' /etc/postfix/main.cf
-		sed -i -r 's~#smtpd_tls_CAfile=~smtpd_tls_CAfile=/etc/postfix/ssl/cacert.pem~g' /etc/postfix/main.cf
-		sed -i -r 's~#smtp_tls_CAfile=~smtp_tls_CAfile=/etc/postfix/ssl/cacert.pem~g' /etc/postfix/main.cf
-		ln -s /etc/postfix/ssl/cacert.pem "/etc/ssl/certs/cacert-$HOSTNAME.pem"
+			  # Dovecot configuration
+			  sed -i -e 's~ssl_cert = </etc/dovecot/ssl/dovecot\.pem~ssl_cert = </etc/postfix/ssl/cert~g' /etc/dovecot/conf.d/10-ssl.conf
+			  sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/postfix/ssl/key~g' /etc/dovecot/conf.d/10-ssl.conf
 
-		# Dovecot configuration
-		sed -i -e 's~ssl_cert = </etc/dovecot/ssl/dovecot\.pem~ssl_cert = </etc/postfix/ssl/'$HOSTNAME'-combined\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
-		sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/postfix/ssl/'$HOSTNAME'-key\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
+			  _notify 'inf' "SSL configured with 'Manual' certificates"
+		  fi
+	    ;;
+    "self-signed" )
+	    # Adding self-signed SSL certificate if provided in 'postfix/ssl' folder
+	    if [[ -e /tmp/docker-mailserver/ssl/$HOSTNAME-cert.pem ]] \
+	    && [[ -e /tmp/docker-mailserver/ssl/$HOSTNAME-key.pem ]] \
+	    && [[ -e /tmp/docker-mailserver/ssl/$HOSTNAME-combined.pem ]] \
+	    && [[ -e /tmp/docker-mailserver/ssl/demoCA/cacert.pem ]]
+      then
+	  	  _notify 'inf' "Adding $HOSTNAME SSL certificate"
 
-		_notify 'inf' "SSL configured with 'self-signed' certificates"
-	fi
-	;;
+		    mkdir -p /etc/postfix/ssl
+		    cp "/tmp/docker-mailserver/ssl/$HOSTNAME-cert.pem" /etc/postfix/ssl
+		    cp "/tmp/docker-mailserver/ssl/$HOSTNAME-key.pem" /etc/postfix/ssl
+
+        # Force permission on key file
+		    chmod 600 "/etc/postfix/ssl/$HOSTNAME-key.pem"
+		    cp "/tmp/docker-mailserver/ssl/$HOSTNAME-combined.pem" /etc/postfix/ssl
+		    cp /tmp/docker-mailserver/ssl/demoCA/cacert.pem /etc/postfix/ssl
+
+		    # Postfix configuration
+		    sed -i -r 's~smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem~smtpd_tls_cert_file=/etc/postfix/ssl/'$HOSTNAME'-cert.pem~g' /etc/postfix/main.cf
+		    sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/postfix/ssl/'$HOSTNAME'-key.pem~g' /etc/postfix/main.cf
+		    sed -i -r 's~#smtpd_tls_CAfile=~smtpd_tls_CAfile=/etc/postfix/ssl/cacert.pem~g' /etc/postfix/main.cf
+		    sed -i -r 's~#smtp_tls_CAfile=~smtp_tls_CAfile=/etc/postfix/ssl/cacert.pem~g' /etc/postfix/main.cf
+		    ln -s /etc/postfix/ssl/cacert.pem "/etc/ssl/certs/cacert-$HOSTNAME.pem"
+
+		    # Dovecot configuration
+		    sed -i -e 's~ssl_cert = </etc/dovecot/ssl/dovecot\.pem~ssl_cert = </etc/postfix/ssl/'$HOSTNAME'-combined\.pem~g' /etc/  dovecot/conf.d/10-ssl.conf
+		    sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/postfix/ssl/'$HOSTNAME'-key\.pem~g' /etc/dovecot/ conf.d/10-ssl.conf
+
+		    _notify 'inf' "SSL configured with 'self-signed' certificates"
+	    fi
+	    ;;
     '' )
-        # $SSL_TYPE=empty, no SSL certificate, plain text access
+      # $SSL_TYPE=empty, no SSL certificate, plain text access
 
-        # Dovecot configuration
-        sed -i -e 's~#disable_plaintext_auth = yes~disable_plaintext_auth = no~g' /etc/dovecot/conf.d/10-auth.conf
-        sed -i -e 's~ssl = required~ssl = yes~g' /etc/dovecot/conf.d/10-ssl.conf
+      # Dovecot configuration
+      sed -i -e 's~#disable_plaintext_auth = yes~disable_plaintext_auth = no~g' /etc/dovecot/conf.d/10-auth.conf
+      sed -i -e 's~ssl = required~ssl = yes~g' /etc/dovecot/conf.d/10-ssl.conf
 
-        _notify 'inf' "SSL configured with plain text access"
-        ;;
+      _notify 'inf' "SSL configured with plain text access"
+      ;;
     * )
-        # Unknown option, default behavior, no action is required
-        _notify 'warn' "SSL configured by default"
-        ;;
+      # Unknown option, default behavior, no action is required
+      _notify 'warn' "SSL configured by default"
+      ;;
 	esac
 }
 
-function _setup_postfix_vhost() {
+function _setup_postfix_vhost()
+{
 	_notify 'task' "Setting up Postfix vhost"
 
-	if [ -f /tmp/vhost.tmp ]; then
+	if [[ -f /tmp/vhost.tmp ]]
+  then
+    # shellcheck disable=SC2002
 		cat /tmp/vhost.tmp | sort | uniq > /etc/postfix/vhost && rm /tmp/vhost.tmp
-  elif [ ! -f /etc/postfix/vhost ]; then
+  elif [[ ! -f /etc/postfix/vhost ]]
+  then
     touch /etc/postfix/vhost
 	fi
 }
 
-function _setup_inet_protocols() {
+function _setup_inet_protocols()
+{
   _notify 'task' 'Setting up POSTFIX_INET_PROTOCOLS option'
   postconf -e "inet_protocols = $POSTFIX_INET_PROTOCOLS"
 }
 
-function _setup_docker_permit() {
+function _setup_docker_permit()
+{
 	_notify 'task' 'Setting up PERMIT_DOCKER Option'
 
 	container_ip=$(ip addr show eth0 | grep 'inet ' | sed 's/[^0-9\.\/]*//g' | cut -d '/' -f 1)
-	container_network="$(echo $container_ip | cut -d '.' -f1-2).0.0"
-	container_networks=$(ip -o -4 addr show type veth | egrep -o '[0-9\.]+/[0-9]+')
+	container_network="$(echo "$container_ip" | cut -d '.' -f1-2).0.0"
+	container_networks=$(ip -o -4 addr show type veth | grep -E -o '[0-9\.]+/[0-9]+')
 
 	case $PERMIT_DOCKER in
 		"host" )
 			_notify 'inf' "Adding $container_network/16 to my networks"
 			postconf -e "$(postconf | grep '^mynetworks =') $container_network/16"
-			echo $container_network/16 >> /etc/opendmarc/ignore.hosts
-			echo $container_network/16 >> /etc/opendkim/TrustedHosts
+			echo "$container_network/16" >> /etc/opendmarc/ignore.hosts
+			echo "$container_network/16" >> /etc/opendkim/TrustedHosts
 			;;
 
 		"network" )
@@ -1144,73 +1285,86 @@ function _setup_docker_permit() {
 			echo 172.16.0.0/12 >> /etc/opendkim/TrustedHosts
 			;;
 		"connected-networks" )
-			for network in $container_networks; do
-				network=$(_sanitize_ipv4_to_subnet_cidr $network)
+			for network in $container_networks
+      do
+				network=$(_sanitize_ipv4_to_subnet_cidr "$network")
 				_notify 'inf' "Adding docker network $network in my networks"
 				postconf -e "$(postconf | grep '^mynetworks =') $network"
-				echo $network >> /etc/opendmarc/ignore.hosts
-				echo $network >> /etc/opendkim/TrustedHosts
+				echo "$network" >> /etc/opendmarc/ignore.hosts
+				echo "$network" >> /etc/opendkim/TrustedHosts
 			done
 			;;
 		* )
 			_notify 'inf' "Adding container ip in my networks"
 			postconf -e "$(postconf | grep '^mynetworks =') $container_ip/32"
-			echo $container_ip/32 >> /etc/opendmarc/ignore.hosts
-			echo $container_ip/32 >> /etc/opendkim/TrustedHosts
+			echo "$container_ip/32" >> /etc/opendmarc/ignore.hosts
+			echo "$container_ip/32" >> /etc/opendkim/TrustedHosts
 			;;
 	esac
 }
 
-function _setup_postfix_virtual_transport() {
+function _setup_postfix_virtual_transport()
+{
 	_notify 'task' 'Setting up Postfix virtual transport'
 
-	[ -z "${POSTFIX_DAGENT}" ] && \
-		echo "${POSTFIX_DAGENT} not set." && \
-		kill -15 `cat /var/run/supervisord.pid` && return 1
-	postconf -e "virtual_transport = ${POSTFIX_DAGENT}"
+	[[ -z $POSTFIX_DAGENT ]] && echo "$POSTFIX_DAGENT not set." && \
+		kill -15 "$(cat /var/run/supervisord.pid)" && return 1
+
+	postconf -e "virtual_transport = $POSTFIX_DAGENT"
 }
 
-function _setup_postfix_override_configuration() {
+function _setup_postfix_override_configuration()
+{
 	_notify 'task' 'Setting up Postfix Override configuration'
 
-	if [ -f /tmp/docker-mailserver/postfix-main.cf ]; then
-		while read line; do
-		# all valid postfix options start with a lower case letter
-		# http://www.postfix.org/postconf.5.html
-		if [[ "$line" =~ ^[a-z] ]]; then
-			postconf -e "$line"
-		fi
+	if [[ -f /tmp/docker-mailserver/postfix-main.cf ]]
+  then
+		while read -r line
+    do
+		  # all valid postfix options start with a lower case letter
+		  # http://www.postfix.org/postconf.5.html
+		  if [[ $line =~ ^[a-z] ]]
+      then
+		  	postconf -e "$line"
+		  fi
 		done < /tmp/docker-mailserver/postfix-main.cf
 		_notify 'inf' "Loaded 'config/postfix-main.cf'"
 	else
 		_notify 'inf' "No extra postfix settings loaded because optional '/tmp/docker-mailserver/postfix-main.cf' not provided."
 	fi
-	if [ -f /tmp/docker-mailserver/postfix-master.cf ]; then
-		while read line; do
-		if [[ "$line" =~ ^[0-9a-z] ]]; then
-			postconf -P "$line"
-		fi
+
+	if [[ -f /tmp/docker-mailserver/postfix-master.cf ]]
+  then
+		while read -r line
+    do
+		  if [[ "$line" =~ ^[0-9a-z] ]]
+      then
+		  	postconf -P "$line"
+		  fi
 		done < /tmp/docker-mailserver/postfix-master.cf
 		_notify 'inf' "Loaded 'config/postfix-master.cf'"
 	else
 		_notify 'inf' "No extra postfix settings loaded because optional '/tmp/docker-mailserver/postfix-master.cf' not provided."
 	fi
 
-    _notify 'inf' "set the compatibility level to 2"
-    postconf compatibility_level=2
+  _notify 'inf' "set the compatibility level to 2"
+  postconf compatibility_level=2
 }
 
-function _setup_postfix_sasl_password() {
+function _setup_postfix_sasl_password()
+{
 	_notify 'task' 'Setting up Postfix SASL Password'
 
-	# Support general SASL password
+	# support general SASL password
 	rm -f /etc/postfix/sasl_passwd
-	if [ ! -z "$SASL_PASSWD" ]; then
+	if [[ -n $SASL_PASSWD ]]
+  then
 		echo "$SASL_PASSWD" >> /etc/postfix/sasl_passwd
 	fi
 
-	# Install SASL passwords
-	if [ -f /etc/postfix/sasl_passwd ]; then
+	# install SASL passwords
+	if [[ -f /etc/postfix/sasl_passwd ]]
+  then
 		chown root:root /etc/postfix/sasl_passwd
 		chmod 0600 /etc/postfix/sasl_passwd
 		_notify 'inf' "Loaded SASL_PASSWD"
@@ -1219,36 +1373,48 @@ function _setup_postfix_sasl_password() {
 	fi
 }
 
-function _setup_postfix_default_relay_host() {
+function _setup_postfix_default_relay_host()
+{
 	_notify 'task' 'Applying default relay host to Postfix'
 
 	_notify 'inf' "Applying default relay host $DEFAULT_RELAY_HOST to /etc/postfix/main.cf"
 	postconf -e "relayhost = $DEFAULT_RELAY_HOST"
 }
 
-function _setup_postfix_relay_hosts() {
+function _setup_postfix_relay_hosts()
+{
 	_notify 'task' 'Setting up Postfix Relay Hosts'
+
 	# copy old AWS_SES variables to new variables
-	if [ -z "$RELAY_HOST" ]; then
-		if [ ! -z "$AWS_SES_HOST" ]; then
+	if [[ -z $RELAY_HOST ]]
+  then
+		if [[ -n $AWS_SES_HOST ]]
+    then
 			_notify 'inf' "Using deprecated AWS_SES environment variables"
-			RELAY_HOST=$AWS_SES_HOST
+			RELAY_HOST="$AWS_SES_HOST"
 		fi
 	fi
-	if [ -z "$RELAY_PORT" ]; then
-		if [ -z "$AWS_SES_PORT" ]; then
+
+	if [[ -z $RELAY_PORT ]]
+  then
+		if [[ -z $AWS_SES_PORT ]]
+    then
 			RELAY_PORT=25
 		else
 			RELAY_PORT=$AWS_SES_PORT
 		fi
 	fi
-	if [ -z "$RELAY_USER" ]; then
-		if [ ! -z "$AWS_SES_USERPASS" ]; then
+
+	if [[ -z $RELAY_USER ]]
+  then
+		if [[ -n $AWS_SES_USERPASS ]]
+    then
 			# NB this will fail if the password contains a colon!
 			RELAY_USER=$(echo "$AWS_SES_USERPASS" | cut -f 1 -d ":")
 			RELAY_PASSWORD=$(echo "$AWS_SES_USERPASS" | cut -f 2 -d ":")
 		fi
 	fi
+
 	_notify 'inf' "Setting up outgoing email relaying via $RELAY_HOST:$RELAY_PORT"
 
 	# setup /etc/postfix/sasl_passwd
@@ -1259,25 +1425,32 @@ function _setup_postfix_relay_hosts() {
 	#
 	# [smtp.mailgun.org]:587  postmaster@domain2.com:your-password-2
 
-	if [ -f /tmp/docker-mailserver/postfix-sasl-password.cf ]; then
+	if [[ -f /tmp/docker-mailserver/postfix-sasl-password.cf ]]
+  then
 		_notify 'inf' "Adding relay authentication from postfix-sasl-password.cf"
-		while read line; do
-			if ! echo "$line" | grep -q -e "^\s*#"; then
+
+		while read -r line
+    do
+			if ! echo "$line" | grep -q -e "^\s*#"
+      then
 				echo "$line" >> /etc/postfix/sasl_passwd
 			fi
 		done < /tmp/docker-mailserver/postfix-sasl-password.cf
 	fi
 
 	# add default relay
-	if [ ! -z "$RELAY_USER" ] && [ ! -z "$RELAY_PASSWORD" ]; then
+	if [[ -n $RELAY_USER ]] && [[ -n $RELAY_PASSWORD ]]
+  then
 		echo "[$RELAY_HOST]:$RELAY_PORT		$RELAY_USER:$RELAY_PASSWORD" >> /etc/postfix/sasl_passwd
 	else
-		if [ ! -f /tmp/docker-mailserver/postfix-sasl-password.cf ]; then
+		if [[ ! -f /tmp/docker-mailserver/postfix-sasl-password.cf ]]
+    then
 			_notify 'warn' "No relay auth file found and no default set"
 		fi
 	fi
 
-	if [ -f /etc/postfix/sasl_passwd ]; then
+	if [[ -f /etc/postfix/sasl_passwd ]]
+  then
 		chown root:root /etc/postfix/sasl_passwd
 		chmod 0600 /etc/postfix/sasl_passwd
 	fi
@@ -1297,11 +1470,16 @@ function _setup_postfix_relay_hosts() {
 		"smtp_sender_dependent_authentication = yes"
 }
 
-function _setup_postfix_dhparam() {
+function _setup_postfix_dhparam()
+{
 	_notify 'task' 'Setting up Postfix dhparam'
-	if [ "$ONE_DIR" = 1 ];then
+
+	if [[ $ONE_DIR -eq 1 ]]
+  then
 		DHPARAMS_FILE=/var/mail-state/lib-shared/dhparams.pem
-		if [ ! -f $DHPARAMS_FILE ]; then
+
+    if [[ ! -f $DHPARAMS_FILE ]]
+    then
 			_notify 'inf' "Use ffdhe4096 for dhparams (postfix)"
       rm -f /etc/postfix/dhparams.pem && cp /etc/postfix/shared/ffdhe4096.pem /etc/postfix/dhparams.pem
 		else
@@ -1310,128 +1488,163 @@ function _setup_postfix_dhparam() {
       _notify 'warn' "Unless you known what you are doing, please remove /var/mail-state/lib-shared/dhparams.pem."
 
       # Copy from the state directory to the working location
-      rm -f /etc/postfix/dhparams.pem && cp $DHPARAMS_FILE /etc/postfix/dhparams.pem
+      rm -f /etc/postfix/dhparams.pem && cp "$DHPARAMS_FILE" /etc/postfix/dhparams.pem
 		fi
 	else
-                if [ ! -f /etc/postfix/dhparams.pem ]; then
-                        if [ -f /etc/dovecot/dh.pem ]; then
-                                _notify 'inf' "Copy dovecot dhparams to postfix"
-                                cp /etc/dovecot/dh.pem /etc/postfix/dhparams.pem
-                        elif [ -f /tmp/docker-mailserver/dhparams.pem ]; then
-                                _notify 'inf' "Copy pre-generated dhparams to postfix"
-                                _notify 'warn' "Using self-generated dhparams is considered as insecure."
-                                _notify 'warn' "Unless you known what you are doing, please remove /var/mail-state/lib-shared/dhparams.pem."
-                                cp /tmp/docker-mailserver/dhparams.pem /etc/postfix/dhparams.pem
-                        else
-			                          _notify 'inf' "Use ffdhe4096 for dhparams (postfix)"
-                                cp /etc/postfix/shared/ffdhe4096.pem /etc/postfix/dhparams.pem
-                        fi
-                else
-                        _notify 'inf' "Use existing postfix dhparams"
-                        _notify 'warn' "Using self-generated dhparams is considered as insecure."
-                        _notify 'warn' "Unless you known what you are doing, please remove /etc/postfix/dhparams.pem."
-                fi
+    if [[ ! -f /etc/postfix/dhparams.pem ]]
+    then
+      if [[ -f /etc/dovecot/dh.pem ]]
+      then
+        _notify 'inf' "Copy dovecot dhparams to postfix"
+        cp /etc/dovecot/dh.pem /etc/postfix/dhparams.pem
+      elif [[ -f /tmp/docker-mailserver/dhparams.pem ]]
+      then
+        _notify 'inf' "Copy pre-generated dhparams to postfix"
+        _notify 'warn' "Using self-generated dhparams is considered as insecure."
+        _notify 'warn' "Unless you known what you are doing, please remove /var/mail-state/lib-shared/dhparams.pem."
+        cp /tmp/docker-mailserver/dhparams.pem /etc/postfix/dhparams.pem
+      else
+		    _notify 'inf' "Use ffdhe4096 for dhparams (postfix)"
+        cp /etc/postfix/shared/ffdhe4096.pem /etc/postfix/dhparams.pem
+      fi
+    else
+      _notify 'inf' "Use existing postfix dhparams"
+      _notify 'warn' "Using self-generated dhparams is considered insecure."
+      _notify 'warn' "Unless you known what you are doing, please remove /etc/postfix/dhparams.pem."
+    fi
 	fi
 }
 
-function _setup_dovecot_dhparam() {
-        _notify 'task' 'Setting up Dovecot dhparam'
-        if [ "$ONE_DIR" = 1 ];then
-                DHPARAMS_FILE=/var/mail-state/lib-shared/dhparams.pem
-                if [ ! -f $DHPARAMS_FILE ]; then
-                        _notify 'inf' "Use ffdhe4096 for dhparams (dovecot)"
-                        rm -f /etc/dovecot/dh.pem && cp /etc/postfix/shared/ffdhe4096.pem /etc/dovecot/dh.pem
-                else
-                        _notify 'inf' "Use dovecot dhparams that was generated previously"
-                        _notify 'warn' "Using self-generated dhparams is considered as insecure."
-                        _notify 'warn' "Unless you known what you are doing, please remove /var/mail-state/lib-shared/dhparams.pem."
+function _setup_dovecot_dhparam()
+{
+  _notify 'task' 'Setting up Dovecot dhparam'
 
-                        # Copy from the state directory to the working location
-                        rm -f /etc/dovecot/dh.pem && cp $DHPARAMS_FILE /etc/dovecot/dh.pem
-                fi
-        else
-                if [ ! -f /etc/dovecot/dh.pem ]; then
-                        if [ -f /etc/postfix/dhparams.pem ]; then
-                                _notify 'inf' "Copy postfix dhparams to dovecot"
-                                cp /etc/postfix/dhparams.pem /etc/dovecot/dh.pem
-                        elif [ -f /tmp/docker-mailserver/dhparams.pem ]; then
-                                _notify 'inf' "Copy pre-generated dhparams to dovecot"
-                                _notify 'warn' "Using self-generated dhparams is considered as insecure."
-                                _notify 'warn' "Unless you known what you are doing, please remove /tmp/docker-mailserver/dhparams.pem."
-                                cp /tmp/docker-mailserver/dhparams.pem /etc/dovecot/dh.pem
-                        else
-			                          _notify 'inf' "Use ffdhe4096 for dhparams (dovecot)"
-                                cp /etc/postfix/shared/ffdhe4096.pem /etc/dovecot/dh.pem
-                        fi
-                else
-                        _notify 'inf' "Use existing dovecot dhparams"
-                        _notify 'warn' "Using self-generated dhparams is considered as insecure."
-                        _notify 'warn' "Unless you known what you are doing, please remove /etc/dovecot/dh.pem."
-                fi
-        fi
+  if [[ $ONE_DIR -eq 1 ]]
+  then
+    DHPARAMS_FILE=/var/mail-state/lib-shared/dhparams.pem
+
+    if [[ ! -f $DHPARAMS_FILE ]]
+    then
+      _notify 'inf' "Use ffdhe4096 for dhparams (dovecot)"
+      rm -f /etc/dovecot/dh.pem && cp /etc/postfix/shared/ffdhe4096.pem /etc/dovecot/dh.pem
+    else
+      _notify 'inf' "Use dovecot dhparams that was generated previously"
+      _notify 'warn' "Using self-generated dhparams is considered as insecure."
+      _notify 'warn' "Unless you known what you are doing, please remove /var/mail-state/lib-shared/dhparams.pem."
+
+      # Copy from the state directory to the working location
+      rm -f /etc/dovecot/dh.pem && cp "$DHPARAMS_FILE" /etc/dovecot/dh.pem
+    fi
+  else
+    if [[ ! -f /etc/dovecot/dh.pem ]]
+    then
+      if [[ -f /etc/postfix/dhparams.pem ]]
+      then
+        _notify 'inf' "Copy postfix dhparams to dovecot"
+        cp /etc/postfix/dhparams.pem /etc/dovecot/dh.pem
+      elif [[ -f /tmp/docker-mailserver/dhparams.pem ]]
+	  then
+        _notify 'inf' "Copy pre-generated dhparams to dovecot"
+        _notify 'warn' "Using self-generated dhparams is considered as insecure."
+        _notify 'warn' "Unless you known what you are doing, please remove /tmp/docker-mailserver/dhparams.pem."
+
+        cp /tmp/docker-mailserver/dhparams.pem /etc/dovecot/dh.pem
+      else
+		_notify 'inf' "Use ffdhe4096 for dhparams (dovecot)"
+      	cp /etc/postfix/shared/ffdhe4096.pem /etc/dovecot/dh.pem
+      fi
+    else
+      _notify 'inf' "Use existing dovecot dhparams"
+      _notify 'warn' "Using self-generated dhparams is considered as insecure."
+      _notify 'warn' "Unless you known what you are doing, please remove /etc/dovecot/dh.pem."
+    fi
+  fi
 }
 
-function _setup_security_stack() {
+function _setup_security_stack()
+{
 	_notify 'task' "Setting up Security Stack"
 
 	# recreate auto-generated file
 	dms_amavis_file="/etc/amavis/conf.d/61-dms_auto_generated"
+
   echo "# WARNING: this file is auto-generated." > $dms_amavis_file
 	echo "use strict;" >> $dms_amavis_file
 
 	# Spamassassin
-	if [ "$ENABLE_SPAMASSASSIN" = 0 ]; then
+	if [[ $ENABLE_SPAMASSASSIN -eq 0 ]]
+  then
 		_notify 'warn' "Spamassassin is disabled. You can enable it with 'ENABLE_SPAMASSASSIN=1'"
 		echo "@bypass_spam_checks_maps = (1);" >> $dms_amavis_file
-	elif [ "$ENABLE_SPAMASSASSIN" = 1 ]; then
+	elif [[ $ENABLE_SPAMASSASSIN -eq 1 ]]
+  then
 		_notify 'inf' "Enabling and configuring spamassassin"
+
+    # shellcheck disable=SC2016
 		SA_TAG=${SA_TAG:="2.0"} && sed -i -r 's/^\$sa_tag_level_deflt (.*);/\$sa_tag_level_deflt = '$SA_TAG';/g' /etc/amavis/conf.d/20-debian_defaults
+
+    # shellcheck disable=SC2016
 		SA_TAG2=${SA_TAG2:="6.31"} && sed -i -r 's/^\$sa_tag2_level_deflt (.*);/\$sa_tag2_level_deflt = '$SA_TAG2';/g' /etc/amavis/conf.d/20-debian_defaults
+
+    # shellcheck disable=SC2016
 		SA_KILL=${SA_KILL:="6.31"} && sed -i -r 's/^\$sa_kill_level_deflt (.*);/\$sa_kill_level_deflt = '$SA_KILL';/g' /etc/amavis/conf.d/20-debian_defaults
+
 		SA_SPAM_SUBJECT=${SA_SPAM_SUBJECT:="***SPAM*** "}
-		if [ "$SA_SPAM_SUBJECT" == "undef" ]; then
+
+    if [[ $SA_SPAM_SUBJECT == "undef" ]]
+    then
+      # shellcheck disable=SC2016
 			sed -i -r 's/^\$sa_spam_subject_tag (.*);/\$sa_spam_subject_tag = undef;/g' /etc/amavis/conf.d/20-debian_defaults
 		else
+      # shellcheck disable=SC2016
 			sed -i -r 's/^\$sa_spam_subject_tag (.*);/\$sa_spam_subject_tag = '"'$SA_SPAM_SUBJECT'"';/g' /etc/amavis/conf.d/20-debian_defaults
 		fi
 
-        # activate short circuits when SA BAYES is certain it has spam or ham.
-        if [ "$SA_SHORTCIRCUIT_BAYES_SPAM" = 1 ]; then
+    # activate short circuits when SA BAYES is certain it has spam or ham.
+    if [[ $SA_SHORTCIRCUIT_BAYES_SPAM -eq 1 ]]
+    then
 			# automatically activate the Shortcircuit Plugin
 			sed -i -r 's/^# loadplugin Mail::SpamAssassin::Plugin::Shortcircuit/loadplugin Mail::SpamAssassin::Plugin::Shortcircuit/g' /etc/spamassassin/v320.pre
-            sed -i -r 's/^# shortcircuit BAYES_99/shortcircuit BAYES_99/g' /etc/spamassassin/local.cf
-        fi
+      sed -i -r 's/^# shortcircuit BAYES_99/shortcircuit BAYES_99/g' /etc/spamassassin/local.cf
+    fi
 
-        if [ "$SA_SHORTCIRCUIT_BAYES_HAM" = 1 ]; then
+    if [[ $SA_SHORTCIRCUIT_BAYES_HAM -eq 1 ]]
+    then
 			# automatically activate the Shortcircuit Plugin
 			sed -i -r 's/^# loadplugin Mail::SpamAssassin::Plugin::Shortcircuit/loadplugin Mail::SpamAssassin::Plugin::Shortcircuit/g' /etc/spamassassin/v320.pre
-            sed -i -r 's/^# shortcircuit BAYES_00/shortcircuit BAYES_00/g' /etc/spamassassin/local.cf
-        fi
+      sed -i -r 's/^# shortcircuit BAYES_00/shortcircuit BAYES_00/g' /etc/spamassassin/local.cf
+    fi
 
-		test -e /tmp/docker-mailserver/spamassassin-rules.cf && cp /tmp/docker-mailserver/spamassassin-rules.cf /etc/spamassassin/
+		if [[ -e /tmp/docker-mailserver/spamassassin-rules.cf ]]
+    then
+      cp /tmp/docker-mailserver/spamassassin-rules.cf /etc/spamassassin/
+    fi
 
 
-		if [ "$SPAMASSASSIN_SPAM_TO_INBOX" = 1 ]; then
-				_notify 'inf' "Configure Spamassassin/Amavis to put SPAM inbox"
+		if [[ $SPAMASSASSIN_SPAM_TO_INBOX -eq 1 ]]
+    then
+			_notify 'inf' "Configure Spamassassin/Amavis to put SPAM inbox"
 
-				sed -i "s/\$final_spam_destiny.*=.*$/\$final_spam_destiny = D_PASS;/g" /etc/amavis/conf.d/49-docker-mailserver
-				sed -i "s/\$final_bad_header_destiny.*=.*$/\$final_bad_header_destiny = D_PASS;/g" /etc/amavis/conf.d/49-docker-mailserver
+			sed -i "s/\$final_spam_destiny.*=.*$/\$final_spam_destiny = D_PASS;/g" /etc/amavis/conf.d/49-docker-mailserver
+			sed -i "s/\$final_bad_header_destiny.*=.*$/\$final_bad_header_destiny = D_PASS;/g" /etc/amavis/conf.d/49-docker-mailserver
 		else
-		  	sed -i "s/\$final_spam_destiny.*=.*$/\$final_spam_destiny = D_BOUNCE;/g" /etc/amavis/conf.d/49-docker-mailserver
-				sed -i "s/\$final_bad_header_destiny.*=.*$/\$final_bad_header_destiny = D_BOUNCE;/g" /etc/amavis/conf.d/49-docker-mailserver
+		  sed -i "s/\$final_spam_destiny.*=.*$/\$final_spam_destiny = D_BOUNCE;/g" /etc/amavis/conf.d/49-docker-mailserver
+			sed -i "s/\$final_bad_header_destiny.*=.*$/\$final_bad_header_destiny = D_BOUNCE;/g" /etc/amavis/conf.d/49-docker-mailserver
 
-				if [ "${DEFAULT_VARS['EXPLICITLY_DEFINED_SPAMASSASSIN_SPAM_TO_INBOX']}" = 0 ]; then
-          _notify 'warn' "Spam messages WILL NOT BE DELIVERED, you will NOT be notified of ANY message bounced. Please define SPAMASSASSIN_SPAM_TO_INBOX explicitly."
-        fi
+			if [[ ${DEFAULT_VARS['EXPLICITLY_DEFINED_SPAMASSASSIN_SPAM_TO_INBOX']} == "0" ]]
+      then
+         _notify 'warn' "Spam messages WILL NOT BE DELIVERED, you will NOT be notified of ANY message bounced. Please define SPAMASSASSIN_SPAM_TO_INBOX explicitly."
+      fi
 		fi
-
 	fi
 
 	# Clamav
-	if [ "$ENABLE_CLAMAV" = 0 ]; then
+	if [[ $ENABLE_CLAMAV -eq 0 ]]
+  then
 		_notify 'warn' "Clamav is disabled. You can enable it with 'ENABLE_CLAMAV=1'"
 		echo "@bypass_virus_checks_maps = (1);" >> $dms_amavis_file
-	elif [ "$ENABLE_CLAMAV" = 1 ]; then
+	elif [[ $ENABLE_CLAMAV -eq 1 ]]
+  then
 		_notify 'inf' "Enabling clamav"
 	fi
 
@@ -1439,28 +1652,40 @@ function _setup_security_stack() {
 	chmod 444 $dms_amavis_file
 
 	# Fail2ban
-	if [ "$ENABLE_FAIL2BAN" = 1 ]; then
+	if [[ $ENABLE_FAIL2BAN -eq 1 ]]
+  then
 		_notify 'inf' "Fail2ban enabled"
-		test -e /tmp/docker-mailserver/fail2ban-fail2ban.cf && cp /tmp/docker-mailserver/fail2ban-fail2ban.cf /etc/fail2ban/fail2ban.local
-		test -e /tmp/docker-mailserver/fail2ban-jail.cf && cp /tmp/docker-mailserver/fail2ban-jail.cf /etc/fail2ban/jail.local
+
+	  if [[ -e /tmp/docker-mailserver/fail2ban-fail2ban.cf ]]
+    then
+      cp /tmp/docker-mailserver/fail2ban-fail2ban.cf /etc/fail2ban/fail2ban.local
+    fi
+
+    if [[ -e /tmp/docker-mailserver/fail2ban-jail.cf ]]
+    then
+      cp /tmp/docker-mailserver/fail2ban-jail.cf /etc/fail2ban/jail.local
+    fi
 	else
-		# Disable logrotate config for fail2ban if not enabled
-		rm -f /etc/logrotate.d/fail2ban
+	  # disable logrotate config for fail2ban if not enabled
+	  rm -f /etc/logrotate.d/fail2ban
 	fi
 
-	# Fix cron.daily for spamassassin
+	# fix cron.daily for spamassassin
 	sed -i -e 's~invoke-rc.d spamassassin reload~/etc/init\.d/spamassassin reload~g' /etc/cron.daily/spamassassin
 
-	# Copy user provided configuration files if provided
-	if [ -f /tmp/docker-mailserver/amavis.cf ]; then
+	# copy user provided configuration files if provided
+	if [[ -f /tmp/docker-mailserver/amavis.cf ]]
+  then
 		cp /tmp/docker-mailserver/amavis.cf /etc/amavis/conf.d/50-user
 	fi
 }
 
-function _setup_logrotate() {
+function _setup_logrotate()
+{
 	_notify 'inf' "Setting up logrotate"
 
-	LOGROTATE="/var/log/mail/mail.log\n{\n  compress\n  copytruncate\n  delaycompress\n"
+	LOGROTATE='/var/log/mail/mail.log\n{\n  compress\n  copytruncate\n  delaycompress\n'
+
 	case "$LOGROTATE_INTERVAL" in
 		"daily" )
 			_notify 'inf' "Setting postfix logrotate interval to daily"
@@ -1474,32 +1699,40 @@ function _setup_logrotate() {
 			_notify 'inf' "Setting postfix logrotate interval to monthly"
 			LOGROTATE="$LOGROTATE  rotate 1\n  monthly\n"
 			;;
+    * ) _notify 'warn' 'LOGROTATE_INTERVAL not found in _setup_logrotate' ;;
 	esac
-	LOGROTATE="$LOGROTATE}"
+
+	LOGROTATE="${LOGROTATE}}"
 	echo -e "$LOGROTATE" > /etc/logrotate.d/maillog
 }
 
-function _setup_mail_summary() {
+function _setup_mail_summary()
+{
 	_notify 'inf' "Enable postfix summary with recipient $PFLOGSUMM_RECIPIENT"
-        case "$PFLOGSUMM_TRIGGER" in
-                "daily_cron" )
-                        _notify 'inf' "Creating daily cron job for pflogsumm report"
+
+  case "$PFLOGSUMM_TRIGGER" in
+    "daily_cron" )
+      _notify 'inf' "Creating daily cron job for pflogsumm report"
+
 			echo "#!/bin/bash" > /etc/cron.daily/postfix-summary
-			echo "/usr/local/bin/report-pflogsumm-yesterday $HOSTNAME $PFLOGSUMM_RECIPIENT $PFLOGSUMM_SENDER" \
-			 >> /etc/cron.daily/postfix-summary
+			echo "/usr/local/bin/report-pflogsumm-yesterday $HOSTNAME $PFLOGSUMM_RECIPIENT $PFLOGSUMM_SENDER" >> /etc/cron.daily/postfix-summary
+
 			chmod +x /etc/cron.daily/postfix-summary
-                        ;;
-                "logrotate" )
-                        _notify 'inf' "Add postrotate action for pflogsumm report"
-			sed -i "s|}|  postrotate\n    /usr/local/bin/postfix-summary $HOSTNAME \
-    $PFLOGSUMM_RECIPIENT $PFLOGSUMM_SENDER\n  endscript\n}\n|" /etc/logrotate.d/maillog
-                        ;;
-        esac
+      ;;
+    "logrotate" )
+      _notify 'inf' "Add postrotate action for pflogsumm report"
+			sed -i "s|}|  postrotate\n    /usr/local/bin/postfix-summary $HOSTNAME $PFLOGSUMM_RECIPIENT $PFLOGSUMM_SENDER\n  endscript\n}\n|" /etc/logrotate.d/maillog
+      ;;
+    * ) _notify 'err' 'PFLOGSUMM_TRIGGER not found in _setup_mail_summery' ;;
+  esac
 }
 
-function _setup_logwatch() {
+function _setup_logwatch()
+{
 	_notify 'inf' "Enable logwatch reports with recipient $LOGWATCH_RECIPIENT"
+
   echo "LogFile = /var/log/mail/freshclam.log" >> /etc/logwatch/conf/logfiles/clam-update.conf
+
 	case "$LOGWATCH_INTERVAL" in
 		"daily" )
 			_notify 'inf' "Creating daily cron job for logwatch reports"
@@ -1515,13 +1748,16 @@ function _setup_logwatch() {
 			>> /etc/cron.weekly/logwatch
 			chmod 744 /etc/cron.weekly/logwatch
 			;;
+    * ) _notify 'warn' 'LOGWATCH_INTERVAL not found in _setup_logwatch' ;;
 	esac
 }
 
-function _setup_user_patches() {
+function _setup_user_patches()
+{
 	_notify 'inf' 'Executing user-patches.sh'
 
-	if [ -f /tmp/docker-mailserver/user-patches.sh ]; then
+	if [[ -f /tmp/docker-mailserver/user-patches.sh ]]
+  then
 		chmod +x /tmp/docker-mailserver/user-patches.sh
 		/tmp/docker-mailserver/user-patches.sh
 		_notify 'inf' "Executed 'config/user-patches.sh'"
@@ -1531,16 +1767,16 @@ function _setup_user_patches() {
 }
 
 function _setup_environment() {
-    _notify 'task' 'Setting up /etc/environment'
+  _notify 'task' 'Setting up /etc/environment'
 
-    local banner="# docker environment"
-    local var
-    if ! grep -q "$banner" /etc/environment; then
-        echo $banner >> /etc/environment
-        for var in "VIRUSMAILS_DELETE_DELAY"; do
-            echo "$var=${!var}" >> /etc/environment
-        done
-    fi
+  local banner="# docker environment"
+  local var
+
+  if ! grep -q "$banner" /etc/environment
+  then
+      echo "$banner" >> /etc/environment
+      echo "VIRUSMAILS_DELETE_DELAY=${DEFAULT_VARS["VIRUSMAILS_DELETE_DELAY"]}" >> /etc/environment
+  fi
 }
 
 ##########################################################################
@@ -1553,24 +1789,31 @@ function _setup_environment() {
 #
 # Description: Place functions for temporary workarounds and fixes here
 ##########################################################################
-function fix() {
+
+
+function fix()
+{
 	_notify 'taskgrg' "Post-configuration checks..."
-	for _func in "${FUNCS_FIX[@]}";do
-		$_func
-		[ $? != 0 ] && defunc
+	for _func in "${FUNCS_FIX[@]}"
+  do
+		if ! $_func
+    then
+      _defunc
+    fi
 	done
 
-        _notify 'taskgrg' "Remove leftover pid files from a stop/start"
-        rm -rf /var/run/*.pid /var/run/*/*.pid
-
-	touch /dev/shm/supervisor.sock
+  _notify 'taskgrg' "Remove leftover pid files from a stop/start"
+  rm -rf /var/run/*.pid /var/run/*/*.pid
+  touch /dev/shm/supervisor.sock
 }
 
-function _fix_var_mail_permissions() {
+function _fix_var_mail_permissions()
+{
 	_notify 'task' 'Checking /var/mail permissions'
 
-	# Fix permissions, but skip this if 3 levels deep the user id is already set
-	if [ `find /var/mail -maxdepth 3 -a \( \! -user 5000 -o \! -group 5000 \) | grep -c .` != 0 ]; then
+	# dix permissions, but skip this if 3 levels deep the user id is already set
+	if [[ $(find /var/mail -maxdepth 3 -a \( \! -user 5000 -o \! -group 5000 \) | grep -c .) -ne 0 ]]
+  then
 		_notify 'inf' "Fixing /var/mail permissions"
 		chown -R 5000:5000 /var/mail
 	else
@@ -1579,17 +1822,22 @@ function _fix_var_mail_permissions() {
 	fi
 }
 
-function _fix_var_amavis_permissions() {
-	if [[ "$ONE_DIR" -eq 0 ]]; then
+function _fix_var_amavis_permissions()
+{
+	if [[ $ONE_DIR -eq 0 ]]
+  then
 		amavis_state_dir=/var/lib/amavis
 	else
 		amavis_state_dir=/var/mail-state/lib-amavis
 	fi
+
+  # shellcheck disable=SC2016
 	_notify 'task' 'Checking $amavis_state_dir permissions'
 
 	amavis_permissions_status=$(find -H $amavis_state_dir -maxdepth 3 -a \( \! -user amavis -o \! -group amavis \))
 
-	if [ -n "$amavis_permissions_status" ]; then
+	if [[ -n $amavis_permissions_status ]]
+  then
 		_notify 'inf' "Fixing $amavis_state_dir permissions"
 		chown -hR amavis:amavis $amavis_state_dir
 	else
@@ -1598,13 +1846,15 @@ function _fix_var_amavis_permissions() {
 	fi
 }
 
-function _fix_cleanup_clamav() {
+function _fix_cleanup_clamav()
+{
     _notify 'task' 'Cleaning up disabled Clamav'
     rm -f /etc/logrotate.d/clamav-*
     rm -f /etc/cron.d/clamav-freshclam
 }
 
-function _fix_cleanup_spamassassin() {
+function _fix_cleanup_spamassassin()
+{
     _notify 'task' 'Cleaning up disabled spamassassin'
     rm -f /etc/cron.daily/spamassassin
 }
@@ -1619,34 +1869,58 @@ function _fix_cleanup_spamassassin() {
 #
 # Description: Place functions that do not fit in the sections above here
 ##########################################################################
-function misc() {
+
+function misc()
+{
 	_notify 'taskgrp' 'Starting Misc'
 
-	for _func in "${FUNCS_MISC[@]}";do
-		$_func
-		[ $? != 0 ] && defunc
+	for _func in "${FUNCS_MISC[@]}"
+  do
+		if ! $_func
+    then
+      _defunc
+    fi
 	done
 }
 
-function _misc_save_states() {
+function _misc_save_states()
+{
 	# consolidate all states into a single directory (`/var/mail-state`) to allow persistence using docker volumes
 	statedir=/var/mail-state
-	if [ "$ONE_DIR" = 1 -a -d $statedir ]; then
+
+	if [[ $ONE_DIR -eq 1 ]] && [[ -d $statedir ]]
+  then
 		_notify 'inf' "Consolidating all state onto $statedir"
-		for d in /var/spool/postfix /var/lib/postfix /var/lib/amavis /var/lib/clamav /var/lib/spamassassin /var/lib/fail2ban /var/lib/postgrey /var/lib/dovecot; do
-			dest=$statedir/`echo $d | sed -e 's/.var.//; s/\//-/g'`
-			if [ -d $dest ]; then
+
+    local FILES=(
+      /var/spool/postfix
+      /var/lib/postfix
+      /var/lib/amavis
+      /var/lib/clamav
+      /var/lib/spamassassin
+      /var/lib/fail2ban
+      /var/lib/postgrey
+      /var/lib/dovecot
+    )
+
+		for d in "${FILES[@]}"
+    do
+			dest="$statedir/$(echo "$d" | sed -e 's/.var.//; s/\//-/g')"
+
+			if [[ -d $dest ]]
+      then
 				_notify 'inf' "  Destination $dest exists, linking $d to it"
-				rm -rf $d
-				ln -s $dest $d
-			elif [ -d $d ]; then
-				_notify 'inf' "  Moving contents of $d to $dest:" `ls $d`
-				mv $d $dest
-				ln -s $dest $d
+				rm -rf "$d"
+				ln -s "$dest" "$d"
+			elif [[ -d $d ]]
+      then
+				_notify 'inf' "  Moving contents of $d to $dest:" "$(ls "$d")"
+				mv "$d" "$dest"
+				ln -s "$dest" "$d"
 			else
 				_notify 'inf' "  Linking $d to $dest"
-				mkdir -p $dest
-				ln -s $dest $d
+				mkdir -p "$dest"
+				ln -s "$dest" "$d"
 			fi
 		done
 
@@ -1663,107 +1937,129 @@ function _misc_save_states() {
 ##########################################################################
 # >> Start Daemons
 ##########################################################################
-function start_daemons() {
+
+function start_daemons()
+{
 	_notify 'taskgrp' 'Starting mail server'
 
-	for _func in "${DAEMONS_START[@]}";do
-		$_func
-		[ $? != 0 ] && defunc
+	for _func in "${DAEMONS_START[@]}"
+  do
+		if ! $_func
+    then
+      _defunc
+    fi
 	done
 }
 
-function _start_daemons_cron() {
+function _start_daemons_cron()
+{
 	_notify 'task' 'Starting cron' 'n'
 	supervisorctl start cron
 }
 
-function _start_daemons_rsyslog() {
+function _start_daemons_rsyslog()
+{
 	_notify 'task' 'Starting rsyslog ' 'n'
-    supervisorctl start rsyslog
+  supervisorctl start rsyslog
 }
 
-function _start_daemons_saslauthd() {
+function _start_daemons_saslauthd()
+{
 	_notify 'task' 'Starting saslauthd' 'n'
-    supervisorctl start "saslauthd_${SASLAUTHD_MECHANISMS}"
+  supervisorctl start "saslauthd_${SASLAUTHD_MECHANISMS}"
 }
 
-function _start_daemons_fail2ban() {
+function _start_daemons_fail2ban()
+{
 	_notify 'task' 'Starting fail2ban ' 'n'
 	touch /var/log/auth.log
-	# Delete fail2ban.sock that probably was left here after container restart
-	if [ -e /var/run/fail2ban/fail2ban.sock ]; then
+
+	# delete fail2ban.sock that probably was left here after container restart
+	if [[ -e /var/run/fail2ban/fail2ban.sock ]]
+  then
 		rm /var/run/fail2ban/fail2ban.sock
 	fi
-    supervisorctl start fail2ban
+
+  supervisorctl start fail2ban
 }
 
-function _start_daemons_opendkim() {
+function _start_daemons_opendkim()
+{
 	_notify 'task' 'Starting opendkim ' 'n'
-    supervisorctl start opendkim
+  supervisorctl start opendkim
 }
 
-function _start_daemons_opendmarc() {
+function _start_daemons_opendmarc()
+{
 	_notify 'task' 'Starting opendmarc ' 'n'
-    supervisorctl start opendmarc
+  supervisorctl start opendmarc
 }
 
-function _start_daemons_postsrsd(){
+function _start_daemons_postsrsd()
+{
 	_notify 'task' 'Starting postsrsd ' 'n'
 	supervisorctl start postsrsd
 }
 
-function _start_daemons_postfix() {
+function _start_daemons_postfix()
+{
 	_notify 'task' 'Starting postfix' 'n'
-    supervisorctl start postfix
+  supervisorctl start postfix
 }
 
-function _start_daemons_dovecot() {
+function _start_daemons_dovecot()
+{
 	# Here we are starting sasl and imap, not pop3 because it's disabled by default
-
 	_notify 'task' 'Starting dovecot services' 'n'
 
-	if [ "$ENABLE_POP3" = 1 ]; then
+	if [[ $ENABLE_POP3 -eq 1 ]]
+  then
 		_notify 'task' 'Starting pop3 services' 'n'
 		mv /etc/dovecot/protocols.d/pop3d.protocol.disab /etc/dovecot/protocols.d/pop3d.protocol
 	fi
 
-	if [ -f /tmp/docker-mailserver/dovecot.cf ]; then
+	if [[ -f /tmp/docker-mailserver/dovecot.cf ]]
+  then
 		cp /tmp/docker-mailserver/dovecot.cf /etc/dovecot/local.conf
 	fi
 
-    supervisorctl start dovecot
+  supervisorctl start dovecot
 
-	# @TODO fix: on integration test
+	# TODO fix: on integration test
 	# doveadm: Error: userdb lookup: connect(/var/run/dovecot/auth-userdb) failed: No such file or directory
 	# doveadm: Fatal: user listing failed
 
-	#if [ "$ENABLE_LDAP" != 1 ]; then
-		#echo "Listing users"
-		#/usr/sbin/dovecot user '*'
-	#fi
+	# if [[ $ENABLE_LDAP -ne 1 ]]
+  # then
+	#   echo "Listing users"
+	#   /usr/sbin/dovecot user '*'
+	# fi
 }
 
-function _start_daemons_fetchmail() {
+function _start_daemons_fetchmail()
+{
 	_notify 'task' 'Starting fetchmail' 'n'
 	/usr/local/bin/setup-fetchmail
 	supervisorctl start fetchmail
 }
 
-function _start_daemons_clamav() {
+function _start_daemons_clamav()
+{
 	_notify 'task' 'Starting clamav' 'n'
-    supervisorctl start clamav
+  supervisorctl start clamav
 }
 
-function _start_daemons_postgrey() {
+function _start_daemons_postgrey()
+{
 	_notify 'task' 'Starting postgrey' 'n'
 	rm -f /var/run/postgrey/postgrey.pid
-    supervisorctl start postgrey
+  supervisorctl start postgrey
 }
 
-
-function _start_daemons_amavis() {
+function _start_daemons_amavis()
+{
 	_notify 'task' 'Starting amavis' 'n'
-    supervisorctl start amavis
+  supervisorctl start amavis
 }
 
 ##########################################################################
@@ -1775,28 +2071,29 @@ function _start_daemons_amavis() {
 # Start check for update postfix-accounts and postfix-virtual
 ##########################################################################
 
-function _start_changedetector() {
+function _start_changedetector()
+{
 	_notify 'task' 'Starting changedetector' 'n'
-    supervisorctl start changedetector
+  supervisorctl start changedetector
 }
-
 
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # !  CARE --> DON'T CHANGE, unless you exactly know what you are doing
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-# >>
 
+# shellcheck source=/dev/null
 . /usr/local/bin/helper_functions.sh
 
-if [[ ${DEFAULT_VARS["DMS_DEBUG"]} == 1 ]]; then
-_notify 'taskgrp' ""
-_notify 'taskgrp' "#"
-_notify 'taskgrp' "#"
-_notify 'taskgrp' "# ENV"
-_notify 'taskgrp' "#"
-_notify 'taskgrp' "#"
-_notify 'taskgrp' ""
-printenv
+if [[ ${DEFAULT_VARS["DMS_DEBUG"]} -eq 1 ]]
+then
+  _notify 'taskgrp' ""
+  _notify 'taskgrp' "#"
+  _notify 'taskgrp' "#"
+  _notify 'taskgrp' "# ENV"
+  _notify 'taskgrp' "#"
+  _notify 'taskgrp' "#"
+  _notify 'taskgrp' ""
+  printenv
 fi
 
 _notify 'taskgrp' ""
@@ -1824,10 +2121,9 @@ _notify 'taskgrp' ""
 touch /var/log/mail/mail.log
 tail -fn 0 /var/log/mail/mail.log
 
-
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # !  CARE --> DON'T CHANGE, unless you exactly know what you are doing
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-# <<
 
 exit 0
+


### PR DESCRIPTION
# The Second Half

This one is rather a blue whale. I completely refactored `start-mailserver.sh`. Therefore, it is now included into `shellcheck`. This was indeed a slow decend into madness.

## Changes

- completely refactored `start-mailserver.sh`
- adjusted Makefile to check this script too

## To Do

- [x] close #1550
- [x] get rid of as many `#shellcheck disable...` comments as possible
- [x] correct the `Makefile` to use `/usr/bin/shellcheck`

## Post Scriptum

@erik-wramner I accidentally merge-commited all commits from #1601; I will squash them next time. I'm sorry for the inconvenience. 
