### PR TITLE
WIP / FEAT: Dual certificate support (eg ECDSA with RSA fallback)

### DIFF
--- a/target/dovecot/10-ssl.conf
+++ b/target/dovecot/10-ssl.conf
@@ -11,6 +11,8 @@
 # certificate, just make sure to update the domains in dovecot-openssl.cnf
 ssl_cert = </etc/dovecot/ssl/dovecot.pem
 ssl_key = </etc/dovecot/ssl/dovecot.key
+#ssl_alt_cert = </path/to/alternative/cert.pem
+#ssl_alt_key = </path/to/alternative/key.pem
 
 # If key file is password protected, give the password here. Alternatively
 # give it when starting dovecot with -p parameter. Since this file is often

--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -18,10 +18,9 @@ inet_interfaces = all
 inet_protocols = all
 
 # TLS parameters
-smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
-smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
-#smtpd_tls_CAfile=
-#smtp_tls_CAfile=
+smtpd_tls_chain_files = /etc/ssl/certs/ssl-fullkeychain-snakeoil.pem
+#smtpd_tls_CAfile =
+#smtp_tls_CAfile =
 smtpd_tls_security_level = may
 smtpd_tls_loglevel = 1
 smtp_tls_security_level = may

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1061,6 +1061,24 @@ function _setup_ssl()
 {
   _notify 'task' 'Setting up SSL'
 
+  # Primary certificate to serve for TLS
+  # sed substituion delimiter uses `~` instead of `/` due to file paths as values
+  function _set_certificate()
+  {
+    local postfix_fullkeychain=$1
+    local dovecot_cert=$2
+    local dovecot_key=$3
+
+    # Postfix configuration
+    # NOTE: `smtpd_tls_chain_files` expects private key defined before public cert chain
+    # May be a single PEM file or a sequence of files, so long as the order is key->leaf->chain
+    sed -i 's~^smtpd_tls_chain_files =.*~smtpd_tls_chain_files = '"${postfix_fullkeychain}~" /etc/postfix/main.cf
+
+    # Dovecot configuration
+    sed -i 's~^ssl_cert = <.*~ssl_cert = <'"${dovecot_cert}~" /etc/dovecot/conf.d/10-ssl.conf
+    sed -i 's~^ssl_key = <.*~ssl_key = <'"${dovecot_key}~" /etc/dovecot/conf.d/10-ssl.conf
+  }
+
   # TLS strength/level configuration
   case "${TLS_LEVEL}" in
     "modern" )
@@ -1134,13 +1152,10 @@ function _setup_ssl()
       then
         _notify 'inf' "Adding ${LETSENCRYPT_DOMAIN} SSL certificate to the postfix and dovecot configuration"
 
-        # Postfix configuration
-        sed -i -r 's~smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem~smtpd_tls_cert_file=/etc/letsencrypt/live/'"${LETSENCRYPT_DOMAIN}"'/fullchain.pem~g' /etc/postfix/main.cf
-        sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/letsencrypt/live/'"${LETSENCRYPT_DOMAIN}"'/'"${LETSENCRYPT_KEY}"'\.pem~g' /etc/postfix/main.cf
+        local cert_chain='/etc/letsencrypt/live/'"${LETSENCRYPT_DOMAIN}"'/fullchain.pem'
+        local private_key='/etc/letsencrypt/live/'"${LETSENCRYPT_DOMAIN}"'/'"${LETSENCRYPT_KEY}"'.pem'
 
-        # Dovecot configuration
-        sed -i -e 's~ssl_cert = </etc/dovecot/ssl/dovecot\.pem~ssl_cert = </etc/letsencrypt/live/'"${LETSENCRYPT_DOMAIN}"'/fullchain\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
-        sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/letsencrypt/live/'"${LETSENCRYPT_DOMAIN}"'/'"${LETSENCRYPT_KEY}"'\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
+        _set_certificate "${private_key} ${cert_chain}" "${cert_chain}" "${private_key}"
 
         _notify 'inf' "SSL configured with 'letsencrypt' certificates"
       fi
@@ -1155,13 +1170,10 @@ function _setup_ssl()
         mkdir -p /etc/postfix/ssl
         cp "/tmp/docker-mailserver/ssl/${HOSTNAME}-full.pem" /etc/postfix/ssl
 
