### PR TITLE
added option to use non-default network-interface, resolves #1227

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement via issue. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0, available at <https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>. Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity). For answers to common questions about this code of conduct, see the FAQ at <https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Why I created this image: [Simple Mail Server with Docker](http://tvi.al/simple-
    - Dovecot was downgraded
 2. ELK was removed
 3. New contributing guidelines were added
+5. Added option to use non-default network interface
 
 ## Includes
 
@@ -345,6 +346,12 @@ Set different options for mynetworks option (can be overwrite in postfix-main.cf
 - connected-networks => Add all connected docker networks (ipv4 only)
 
 Note: you probably want to [set `POSTFIX_INET_PROTOCOLS=ipv4`](#postfix_inet_protocols) to make it work fine with Docker.
+
+##### NETWORK_INTERFACE
+
+In case you network interface differs from 'eth0', e.g. when you are using HostNetworking in Kubernetes, you can set NETWORK_INTERFACE to whatever interface you want. This interface will then be used.
+
+- **empty** => eth0
 
 ##### VIRUSMAILS_DELETE_DELAY
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Why I created this image: [Simple Mail Server with Docker](http://tvi.al/simple-
    - Dovecot was downgraded
 2. ELK was removed
 3. New contributing guidelines were added
-5. Added option to use non-default network interface
+4. Added option to use non-default network interface
 
 ## Includes
 
@@ -69,13 +69,13 @@ Before you open an issue, please have a look this `README`, the [Wiki](https://g
 
 Recommended:
 
-- 1 CPU
+- 1 Core
 - 1-2GB RAM
 - Swap enabled for the container
 
 Minimum:
 
-- 1 CPU
+- 1 vCore
 - 512MB RAM
 
 **Note:** You'll need to deactivate some services like ClamAV to be able to run on a host with 512MB of RAM. Even with 1G RAM you may run into problems without swap, see [FAQ](https://github.com/tomav/docker-mailserver/wiki/FAQ-and-Tips).
@@ -104,7 +104,10 @@ curl -o env-mailserver https://raw.githubusercontent.com/tomav/docker-mailserver
   - These files supports only simple `VAR=VAL` lines (see [Documentation](https://docs.docker.com/compose/env-file/)).
   - Don't quote your values.
   - Variable substitution is *not* supported (e.g. `OVERRIDE_HOSTNAME=$HOSTNAME.$DOMAINNAME`).
-- Install [docker-compose](https://docs.docker.com/compose/) in the version `1.7` or higher.
+- [Install the latest docker-compose](https://docs.docker.com/compose/install/)
+
+**Note:**: Variables in `.env` are expanded in the `docker-compose.yml` file **only** and **not** in the container. The file `env-mailserver` serves this case where environment variables are used in the container.
+
 
 **Note:** If you want to use a bare domain (host name equals domain name) see [FAQ](https://github.com/tomav/docker-mailserver/wiki/FAQ-and-Tips#can-i-use-nakedbare-domains-no-host-name).
 
@@ -161,9 +164,9 @@ version: '3.8'
 services:
   mail:
     image: tvial/docker-mailserver:latest
-    hostname: mail                         # ${HOSTNAME}
-    domainname: domain.com                 # ${DOMAINNAME}
-    container_name: mail                   # ${CONTAINER_NAME}
+    hostname: mail          # ${HOSTNAME}
+    domainname: domain.com  # ${DOMAINNAME}
+    container_name: mail    # ${CONTAINER_NAME}
     ports:
       - "25:25"
       - "143:143"
@@ -201,9 +204,9 @@ version: '3.8'
 services:
   mail:
     image: tvial/docker-mailserver:latest
-    hostname: mail                         # ${HOSTNAME}
-    domainname: domain.com                 # ${DOMAINNAME}
-    container_name: mail                   # ${CONTAINER_NAME}
+    hostname: mail          # ${HOSTNAME}
+    domainname: domain.com  # ${DOMAINNAME}
+    container_name: mail    # ${CONTAINER_NAME}
     ports:
       - "25:25"
       - "143:143"
@@ -256,10 +259,6 @@ volumes:
 ## Environment variables
 
 If an option doesn't work as documented here, check if you are running the latest image! Values in **bold** are the default values.
-
-### Reminder
-
-Please note: Variables in `.env` are expanded in the `docker-compose.yml` file **only** and **not** in the container. The file `env-mailserver` serves this case where environment variables are used in the container.
 
 ### Assignments
 
@@ -349,7 +348,7 @@ Note: you probably want to [set `POSTFIX_INET_PROTOCOLS=ipv4`](#postfix_inet_pro
 
 ##### NETWORK_INTERFACE
 
-In case you network interface differs from 'eth0', e.g. when you are using HostNetworking in Kubernetes, you can set NETWORK_INTERFACE to whatever interface you want. This interface will then be used.
+In case your network interface differs from `eth0`, e.g. when you are using HostNetworking in Kubernetes, you can set this to whatever interface you want. This interface will then be used.
 
 - **empty** => `eth0`
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Note: you probably want to [set `POSTFIX_INET_PROTOCOLS=ipv4`](#postfix_inet_pro
 
 In case you network interface differs from 'eth0', e.g. when you are using HostNetworking in Kubernetes, you can set NETWORK_INTERFACE to whatever interface you want. This interface will then be used.
 
-- **empty** => eth0
+- **empty** => `eth0`
 
 ##### VIRUSMAILS_DELETE_DELAY
 

--- a/env-mailserver.dist
+++ b/env-mailserver.dist
@@ -31,6 +31,7 @@ PERMIT_DOCKER=
 
 # In case you network interface differs from 'eth0', e.g. when you are using HostNetworking in Kubernetes,
 # you can set NETWORK_INTERFACE to whatever interface you want. This interface will then be used.
+#  - **empty** => eth0
 NETWORK_INTERFACE=
 
 # empty => modern

--- a/env-mailserver.dist
+++ b/env-mailserver.dist
@@ -29,6 +29,10 @@ POSTMASTER_ADDRESS=
 # connected-networks => Add all connected docker networks (ipv4 only)
 PERMIT_DOCKER=
 
+# In case you network interface differs from 'eth0', e.g. when you are using HostNetworking in Kubernetes,
+# you can set NETWORK_INTERFACE to whatever interface you want. This interface will then be used.
+NETWORK_INTERFACE=
+
 # empty => modern
 # modern => Enables TLSv1.2 and modern ciphers only. (default)
 # intermediate => Enables TLSv1, TLSv1.1 and TLSv1.2 and broad compatibility ciphers.

--- a/setup.sh
+++ b/setup.sh
@@ -6,19 +6,19 @@
 set -euEo pipefail
 trap '_report_err ${_} ${LINENO} ${?}' ERR
 
-function _report_err()
+function _report_err
 {
   echo "ERROR occured :: source ${1} ; line ${2} ; exit code ${3} ;;" >&2
   _unset_vars
 }
 
-function _unset_vars()
+function _unset_vars
 {
   unset CDIR CRI INFO IMAGE_NAME CONTAINER_NAME DEFAULT_CONFIG_PATH
   unset USE_CONTAINER WISHED_CONFIG_PATH CONFIG_PATH VOLUME USE_TTY
 }
 
-function _get_current_directory()
+function _get_current_directory
 {
   if dirname "$(readlink -f "${0}")" &>/dev/null
   then
@@ -44,7 +44,7 @@ CONFIG_PATH=
 VOLUME=
 USE_TTY=
 
-function _check_root()
+function _check_root
 {
   if [[ ${EUID} -ne 0 ]]
   then
@@ -53,7 +53,7 @@ function _check_root()
   fi
 }
 
-function _update_config_path()
+function _update_config_path
 {
   if [[ -n ${CONTAINER_NAME} ]]
   then
@@ -68,7 +68,7 @@ function _update_config_path()
   fi
 }
 
-function _inspect()
+function _inspect
 {
   if _docker_image_exists "${IMAGE_NAME}"
   then
@@ -86,7 +86,7 @@ function _inspect()
   fi
 }
 
-function _usage()
+function _usage
 {
   echo "Usage: ${0} [-i IMAGE_NAME] [-c CONTAINER_NAME] <subcommand> <subcommand> [args]
 
@@ -141,7 +141,7 @@ SUBCOMMANDS:
 "
 }
 
-function _docker_image_exists()
+function _docker_image_exists
 {
   if ${CRI} history -q "${1}" >/dev/null 2>&1
   then
@@ -151,7 +151,7 @@ function _docker_image_exists()
   fi
 }
 
-function _docker_image()
+function _docker_image
 {
   if ${USE_CONTAINER}
   then
@@ -171,7 +171,7 @@ function _docker_image()
   fi
 }
 
-function _docker_container()
+function _docker_container
 {
   if [[ -n ${CONTAINER_NAME} ]]
   then
@@ -182,7 +182,7 @@ function _docker_container()
   fi
 }
 
-function _main()
+function _main
 {
   if [[ -n $(command -v docker) ]]
   then

--- a/target/helper_functions.sh
+++ b/target/helper_functions.sh
@@ -35,8 +35,7 @@ function _sanitize_ipv4_to_subnet_cidr()
 {
   local DIGIT_PREFIX_LENGTH="${1#*/}"
 
-  declare -a MASKED_DIGITS
-  declare -a DIGITS
+  declare -a MASKED_DIGITS DIGITS
   IFS='.' ; read -r -a DIGITS < <(echo "${1%%/*}") ; unset IFS
 
   for ((i = 0 ; i < 4 ; i++))


### PR DESCRIPTION
This PR adds the possibility to use a network interface of choice. When using Kubernetes with Host Networking, this was an issue as `eth0` was the default and not changeable.