### PR TITLE
silence errorneous output when not generating reports

### DIFF
--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -170,8 +170,8 @@ function register_functions
   _register_setup_function "_setup_environment"
   _register_setup_function "_setup_logrotate"
 
-  [[ ${PFLOGSUMM_TRIGGER} != "none" ]] && _register_setup_function "_setup_mail_summary"
-  [[ ${LOGWATCH_TRIGGER} != "none" ]] && _register_setup_function "_setup_logwatch"
+  [[ ${PFLOGSUMM_TRIGGER:="none"} != "none" ]] && _register_setup_function "_setup_mail_summary"
+  [[ ${LOGWATCH_INTERVAL:="none"} != "none" ]] && _register_setup_function "_setup_logwatch"
 
   _register_setup_function "_setup_user_patches"
 

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -170,8 +170,8 @@ function register_functions
   _register_setup_function "_setup_environment"
   _register_setup_function "_setup_logrotate"
 
-  [[ ${PFLOGSUMM_TRIGGER:="none"} != "none" ]] && _register_setup_function "_setup_mail_summary"
-  [[ ${LOGWATCH_INTERVAL:="none"} != "none" ]] && _register_setup_function "_setup_logwatch"
+  [[ ${PFLOGSUMM_TRIGGER:-"none"} != "none" ]] && _register_setup_function "_setup_mail_summary"
+  [[ ${LOGWATCH_INTERVAL:-"none"} != "none" ]] && _register_setup_function "_setup_logwatch"
 
   _register_setup_function "_setup_user_patches"
 

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1725,7 +1725,7 @@ function _setup_mail_summary
       _notify 'inf' "Add postrotate action for pflogsumm report"
       sed -i "s|}|  postrotate\n    /usr/local/bin/postfix-summary ${HOSTNAME} ${PFLOGSUMM_RECIPIENT} ${PFLOGSUMM_SENDER}\n  endscript\n}\n|" /etc/logrotate.d/maillog
       ;;
-    "none" ) _notify 'warn' "Postfix log summary reports disabled. You can enable them with 'PFLOGSUMM_TRIGGER=daily_cron' or 'PFLOGSUMM_TRIGGER=logrotate'" ;;
+    "none" ) _notify 'inf' "Postfix log summary reports disabled. You can enable them with 'PFLOGSUMM_TRIGGER=daily_cron' or 'PFLOGSUMM_TRIGGER=logrotate'" ;;
     * ) _notify 'err' 'PFLOGSUMM_TRIGGER not found in _setup_mail_summery' ;;
   esac
 }
@@ -1751,7 +1751,7 @@ function _setup_logwatch
       >> /etc/cron.weekly/logwatch
       chmod 744 /etc/cron.weekly/logwatch
       ;;
-    "none" ) _notify 'warn' "Logwatch reports disabled. You can enable them with 'LOGWATCH_INTERVAL=daily' or 'LOGWATCH_INTERVAL=weekly'" ;;
+    "none" ) _notify 'inf' "Logwatch reports disabled. You can enable them with 'LOGWATCH_INTERVAL=daily' or 'LOGWATCH_INTERVAL=weekly'" ;;
     * ) _notify 'warn' 'LOGWATCH_INTERVAL not found in _setup_logwatch' ;;
   esac
 }

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -170,8 +170,8 @@ function register_functions
   _register_setup_function "_setup_environment"
   _register_setup_function "_setup_logrotate"
 
-  [[ ${PFLOGSUMM_TRIGGER:-"none"} != "none" ]] && _register_setup_function "_setup_mail_summary"
-  [[ ${LOGWATCH_INTERVAL:-"none"} != "none" ]] && _register_setup_function "_setup_logwatch"
+  _register_setup_function "_setup_mail_summary"
+  _register_setup_function "_setup_logwatch"
 
   _register_setup_function "_setup_user_patches"
 
@@ -1725,6 +1725,7 @@ function _setup_mail_summary
       _notify 'inf' "Add postrotate action for pflogsumm report"
       sed -i "s|}|  postrotate\n    /usr/local/bin/postfix-summary ${HOSTNAME} ${PFLOGSUMM_RECIPIENT} ${PFLOGSUMM_SENDER}\n  endscript\n}\n|" /etc/logrotate.d/maillog
       ;;
+    "none" ) _notify 'warn' "Postfix log summary reports disabled. You can enable them with 'PFLOGSUMM_TRIGGER=daily_cron' or 'PFLOGSUMM_TRIGGER=logrotate'" ;;
     * ) _notify 'err' 'PFLOGSUMM_TRIGGER not found in _setup_mail_summery' ;;
   esac
 }
@@ -1750,6 +1751,7 @@ function _setup_logwatch
       >> /etc/cron.weekly/logwatch
       chmod 744 /etc/cron.weekly/logwatch
       ;;
+    "none" ) _notify 'warn' "Logwatch reports disabled. You can enable them with 'LOGWATCH_INTERVAL=daily' or 'LOGWATCH_INTERVAL=weekly'" ;;
     * ) _notify 'warn' 'LOGWATCH_INTERVAL not found in _setup_logwatch' ;;
   esac
 }


### PR DESCRIPTION
Another small PR in my efforts to get the logs clean. The documentation states that for the postfix and logwatch reports, we should set PFLOGSUMM_TRIGGER and LOGWATCH_INTERVAL to empty (the defaults) to not generate those reports. When doing this, the functions _setup_mail_summary and _setup_logwatch get called and generate the erroneous output:

Error PFLOGSUMM_TRIGGER not found in _setup_mail_summery
Warning LOGWATCH_INTERVAL not found in _setup_logwatch 

This PR corrects the start-mailserver.sh script to not call those function in the case that we are not generating reports. I tested it with a container build and run both with and without the changes and the log lines disappear when the changes are present.