-        # Postfix configuration
-        sed -i -r 's~smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem~smtpd_tls_cert_file=/etc/postfix/ssl/'"${HOSTNAME}"'-full.pem~g' /etc/postfix/main.cf
-        sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/postfix/ssl/'"${HOSTNAME}"'-full.pem~g' /etc/postfix/main.cf
+        # Private key with full certificate chain all in single PEM file,
+        local fullkeychain='/etc/postfix/ssl/'"${HOSTNAME}"'-full.pem'
 
-        # Dovecot configuration
-        sed -i -e 's~ssl_cert = </etc/dovecot/ssl/dovecot\.pem~ssl_cert = </etc/postfix/ssl/'"${HOSTNAME}"'-full\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
-        sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/postfix/ssl/'"${HOSTNAME}"'-full\.pem~g' /etc/dovecot/conf.d/10-ssl.conf
+        _set_certificate "${fullkeychain}" "${fullkeychain}" "${fullkeychain}"
 
         _notify 'inf' "SSL configured with 'CA signed/custom' certificates"
       fi
@@ -1178,13 +1190,10 @@ function _setup_ssl()
         chmod 600 /etc/postfix/ssl/cert
         chmod 600 /etc/postfix/ssl/key
 
-        # Postfix configuration
-        sed -i -r 's~smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem~smtpd_tls_cert_file=/etc/postfix/ssl/cert~g' /etc/postfix/main.cf
-        sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/postfix/ssl/key~g' /etc/postfix/main.cf
+        local cert_chain='/etc/postfix/ssl/cert'
+        local private_key='/etc/postfix/ssl/key'
 
-        # Dovecot configuration
-        sed -i -e 's~ssl_cert = </etc/dovecot/ssl/dovecot\.pem~ssl_cert = </etc/postfix/ssl/cert~g' /etc/dovecot/conf.d/10-ssl.conf
-        sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/postfix/ssl/key~g' /etc/dovecot/conf.d/10-ssl.conf
+        _set_certificate "${private_key} ${cert_chain}" "${cert_chain}" "${private_key}"
 
         _notify 'inf' "SSL configured with 'Manual' certificates"
       fi
@@ -1193,7 +1202,6 @@ function _setup_ssl()
       # Adding self-signed SSL certificate if provided in 'postfix/ssl' folder
       if [[ -e /tmp/docker-mailserver/ssl/${HOSTNAME}-cert.pem ]] \
       && [[ -e /tmp/docker-mailserver/ssl/${HOSTNAME}-key.pem ]] \
-      && [[ -e /tmp/docker-mailserver/ssl/${HOSTNAME}-combined.pem ]] \
       && [[ -e /tmp/docker-mailserver/ssl/demoCA/cacert.pem ]]
       then
         _notify 'inf' "Adding ${HOSTNAME} SSL certificate"
@@ -1204,20 +1212,18 @@ function _setup_ssl()
 
         # Force permission on key file
         chmod 600 "/etc/postfix/ssl/${HOSTNAME}-key.pem"
-        cp "/tmp/docker-mailserver/ssl/${HOSTNAME}-combined.pem" /etc/postfix/ssl
         cp /tmp/docker-mailserver/ssl/demoCA/cacert.pem /etc/postfix/ssl
 
-        # Postfix configuration
-        sed -i -r 's~smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem~smtpd_tls_cert_file=/etc/postfix/ssl/'"${HOSTNAME}"'-cert.pem~g' /etc/postfix/main.cf
-        sed -i -r 's~smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key~smtpd_tls_key_file=/etc/postfix/ssl/'"${HOSTNAME}"'-key.pem~g' /etc/postfix/main.cf
-        sed -i -r 's~#smtpd_tls_CAfile=~smtpd_tls_CAfile=/etc/postfix/ssl/cacert.pem~g' /etc/postfix/main.cf
-        sed -i -r 's~#smtp_tls_CAfile=~smtp_tls_CAfile=/etc/postfix/ssl/cacert.pem~g' /etc/postfix/main.cf
+        local cert_chain='/etc/postfix/ssl/'"${HOSTNAME}"'-cert.pem'
+        local private_key='/etc/postfix/ssl/'"${HOSTNAME}"'-key.pem'
+        local private_ca='/etc/ssl/certs/cacert-'"${HOSTNAME}"'.pem'
 
