### PR TITLE
Add possibility to use a domain as a send only domain

### DIFF
--- a/target/check-for-changes.sh
+++ b/target/check-for-changes.sh
@@ -222,7 +222,7 @@ s/$/ regexp:\/etc\/postfix\/regexp/
         if [[ -n ${SENDONLY_DOMAINS} ]]
         then
           declare -a SEND_DOMAIN
-          IFS=',' read -r -a SEND_DOMAIN <<< "${SENDONLY_DOMAINS}"
+          IFS=',' ; read -r -a SEND_DOMAIN <<< "${SENDONLY_DOMAINS}"
           unset IFS
 
           for domain in "${SEND_DOMAIN[@]}"

--- a/target/check-for-changes.sh
+++ b/target/check-for-changes.sh
@@ -219,6 +219,17 @@ s/$/ regexp:\/etc\/postfix\/regexp/
       then
         # shellcheck disable=SC2002
         cat /tmp/vhost.tmp | sort | uniq >/etc/postfix/vhost && rm /tmp/vhost.tmp
+        if [[ -n ${SENDONLY_DOMAINS} ]]
+        then
+          declare -a SEND_DOMAIN
+          IFS=',' read -r -a SEND_DOMAIN <<< "${SENDONLY_DOMAINS}"
+          unset IFS
+
+          for domain in "${SEND_DOMAIN[@]}"
+          do
+            sed -i "/^$domain/d" /etc/postfix/vhost
+          done
+        fi
       fi
 
       if [[ $(find /var/mail -maxdepth 3 -a \( \! -user 5000 -o \! -group 5000 \) | grep -c .) -ne 0 ]]

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1244,6 +1244,20 @@ function _setup_postfix_vhost()
   if [[ -f /tmp/vhost.tmp ]]
   then
     sort < /tmp/vhost.tmp | uniq > /etc/postfix/vhost && rm /tmp/vhost.tmp
+
+    if [[ -n "${SENDONLY_DOMAINS}" ]]
+    then
+      declare -a SEND_DOMAIN
+      IFS=',' ; read -r -a SEND_DOMAIN <<< "${SENDONLY_DOMAINS}"
+      unset IFS
+
+      for domain in "${SEND_DOMAIN[@]}"
+      do
+        echo $domain
+        sed -i "/^$domain/d" /etc/postfix/vhost
+      done
+    fi
+
   elif [[ ! -f /etc/postfix/vhost ]]
   then
     touch /etc/postfix/vhost


### PR DESCRIPTION
This changes enable to exclude domains for local delivery options. This is important to use this module as a send only instance.

I do not have too much time at hand, so I am just leaving that here, there is probably some work to do to pull it in, however I will very probably respond slow, so feel free to copy it over in your own terms, I am using my own image already though.