### PR TITLE
Implement initial support for shared mailboxes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -228,7 +228,7 @@ RUN curl -s https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > /et
 
 COPY ./target/bin /usr/local/bin
 # Start-mailserver script
-COPY ./target/bin-helper.sh ./target/helper-functions.sh ./target/check-for-changes.sh ./target/start-mailserver.sh ./target/fail2ban-wrapper.sh ./target/postfix-wrapper.sh ./target/postsrsd-wrapper.sh ./target/docker-configomat/configomat.sh /usr/local/bin/
+COPY ./target/share-inbox.sh ./target/bin-helper.sh ./target/helper-functions.sh ./target/check-for-changes.sh ./target/start-mailserver.sh ./target/fail2ban-wrapper.sh ./target/postfix-wrapper.sh ./target/postsrsd-wrapper.sh ./target/docker-configomat/configomat.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/*
 
 # Configure supervisor

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A fullstack but simple mail server (SMTP, IMAP, Antispam, Antivirus...).
 Only configuration files, no SQL database. Keep it simple and versioned.
 Easy to deploy and upgrade.
 
-[Why was this image was created?](http://tvi.al/simple-mail-server-with-docker/)
+[Why was this image was created.](http://tvi.al/simple-mail-server-with-docker/)
 
 1. [Announcements](#announcements)
 2. [Includes](#includes)

--- a/README.md
+++ b/README.md
@@ -680,6 +680,23 @@ The following variables overwrite the default values for ```/etc/dovecot/dovecot
 - Note: The left-hand value is the directory attribute, the right hand value is the dovecot variable.
 - More details on the [Dovecot Wiki](https://wiki.dovecot.org/AuthDatabase/LDAP/PasswordLookups)
 
+##### DOVECOT_NAMESPACE_SEPARATOR
+
+- **empty** => separator of namespaces is backend-dependent
+- typical namespace separator is slash `/`
+
+##### DOVECOT_ENABLE_INBOX_SHARING
+
+- **0** => inbox sharing is disabled
+- 1 => inbox sharing is enabled
+
+In order to enable inbox sharing, you also need to specify a namespace separator using the `DOVECOT_NAMESPACE_SEPARATOR` variable.
+Then, you may want to tweak [sharing settings](https://wiki.dovecot.org/SharedMailboxes/Shared) in the config file - `/etc/dovecot/11-shared.conf` in the container.
+Finally, you will want to define how will Dovecot keep track of which mailboxes are shared to a particular user by [defining a dictionary](https://wiki.dovecot.org/Dictionary).
+
+You can share a mailbox by calling a script `/usr/local/bin/share_inbox.sh` in the container e.g. using `docker-compose exec`.
+That script will sync [mailbox's ACLs](https://doc.dovecot.org/settings/plugin/acl/) together with the dictionary.
+
 #### Postgrey
 
 ##### ENABLE_POSTGREY

--- a/README.md
+++ b/README.md
@@ -694,7 +694,7 @@ In order to enable inbox sharing, you also need to specify a namespace separator
 Then, you may want to tweak [sharing settings](https://wiki.dovecot.org/SharedMailboxes/Shared) in the config file - `/etc/dovecot/11-shared.conf` in the container.
 Finally, you will want to define how will Dovecot keep track of which mailboxes are shared to a particular user by [defining a dictionary](https://wiki.dovecot.org/Dictionary).
 
-You can share a mailbox by calling a script `/usr/local/bin/share_inbox.sh` in the container e.g. using `docker-compose exec`.
+You can share a mailbox by calling a script `/usr/local/bin/share-inbox.sh` in the container e.g. using `docker-compose exec`.
 That script will sync [mailbox's ACLs](https://doc.dovecot.org/settings/plugin/acl/) together with the dictionary.
 
 #### Postgrey

--- a/target/dovecot/10-mail.conf
+++ b/target/dovecot/10-mail.conf
@@ -46,7 +46,7 @@ namespace inbox {
   # Hierarchy separator to use. You should use the same separator for all
   # namespaces or some clients get confused. '/' is usually a good one.
   # The default however depends on the underlying mail storage format.
-  #separator =
+  #@NAMESPACE_SEPARATOR_CLAUSE@
 
   # Prefix required to access this namespace. This needs to be different for
   # all namespaces. For example "Public/".
@@ -77,28 +77,7 @@ namespace inbox {
   #subscriptions = yes
 }
 
-# Example shared namespace configuration
-#namespace {
-  #type = shared
-  #separator = /
-
-  # Mailboxes are visible under "shared/user@domain/"
-  # %%n, %%d and %%u are expanded to the destination user.
-  #prefix = shared/%%u/
-
-  # Mail location for other users' mailboxes. Note that %variables and ~/
-  # expands to the logged in user's data. %%n, %%d, %%u and %%h expand to the
-  # destination user's data.
-  #location = maildir:%%h/Maildir:INDEX=~/Maildir/shared/%%u
-
-  # Use the default namespace for saving subscriptions.
-  #subscriptions = no
-
-  # List the shared/ namespace only if there are visible shared mailboxes.
-  #list = children
-#}
-# Should shared INBOX be visible as "shared/user" or "shared/user/INBOX"?
-#mail_shared_explicit_inbox = no
+# See 11-shared.conf for shared inbox configuration
 
 # System user and group used to access mails. If you use multiple, userdb
 # can override these by returning uid or gid fields. You can use either numbers

--- a/target/dovecot/10-mail.conf
+++ b/target/dovecot/10-mail.conf
@@ -46,7 +46,7 @@ namespace inbox {
   # Hierarchy separator to use. You should use the same separator for all
   # namespaces or some clients get confused. '/' is usually a good one.
   # The default however depends on the underlying mail storage format.
-  #@NAMESPACE_SEPARATOR_CLAUSE@
+  #@DOVECOT_NAMESPACE_SEPARATOR_CLAUSE@
 
   # Prefix required to access this namespace. This needs to be different for
   # all namespaces. For example "Public/".

--- a/target/dovecot/11-shared.conf
+++ b/target/dovecot/11-shared.conf
@@ -4,7 +4,7 @@
 
 #<#namespace {
 #<#  type = shared
-#<#  @NAMESPACE_SEPARATOR_CLAUSE@
+#<#  @DOVECOT_NAMESPACE_SEPARATOR_CLAUSE@
 #<#
 #<#  # Mailboxes are visible under "shared/user@domain/"
 #<#  # %%n, %%d and %%u are expanded to the destination user.

--- a/target/dovecot/11-shared.conf
+++ b/target/dovecot/11-shared.conf
@@ -1,0 +1,53 @@
+# Example shared namespace configuration
+#<## <-- '#<#' indicates comment characters that are safe to be auto-removed
+#<## by the setup script under certain conditions (when inbox sharing is on)
+
+#<#namespace {
+#<#  type = shared
+#<#  @NAMESPACE_SEPARATOR_CLAUSE@
+#<#
+#<#  # Mailboxes are visible under "shared/user@domain/"
+#<#  # %%n, %%d and %%u are expanded to the destination user.
+#<#  prefix = shared/%%u/
+#<#
+#<#  # Mail location for other users' mailboxes. Note that %variables and ~/
+#<#  # expands to the logged in user's data. %%n, %%d, %%u and %%h expand to the
+#<#  # destination user's data.
+#<#  location = maildir:%%h:INDEX=~/shared/%%u:INDEXPVT=~/shared/%%u
+#<#
+#<#  subscriptions = yes
+#<#
+#<#  # List the shared/ namespace only if there are visible shared mailboxes.
+#<#  list = children
+#<#}
+#<## Should shared INBOX be visible as "shared/user" or "shared/user/INBOX"?
+#<#mail_shared_explicit_inbox = no
+#<#
+#<#
+#<## The ACL plugin is needed for access definitions
+#<#mail_plugins = acl
+#<#protocol imap {
+#<#  mail_plugins = $mail_plugins acl imap_acl
+#<#}
+#<#
+#<#
+#<## This is a suitable default ACL setting
+#<#plugin {
+#<#  # Without global ACLs:
+#<#  acl = vfile
+#<#
+#<#  # With global ACL files in /etc/dovecot/dovecot-acls file (v2.2.11+):
+#<#  # acl = vfile:/etc/dovecot/dovecot-acl
+#<#
+#<#  # If enabled, don't try to find dovecot-acl files from mailbox directories.
+#<#  # This reduces unnecessary disk I/O when only global ACLs are used. (v2.2.31+)
+#<#  # acl_globals_only = yes
+#<#}
+
+
+# You need a dictionary to advertise shared inboxes to clients.
+# Dictionaries can have various backends.
+# You will probably want to customize this, so the dictionary is persistent.
+# plugin {
+# acl_shared_dict = file:/var/mail/dictionary/dict-acl
+# }

--- a/target/share-inbox.sh
+++ b/target/share-inbox.sh
@@ -18,9 +18,9 @@ then
   exit 1
 fi
 
-sharing=$1
+SHARING=$1
 shift
-shared_to=$1
+SHARED_TO=$1
 shift
 
-doveadm acl add -u "${sharing}@${DOMAIN}" 'Inbox' "user=${shared_to}@${DOMAIN}" "$@"
+doveadm acl add -u "${SHARING}@${DOMAIN}" 'Inbox' "user=${SHARED_TO}@${DOMAIN}" "$@"

--- a/target/share-inbox.sh
+++ b/target/share-inbox.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# $1: The source account name
+# $2: The account name of who receives access
+# $3, $4 and so on: list of permissions - one of: lookup read write write-seen write-deleted insert post expunge
+# Call me like this: share_inbox.sh office bob lookup read
+
+DOMAIN=$(hostname -d)
+if [[ "${ENABLE_SHARED_INBOX}" = 0 ]]
+then
+  echo "You have to enable inbox sharing by means of 'ENABLE_SHARED_INBOX' before actually sharing anything." >&2
+  exit 1
+fi
+
+if ! grep -q '\.' <<< "${DOMAIN}"
+then
+  echo "Couldn't detect the target domain - 'hostname -d' returned '${DOMAIN}', which seems to be garbage. Configure the container, so it is aware of its domain" >&2
+  exit 1
+fi
+
+sharing=$1
+shift
+shared_to=$1
+shift
+
+doveadm acl add -u "${sharing}@${DOMAIN}" 'Inbox' "user=${shared_to}@${DOMAIN}" "$@"

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -49,6 +49,9 @@ DEFAULT_VARS["SPAMASSASSIN_SPAM_TO_INBOX"]="${SPAMASSASSIN_SPAM_TO_INBOX:=0}"
 DEFAULT_VARS["MOVE_SPAM_TO_JUNK"]="${MOVE_SPAM_TO_JUNK:=1}"
 DEFAULT_VARS["VIRUSMAILS_DELETE_DELAY"]="${VIRUSMAILS_DELETE_DELAY:=7}"
 DEFAULT_VARS["NETWORK_INTERFACE"]="${NETWORK_INTERFACE:="eth0"}"
+DEFAULT_VARS["ENABLE_SHARED_INBOX"]="${DOVECOT_ENABLE_INBOX_SHARING:=0}"
+DEFAULT_VARS["NAMESPACE_SEPARATOR_CLAUSE"]="separator = ${DOVECOT_NAMESPACE_SEPARATOR}"
+DEFAULT_VARS["SHARED_INBOX_CONFIG"]="11-shared.conf"
 # DEFAULT_VARS["DMS_DEBUG"] defined in helper-functions.sh
 
 ##########################################################################
@@ -131,6 +134,7 @@ function register_functions
 
   _register_setup_function "_setup_docker_permit"
 
+  _register_setup_function "_setup_namespaces"
   _register_setup_function "_setup_mailname"
   _register_setup_function "_setup_amavis"
   _register_setup_function "_setup_dmarc_hostname"
@@ -805,6 +809,30 @@ function _setup_ldap
   fi
 
   return 0
+}
+
+function _setup_namespaces
+{
+  _notify 'inf' "Setting up dovecot namespaces"
+  uncomment_shared_config_contents=no
+  if [[ "${DEFAULT_VARS[ENABLE_SHARED_INBOX]}" = 0 ]]
+  then
+    _notify 'inf' "Shared inboxes are disabled - the '${DEFAULT_VARS[SHARED_INBOX_CONFIG]}' config file is left commented out"
+  else
+    uncomment_shared_config_contents=yes
+  fi
+  if [[ -z "${DOVECOT_NAMESPACE_SEPARATOR}" ]]
+  then
+    [[ "${DEFAULT_VARS[ENABLE_SHARED_INBOX]}" = 1 ]] && _notify 'warn' 'Namespace separator has to be defined in order for shared inboxes to work.'
+    uncomment_shared_config_contents=no
+    NAMESPACE_SEPARATOR_CLAUSE="# ${DEFAULT_VARS[NAMESPACE_SEPARATOR_CLAUSE]}"
+  else
+    NAMESPACE_SEPARATOR_CLAUSE="${DEFAULT_VARS[NAMESPACE_SEPARATOR_CLAUSE]}"
+  fi
+
+  [[ "${uncomment_shared_config_contents}" = yes ]] &&  sed -i -e "s/^#<#//" "/etc/dovecot/conf.d/${DEFAULT_VARS[SHARED_INBOX_CONFIG]}"
+  sed -i -e "s|#@NAMESPACE_SEPARATOR_CLAUSE@|${NAMESPACE_SEPARATOR_CLAUSE}|" /etc/dovecot/conf.d/10-mail.conf
+  sed -i -e "s|@NAMESPACE_SEPARATOR_CLAUSE@|${NAMESPACE_SEPARATOR_CLAUSE}|" "/etc/dovecot/conf.d/${DEFAULT_VARS[SHARED_INBOX_CONFIG]}"
 }
 
 function _setup_postgrey


### PR DESCRIPTION
This PR aims to evolve into a mergeable implementation of support needed to run docker-mailserver with shared inboxes. See #1625 This PR is a draft, so if you decide to give feedback, go for the big picture - a more thorough feedback will become appropriate as the PR gets polished and tested.

The PR uses following means to implement the functionality:

- The `10-mail.conf` has been split in two - the original `10-mail.conf` and `11-shared.conf`. The new file contains configuration that has been commented out in the former file. Contents of the file are commented in a specific way that allows for fully automated uncomment in case of automated setup, or for noop in case that the file is persistent and you have edited it manually.

- New env variables have been added:

  - `DOVECOT_NAMESPACE_SEPARATOR` - historically, this has not been defined, but you need to define it to use shared inboxes. Slash seems to be a good separator.
  - `DOVECOT_ENABLE_INBOX_SHARING` - leave blank or set to 0 to disable, anything else means enable.

  If those are left untouched, the newly implemented functionality doesn't change the setup in any way, i.e. the change is backwards-compatible.

- The startup script substitutes the value of the namespace separator into both new config files, and it uncomments sections of the sharing-related config file if this functionality is requested.

- A script that facilitates inbox sharing has been introduced - `share_inbox.sh `

Steps that the user is supposed to take:

- Define sharing dictionaries - that could be maybe outsourced to a variable as well, but I don't have the expertise to propose this ATM. It is enough to have this snippet in `dovecot.cf`:
  ```
  plugin {
   acl_shared_dict = file:/var/mail/dictionary/dict-acl
  }
  ```

- Share inboxes by executing the script in the container (or calling the container's `doveadm` directly), e.g. 
  ```
  docker-compose exec mail /usr/local/bin/share_inbox.sh office alice lookup read write write-seen
  ```

- Make the sharing config file persistent, and customize it (optional).

Anyway, if you configure the inbox that can access shared inboxes with Thunderbird, you will be able to subscribe to inboxes that are shared to you.