-        ln -s /etc/postfix/ssl/cacert.pem "/etc/ssl/certs/cacert-${HOSTNAME}.pem"
+        _set_certificate "${private_key} ${cert_chain}" "${cert_chain}" "${private_key}"
 
-        # Dovecot configuration
-        sed -i -e 's~ssl_cert = </etc/dovecot/ssl/dovecot\.pem~ssl_cert = </etc/postfix/ssl/'"${HOSTNAME}"'-combined\.pem~g' /etc/  dovecot/conf.d/10-ssl.conf
-        sed -i -e 's~ssl_key = </etc/dovecot/ssl/dovecot\.key~ssl_key = </etc/postfix/ssl/'"${HOSTNAME}"'-key\.pem~g' /etc/dovecot/ conf.d/10-ssl.conf
+        # Have Postfix trust the self-signed CA (not installed within the system trust store)
+        sed -i -r 's~^#?smtpd_tls_CAfile =.*~smtpd_tls_CAfile = /etc/postfix/ssl/cacert.pem~' /etc/postfix/main.cf
+        sed -i -r 's~^#?smtp_tls_CAfile =.*~smtp_tls_CAfile = /etc/postfix/ssl/cacert.pem~' /etc/postfix/main.cf
+        ln -s /etc/postfix/ssl/cacert.pem "${private_ca}"
 
         _notify 'inf' "SSL configured with 'self-signed' certificates"
       fi

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -95,7 +95,7 @@ CHKSUM_FILE=/tmp/docker-mailserver-config-chksum
 # Implement them in the section-group: {check,setup,fix,start}
 ##########################################################################
 
