### PR TITLE
Small fixes for extracting certs from the acme.json file

### DIFF
--- a/target/helper-functions.sh
+++ b/target/helper-functions.sh
@@ -56,11 +56,12 @@ import sys,json
 acme = json.load(sys.stdin)
 for key, value in acme.items():
     certs = value['Certificates']
-    for cert in certs:
-        if 'domain' in cert and 'key' in cert:
-            if 'main' in cert['domain'] and cert['domain']['main'] == '${1}' or 'sans' in cert['domain'] and '${1}' in cert['domain']['sans']:
-                print cert['key']
-                break
+    if certs is not None:
+        for cert in certs:
+            if 'domain' in cert and 'key' in cert:
+                if 'main' in cert['domain'] and cert['domain']['main'] == '${1}' or 'sans' in cert['domain'] and '${1}' in cert['domain']['sans']:
+                    print cert['key']
+                    break
 ")
 
   local CERT
@@ -70,11 +71,12 @@ import sys,json
 acme = json.load(sys.stdin)
 for key, value in acme.items():
     certs = value['Certificates']
-    for cert in certs:
-        if 'domain' in cert and 'certificate' in cert:
-            if 'main' in cert['domain'] and cert['domain']['main'] == '${1}' or 'sans' in cert['domain'] and '${1}' in cert['domain']['sans']:
-                print cert['certificate']
-                break
+    if certs is not None:
+        for cert in certs:
+            if 'domain' in cert and 'certificate' in cert:
+                if 'main' in cert['domain'] and cert['domain']['main'] == '${1}' or 'sans' in cert['domain'] and '${1}' in cert['domain']['sans']:
+                    print cert['certificate']
+                    break
 ")
 
   if [[ -n "${KEY}${CERT}" ]]

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1095,7 +1095,7 @@ function _setup_ssl
       local LETSENCRYPT_DOMAIN=""
       local LETSENCRYPT_KEY=""
 
-      [[ -f /etc/letsencrypt/acme.json ]] && (_extract_certs_from_acme "${HOSTNAME}" || _extract_certs_from_acme "${DOMAINNAME}")
+      [[ -f /etc/letsencrypt/acme.json ]] && (_extract_certs_from_acme "${SSL_DOMAIN}" || _extract_certs_from_acme "${HOSTNAME}" || _extract_certs_from_acme "${DOMAINNAME}")
 
       # first determine the letsencrypt domain by checking both the full hostname or just the domainname if a SAN is used in the cert
       if [[ -e /etc/letsencrypt/live/${HOSTNAME}/fullchain.pem ]]

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1095,7 +1095,16 @@ function _setup_ssl
       local LETSENCRYPT_DOMAIN=""
       local LETSENCRYPT_KEY=""
 
-      [[ -f /etc/letsencrypt/acme.json ]] && (_extract_certs_from_acme "${SSL_DOMAIN}" || _extract_certs_from_acme "${HOSTNAME}" || _extract_certs_from_acme "${DOMAINNAME}")
+      if [[ -f /etc/letsencrypt/acme.json ]]
+      then
+        if ! _extract_certs_from_acme "${SSL_DOMAIN}"
+        then
+          if ! _extract_certs_from_acme "${HOSTNAME}"
+          then
+            _extract_certs_from_acme "${DOMAINNAME}"
+          fi
+        fi
+      fi
 
       # first determine the letsencrypt domain by checking both the full hostname or just the domainname if a SAN is used in the cert
       if [[ -e /etc/letsencrypt/live/${HOSTNAME}/fullchain.pem ]]

--- a/test/config/letsencrypt/acme.json
+++ b/test/config/letsencrypt/acme.json
@@ -1,4 +1,8 @@
 {
+  "empty": {
+    "Account": null,
+    "Certificates": null
+  },
   "le": {
     "Account": {
       "Email": "acme@admin.com",


### PR DESCRIPTION
As I wanted to setup TLS with certificates provided by traefik I ran into two small bugs:

The first was a python exception. I have an acme.json containing sections which look like:
```
  "httpChallenge": {
    "Account": null,
    "Certificates": null
  }
```
The script didn't test if `Certificates` was `null`.

The second problem was that the environment variable `SSL_DOMAIN` was only used while watching for changes in the acme.json, not during start-up.

Both bugs are fixed with this PR.