### PR TITLE
Add additional pem file for _monitored_files_checksums

### DIFF
--- a/target/helper-functions.sh
+++ b/target/helper-functions.sh
@@ -202,6 +202,7 @@ function _monitored_files_checksums
       dovecot-quotas.cf \
       /etc/letsencrypt/acme.json \
       "/etc/letsencrypt/live/${HOSTNAME}/key.pem" \
+      "/etc/letsencrypt/live/${HOSTNAME}/privkey.pem" \
       "/etc/letsencrypt/live/${HOSTNAME}/fullchain.pem"
   )
 }


### PR DESCRIPTION
Hi,

[start-mailserver.sh](https://github.com/tomav/docker-mailserver/blob/master/target/start-mailserver.sh#L1113
) checks if private key "privkey.pem" or "key.pem"
but [helper-functions.sh](https://github.com/tomav/docker-mailserver/blob/master/target/helper-functions.sh#L204) monitors only key.pem 
My certbot generates only "privkey.pem" thats why, there could be issues while updating private key.