-function register_functions()
+function regiter_functions()
 {
   _notify 'taskgrp' 'Initializing setup'
   _notify 'task' 'Registering check,setup,fix,misc and start-daemons functions'
@@ -1065,45 +1065,45 @@ function _setup_ssl()
   # sed substituion delimiter uses `~` instead of `/` due to file paths as values
   function _set_certificate()
   {
-    local postfix_fullkeychain=$1
-    local dovecot_cert=$2
-    local dovecot_key=$3
+    local POSTFIX_FULLKEYCHAIN=$1
+    local DOVECOT_CERT=$2
+    local DOVECOT_KEY=$3
 
     # Postfix configuration
     # NOTE: `smtpd_tls_chain_files` expects private key defined before public cert chain
     # May be a single PEM file or a sequence of files, so long as the order is key->leaf->chain
-    sed -i 's~^smtpd_tls_chain_files =.*~smtpd_tls_chain_files = '"${postfix_fullkeychain}~" /etc/postfix/main.cf
+    sed -i 's~^smtpd_tls_chain_files =.*~smtpd_tls_chain_files = '"${POSTFIX_FULLKEYCHAIN}~" /etc/postfix/main.cf
 
     # Dovecot configuration
-    sed -i 's~^ssl_cert = <.*~ssl_cert = <'"${dovecot_cert}~" /etc/dovecot/conf.d/10-ssl.conf
-    sed -i 's~^ssl_key = <.*~ssl_key = <'"${dovecot_key}~" /etc/dovecot/conf.d/10-ssl.conf
+    sed -i 's~^ssl_cert = <.*~ssl_cert = <'"${DOVECOT_CERT}~" /etc/dovecot/conf.d/10-ssl.conf
+    sed -i 's~^ssl_key = <.*~ssl_key = <'"${DOVECOT_KEY}~" /etc/dovecot/conf.d/10-ssl.conf
   }
 
   # Enables supporting two certificate types such as ECDSA with an RSA fallback
   function _set_alt_certificate()
   {
-    local copy_cert_from_path=$1
-    local copy_key_from_path=$2
-    local cert_chain_alt='/etc/postfix/ssl/cert_alt'
-    local private_key_alt='/etc/postfix/ssl/key_alt'
+    local COPY_CERT_FROM_PATH=$1
+    local COPY_KEY_FROM_PATH=$2
+    local CERT_CHAIN_ALT='/etc/postfix/ssl/cert_alt'
+    local PRIVATE_KEY_ALT='/etc/postfix/ssl/key_alt'
 
-    cp "${copy_cert_from_path}" "${cert_chain_alt}"
-    cp "${copy_key_from_path}" "${private_key_alt}"
-    chmod 600 "${cert_chain_alt}"
-    chmod 600 "${private_key_alt}"
+    cp "${COPY_CERT_FROM_PATH}" "${CERT_CHAIN_ALT}"
+    cp "${COPY_KEY_FROM_PATH}" "${PRIVATE_KEY_ALT}"
+    chmod 600 "${CERT_CHAIN_ALT}"
+    chmod 600 "${PRIVATE_KEY_ALT}"
 
     # Postfix configuration
     # NOTE: This operation doesn't replace the line, it appends to the end of the line.
     # Thus this method should only be used when this line has explicitly been
     # replaced on run, otherwise without `docker-compose down`, container state
     # may persist and cause a failure in postfix configuration.
-    sed -i 's~^smtpd_tls_chain_files =.*~& '"${private_key_alt} ${cert_chain_alt}~" /etc/postfix/main.cf
+    sed -i 's~^smtpd_tls_chain_files =.*~& '"${PRIVATE_KEY_ALT} ${CERT_CHAIN_ALT}~" /etc/postfix/main.cf
 
     # Dovecot configuration
     # Conditionally checks for `#`, in the event that internal container
     # state is persisted (`docker-compose up`, twice, without `docker-compose down`)
-    sed -i 's~^#\?ssl_alt_cert = <.*~ssl_alt_cert = <'"${cert_chain_alt}"'~' /etc/dovecot/conf.d/10-ssl.conf
-    sed -i 's~^#\?ssl_alt_key = <.*~ssl_alt_key = <'"${private_key_alt}"'~' /etc/dovecot/conf.d/10-ssl.conf
+    sed -i 's~^#\?ssl_alt_cert = <.*~ssl_alt_cert = <'"${CERT_CHAIN_ALT}"'~' /etc/dovecot/conf.d/10-ssl.conf
+    sed -i 's~^#\?ssl_alt_key = <.*~ssl_alt_key = <'"${PRIVATE_KEY_ALT}"'~' /etc/dovecot/conf.d/10-ssl.conf
   }
 
   # TLS strength/level configuration
@@ -1179,10 +1179,10 @@ function _setup_ssl()
       then
         _notify 'inf' "Adding ${LETSENCRYPT_DOMAIN} SSL certificate to the postfix and dovecot configuration"
 
-        local cert_chain='/etc/letsencrypt/live/'"${LETSENCRYPT_DOMAIN}"'/fullchain.pem'
-        local private_key='/etc/letsencrypt/live/'"${LETSENCRYPT_DOMAIN}"'/'"${LETSENCRYPT_KEY}"'.pem'
+        local CERT_CHAIN='/etc/letsencrypt/live/'"${LETSENCRYPT_DOMAIN}"'/fullchain.pem'
+        local PRIVATE_KEY='/etc/letsencrypt/live/'"${LETSENCRYPT_DOMAIN}"'/'"${LETSENCRYPT_KEY}"'.pem'
 
-        _set_certificate "${private_key} ${cert_chain}" "${cert_chain}" "${private_key}"
+        _set_certificate "${PRIVATE_KEY} ${CERT_CHAIN}" "${CERT_CHAIN}" "${PRIVATE_KEY}"
 
         _notify 'inf' "SSL configured with 'letsencrypt' certificates"
       fi
@@ -1217,10 +1217,10 @@ function _setup_ssl()
         chmod 600 /etc/postfix/ssl/cert
         chmod 600 /etc/postfix/ssl/key
 
-        local cert_chain='/etc/postfix/ssl/cert'
-        local private_key='/etc/postfix/ssl/key'
+        local CERT_CHAIN='/etc/postfix/ssl/cert'
+        local PRIVATE_KEY='/etc/postfix/ssl/key'
 
-        _set_certificate "${private_key} ${cert_chain}" "${cert_chain}" "${private_key}"
+        _set_certificate "${PRIVATE_KEY} ${CERT_CHAIN}" "${CERT_CHAIN}" "${PRIVATE_KEY}"
 
         # Support for a fallback certificate, useful for hybrid/dual ECDSA + RSA certs
         if [[ -n ${SSL_ALT_CERT_PATH} ]] && [[ -n ${SSL_ALT_KEY_PATH} ]]
@@ -1249,16 +1249,16 @@ function _setup_ssl()
         chmod 600 "/etc/postfix/ssl/${HOSTNAME}-key.pem"
         cp /tmp/docker-mailserver/ssl/demoCA/cacert.pem /etc/postfix/ssl
 
-        local cert_chain='/etc/postfix/ssl/'"${HOSTNAME}"'-cert.pem'
-        local private_key='/etc/postfix/ssl/'"${HOSTNAME}"'-key.pem'
-        local private_ca='/etc/ssl/certs/cacert-'"${HOSTNAME}"'.pem'
+        local CERT_CHAIN='/etc/postfix/ssl/'"${HOSTNAME}"'-cert.pem'
+        local PRIVATE_KEY='/etc/postfix/ssl/'"${HOSTNAME}"'-key.pem'
+        local PRIVATE_CA='/etc/ssl/certs/cacert-'"${HOSTNAME}"'.pem'
 
-        _set_certificate "${private_key} ${cert_chain}" "${cert_chain}" "${private_key}"
+        _set_certificate "${PRIVATE_KEY} ${CERT_CHAIN}" "${CERT_CHAIN}" "${PRIVATE_KEY}"
 
         # Have Postfix trust the self-signed CA (not installed within the system trust store)
         sed -i -r 's~^#?smtpd_tls_CAfile =.*~smtpd_tls_CAfile = /etc/postfix/ssl/cacert.pem~' /etc/postfix/main.cf
         sed -i -r 's~^#?smtp_tls_CAfile =.*~smtp_tls_CAfile = /etc/postfix/ssl/cacert.pem~' /etc/postfix/main.cf
-        ln -s /etc/postfix/ssl/cacert.pem "${private_ca}"
+        ln -s /etc/postfix/ssl/cacert.pem "${PRIVATE_CA}"
 
         _notify 'inf' "SSL configured with 'self-signed' certificates"
       fi
@@ -1798,13 +1798,18 @@ function _setup_logwatch()
 
 function _setup_user_patches()
 {
-  _notify 'inf' 'Executing user-patches.sh'
-
   if [[ -f /tmp/docker-mailserver/user-patches.sh ]]
   then
-    chmod +x /tmp/docker-mailserver/user-patches.sh
-    /tmp/docker-mailserver/user-patches.sh
-    _notify 'inf' "Executed 'config/user-patches.sh'"
+    _notify 'inf' 'Executing user-patches.sh'
+    chmod +x /tmp/docker-mailserver/user-patches.sh &>/dev/null || true
+
+    if [[ -x /tmp/docker-mailserver/user-patches.sh ]]
+    then
+      /tmp/docker-mailserver/user-patches.sh
+      _notify 'inf' "Executed 'config/user-patches.sh'"
+    else
+      _notify 'err' "Could not execute user-patches.sh. Not executable!"
+    fi
   else
     _notify 'inf' "No user patches executed because optional '/tmp/docker-mailserver/user-patches.sh' is not provided."
   fi
@@ -2170,3 +2175,4 @@ tail -fn 0 /var/log/mail/mail.log
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 exit 0
+s

--- a/test/mail_ssl_letsencrypt.bats
+++ b/test/mail_ssl_letsencrypt.bats
@@ -54,10 +54,7 @@ function teardown_file() {
 
 @test "checking ssl: letsencrypt configuration is correct" {
   #test domain has certificate files
-  run docker exec mail_lets_domain /bin/sh -c 'postconf | grep "smtpd_tls_cert_file = /etc/letsencrypt/live/my-domain.com/fullchain.pem" | wc -l'
-  assert_success
-  assert_output 1
-  run docker exec mail_lets_domain /bin/sh -c 'postconf | grep "smtpd_tls_key_file = /etc/letsencrypt/live/my-domain.com/key.pem" | wc -l'
+  run docker exec mail_lets_domain /bin/sh -c 'postconf | grep "smtpd_tls_chain_files = /etc/letsencrypt/live/my-domain.com/key.pem /etc/letsencrypt/live/my-domain.com/fullchain.pem" | wc -l'
   assert_success
   assert_output 1
   run docker exec mail_lets_domain /bin/sh -c 'doveconf | grep "ssl_cert = </etc/letsencrypt/live/my-domain.com/fullchain.pem" | wc -l'
@@ -67,10 +64,7 @@ function teardown_file() {
   assert_success
   assert_output 1
   #test hostname has certificate files
-  run docker exec mail_lets_hostname /bin/sh -c 'postconf | grep "smtpd_tls_cert_file = /etc/letsencrypt/live/mail.my-domain.com/fullchain.pem" | wc -l'
-  assert_success
-  assert_output 1
-  run docker exec mail_lets_hostname /bin/sh -c 'postconf | grep "smtpd_tls_key_file = /etc/letsencrypt/live/mail.my-domain.com/privkey.pem" | wc -l'
+  run docker exec mail_lets_hostname /bin/sh -c 'postconf | grep "smtpd_tls_chain_files = /etc/letsencrypt/live/mail.my-domain.com/privkey.pem /etc/letsencrypt/live/mail.my-domain.com/fullchain.pem" | wc -l'
   assert_success
   assert_output 1
   run docker exec mail_lets_hostname /bin/sh -c 'doveconf | grep "ssl_cert = </etc/letsencrypt/live/mail.my-domain.com/fullchain.pem" | wc -l'


### PR DESCRIPTION
Since Postfix 3.4 (Feb 2019), `smtpd_tls_cert_file` and `smtpd_tls_key_file` have been deprecated in favor of [`smtpd_tls_chain_files`](http://www.postfix.org/postconf.5.html#smtp_tls_chain_files) which supports a list of values where a single or sequence of file paths provide a private key followed by it's certificate chain. 

## 1st commit - DRY logic, subtle changes/improvements, small bugfix

The first commit refactors the relevant code to support this settings change in Postfix, while also moving common logic for each TLS setup variation into a function. 

`sed` lines were also revised as they often contained unnecessary options(`-e`, `-r`) and regex tokens/syntax(`g`), or specific paths that were better extracted out as variables or unnecessary for a match(use `.*` instead).

The `self-signed` case had an additional `-combined.pem` file used instead of the `-cert.pem` for Dovecot's `ssl_cert` value. This didn't make much sense (unless there's a known reason for doing this), the `-combined.pem` is a bundle file containing the private key followed by the certificate, I see no reason to support that so I've replaced it with the same `-cert.pem` that Postfix uses for it's certificate. This makes it more consistent with other cases.

`self-signed` Dovecot paths to apply `sed` to were also **invalid** due to whitespace within the file paths AFAIK.

The `custom` case also differed, in that it provides a similar key+cert bundle as the self-signed `-combined.pem`, this one is `-full.pem` which I've not inspected but assume contains a full certificate chain (leaf + issuer chain), which is useful for including CA certs in a chain that don't belong to a systems trust store.

An additional bonus of this refactor is that previously a `docker-compose up` when exited, persisted the container's internal filesystem state which would be used by a follow up `docker-compose up`, which caused unexpected behaviour / breakage in the event that you changed from `self-signed` to `manual` for example or if `HOSTNAME` were to change. `docker-compose down` was required to properly clear this state to a "fresh" idempotent state. **That issue may be present elsewhere in the codebase btw**.

Postfix `main.cf` also had a slight consistency fix to maintain spaces between `=` assignment like the rest of the config file and related configs such as Dovecot use.

I've not tested each case personally, only the `manual` case. I'm not deeply familiar with the codebase or the `bats` tests, this PR has been validated to work for `manual`, it might benefit from an extra `bats` test covering the dual cert support?

## 2nd commit - Dual cert feature

`smtpd_tls_chain_files` allows for multiple key+cert bundles so that you can provide different key types, such as ECDSA and RSA.

To maintain compatibility with the current `SSL_CERT_PATH` and `SSL_KEY_PATH` ENV variables only a 2nd certificate is supported.

Since Dovecot 2.2.31 (June 2017) [a related feature is also available](https://wiki.dovecot.org/SSL/DovecotConfiguration#Multiple_SSL_certificates), but it is limited to only providing one alternative certificate via separate cert and key settings. That limitation is a non-issue as this feature is only supporting a 2nd alternative certificate via `SSL_ALT_CERT_PATH` and `SSL_ALT_KEY_PATH` ENV vars.

---

## TL;DR

This feature enables support for multiple certificates, eg for serving modern ECDSA cert with an RSA cert as fallback.

---

I needed this for testing my active PR. (which I'm already using locally, but figured was worth polishing up for a separate PR) 

I presently do not have time to learn about `bats` and how to implement any tests required for this PR, any assistance would be appreciated regarding that, even if it's just some guidance on what needs to be tested and roughly how to go about achieving that.