### PR TITLE
fix: Use correct `imap` service for Fail2Ban Dovecot config

### DIFF
--- a/target/fail2ban/jail.conf
+++ b/target/fail2ban/jail.conf
@@ -549,7 +549,7 @@ logpath = /service/qmail/log/main/current
 # but can be set by syslog_facility in the dovecot configuration.
 [dovecot]
 
-port    = pop3,pop3s,imap,imaps,submission,465,sieve
+port    = pop3,pop3s,imap2,imaps,submission,465,sieve
 logpath = /var/log/mail/mail.log
 enabled = true
 
@@ -580,7 +580,7 @@ logpath = %(exim_main_log)s
 
 [kerio]
 
-port    = imap,smtp,imaps,465
+port    = imap2,smtp,imaps,465
 logpath = /opt/kerio/mailserver/store/logs/security.log
 
 
@@ -613,7 +613,7 @@ logpath = %(syslog_mail)s
 
 [squirrelmail]
 
-port = smtp,465,submission,imap2,imap2,imaps,pop3,pop3s,http,https,socks
+port = smtp,465,submission,imap2,imaps,pop3,pop3s,http,https,socks
 logpath = /var/lib/squirrelmail/prefs/squirrelmail_access_log
 
 


### PR DESCRIPTION
While this change really only affects Dovecot (since most of this config seems to be irrelevant), `imap` does not have a service entry in `/etc/services` ([which is what the service names map to](https://serverfault.com/a/522203/596986)), it seems these were missed during the [2018 switch to a Debian base image](https://github.com/tomav/docker-mailserver/pull/784/commits/6f7af23e271c0468418d6eca547c5824a9eff149) from the previous [Ubuntu base image which had added these additions in 2016](https://github.com/tomav/docker-mailserver/issues/152).

Technically, as the config file itself states at the top of the file, any changes should be done as separate config files to override the base config. Unclear why that was not respected, a better PR might be to diff against the base config that's actually shipped instead of overwriting it, and ship those as separate config files as Fail2Ban advises?

I've not verified, but presumably `imap` in the current config for Dovecot, shouldn't match port 143 and thus not trigger Fail2Ban, only `imaps` on port 993. `docker exec` into a running image of `tvial/docker-mailserver` has the following:

```
$ grep imap /etc/services            
imap2           143/tcp         imap            # Interim Mail Access P 2 and 4
imaps           993/tcp                         # IMAP over SSL
```

On Manjaro (and presumably Ubuntu), `imap2` is `imap`, so this is something that should be kept in mind if changing base images again in future.