### PR TITLE
silence amavisd-new cron job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,8 +115,8 @@ RUN echo "0 */6 * * * clamav /usr/bin/freshclam --quiet" > /etc/cron.d/clamav-fr
   chown -R clamav:root /var/run/clamav && \
   rm -rf /var/log/clamav/
 
-RUN sed -Ei 's|(^.*sa-sync.*$)|\1 > /dev/null/ 2>\&1|g' /etc/cron.d/amavisd-new && \
-  sed -Ei 's|(^.*sa-clean.*$)|\1 > /dev/null/ 2>\&1|g' /etc/cron.d/amavisd-new
+RUN sed -Ei 's|(^.*sa-sync.*$)|\1 > /dev/null 2>\&1|g' /etc/cron.d/amavisd-new && \
+  sed -Ei 's|(^.*sa-clean.*$)|\1 > /dev/null 2>\&1|g' /etc/cron.d/amavisd-new
 
 # Configures Dovecot
 COPY target/dovecot/auth-passwdfile.inc target/dovecot/??-*.conf /etc/dovecot/conf.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,8 +115,8 @@ RUN echo "0 */6 * * * clamav /usr/bin/freshclam --quiet" > /etc/cron.d/clamav-fr
   chown -R clamav:root /var/run/clamav && \
   rm -rf /var/log/clamav/
 
-RUN sed -Ei 's|(^.*sa-sync.*$)|\1 > /dev/null 2>\&1|g' /etc/cron.d/amavisd-new && \
-  sed -Ei 's|(^.*sa-clean.*$)|\1 > /dev/null 2>\&1|g' /etc/cron.d/amavisd-new
+RUN sed -Ei 's|(^.*sa-sync.*$)|\1 >> /var/log/mail/amavisd-new.log 2>\&1|g' /etc/cron.d/amavisd-new && \
+  sed -Ei 's|(^.*sa-clean.*$)|\1 >> /var/log/mail/amavisd-new.log 2>\&1|g' /etc/cron.d/amavisd-new
 
 # Configures Dovecot
 COPY target/dovecot/auth-passwdfile.inc target/dovecot/??-*.conf /etc/dovecot/conf.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,9 @@ RUN echo "0 */6 * * * clamav /usr/bin/freshclam --quiet" > /etc/cron.d/clamav-fr
   chown -R clamav:root /var/run/clamav && \
   rm -rf /var/log/clamav/
 
+RUN sed -Ei 's|(^.*sa-sync.*$)|\1 > /dev/null/ 2>\&1|g' /etc/cron.d/amavisd-new && \
+  sed -Ei 's|(^.*sa-clean.*$)|\1 > /dev/null/ 2>\&1|g' /etc/cron.d/amavisd-new
+
 # Configures Dovecot
 COPY target/dovecot/auth-passwdfile.inc target/dovecot/??-*.conf /etc/dovecot/conf.d/
 COPY target/dovecot/scripts/quota-warning.sh /usr/local/bin/quota-warning.sh


### PR DESCRIPTION
This is to fix issue #1224. The amavisd-new cron job, installed by the amavisd-new Debian package, is just noisy. The code that ultimately gets called is the function create_default_prefs on line 1997 of https://github.com/apache/spamassassin/blob/cf0449823c873fa27db112509c78e180957646d3/lib/Mail/SpamAssassin.pm, which issues a warning in essentially all cases. This leads to the cron job trying to email the amavis system user with this output, which fails and produces lots of garbage in the logs. This PR shuts the job up, stopping that chain of events. Please feel free to dump the output to a log file if you like, I sent it to /dev/null/ as it looks relatively worthless to me.

