### PR TITLE
Add more config options to saslauthd.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,6 +808,30 @@ Note: This postgrey setting needs `ENABLE_POSTGREY=1`
 - empty or 0 => `ldap://` will be used
 - 1 => `ldaps://` will be used
 
+##### SASLAUTHD_LDAP_START_TLS
+
+- **empty** => `no`
+- `yes` => Enable `ldap_start_tls` option
+
+##### SASLAUTHD_LDAP_TLS_CHECK_PEER
+
+- **empty** => `no`
+- `yes` => Enable `ldap_tls_check_peer` option
+
+##### SASLAUTHD_LDAP_TLS_CACERT_DIR
+
+Path to directory with CA (Certificate Authority) certificates.
+
+- **empty** => Nothing is added to the configuration
+- Any value => Fills the `ldap_tls_cacert_dir` option
+
+##### SASLAUTHD_LDAP_TLS_CACERT_FILE
+
+File containing CA (Certificate Authority) certificate(s).
+
+- **empty** => Nothing is added to the configuration
+- Any value => Fills the `ldap_tls_cacert_file` option
+
 ##### SASLAUTHD_LDAP_BIND_DN
 
 - empty => anonymous bind

--- a/README.md
+++ b/README.md
@@ -854,10 +854,30 @@ File containing CA (Certificate Authority) certificate(s).
 - e.g. for active directory: `(&(sAMAccountName=%U)(objectClass=person))`
 - e.g. for openldap: `(&(uid=%U)(objectClass=person))`
 
+##### SASLAUTHD_LDAP_PASSWORD_ATTR
+
+Specify what password attribute to use for password verification.
+
+- **empty** => Nothing is added to the configuration but the documentation says it is `userPassword` by default.
+- Any value => Fills the `ldap_password_attr` option
+
 ##### SASL_PASSWD
 
 - **empty** => No sasl_passwd will be created
 - string => `/etc/postfix/sasl_passwd` will be created with the string as password
+
+##### SASLAUTHD_LDAP_AUTH_METHOD
+
+- **empty** => `bind` will be used as a default value
+- `fastbind` => The fastbind method is used
+- `custom` => The custom method uses userPassword attribute to verify the password
+
+##### SASLAUTHD_LDAP_MECH
+
+Specify the authentication mechanism for SASL bind.
+
+- **empty** => Nothing is added to the configuration
+- Any value => Fills the `ldap_mech` option
 
 #### SRS (Sender Rewriting Scheme)
 

--- a/mailserver.env
+++ b/mailserver.env
@@ -356,9 +356,24 @@ SASLAUTHD_LDAP_TLS_CACERT_FILE=
 # Any value => Fills the `ldap_tls_cacert_dir` option
 SASLAUTHD_LDAP_TLS_CACERT_DIR=
 
+# Specify what password attribute to use for password verification.
+# empty => Nothing is added to the configuration but the documentation says it is `userPassword` by default.
+# Any value => Fills the `ldap_password_attr` option
+SASLAUTHD_LDAP_PASSWORD_ATTR=
+
 # empty => No sasl_passwd will be created
 # string => `/etc/postfix/sasl_passwd` will be created with the string as password
 SASL_PASSWD=
+
+# empty => `bind` will be used as a default value
+# `fastbind` => The fastbind method is used
+# `custom` => The custom method uses userPassword attribute to verify the password
+SASLAUTHD_LDAP_AUTH_METHOD=
+
+# Specify the authentication mechanism for SASL bind
+# empty => Nothing is added to the configuration
+# Any value => Fills the `ldap_mech` option
+SASLAUTHD_LDAP_MECH=
 
 # –––––––––––––––––––––––––––––––––––––––––––––––
 # ––– SRS Section –––––––––––––––––––––––––––––––

--- a/mailserver.env
+++ b/mailserver.env
@@ -343,7 +343,18 @@ SASLAUTHD_LDAP_START_TLS=
 
 # empty => no
 # yes => Require and verify server certificate
+# If yes you must/could specify SASLAUTHD_LDAP_TLS_CACERT_FILE or SASLAUTHD_LDAP_TLS_CACERT_DIR.
 SASLAUTHD_LDAP_TLS_CHECK_PEER=
+
+# File containing CA (Certificate Authority) certificate(s).
+# empty => Nothing is added to the configuration
+# Any value => Fills the `ldap_tls_cacert_file` option
+SASLAUTHD_LDAP_TLS_CACERT_FILE=
+
+# Path to directory with CA (Certificate Authority) certificates.
+# empty => Nothing is added to the configuration
+# Any value => Fills the `ldap_tls_cacert_dir` option
+SASLAUTHD_LDAP_TLS_CACERT_DIR=
 
 # empty => No sasl_passwd will be created
 # string => `/etc/postfix/sasl_passwd` will be created with the string as password

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -917,6 +917,7 @@ function _setup_saslauthd
 
   [[ -z ${SASLAUTHD_LDAP_START_TLS} ]] && SASLAUTHD_LDAP_START_TLS=no
   [[ -z ${SASLAUTHD_LDAP_TLS_CHECK_PEER} ]] && SASLAUTHD_LDAP_TLS_CHECK_PEER=no
+  [[ -z ${SASLAUTHD_LDAP_AUTH_METHOD} ]] && SASLAUTHD_LDAP_AUTH_METHOD=bind
 
   if [[ -z ${SASLAUTHD_LDAP_TLS_CACERT_FILE} ]]
   then
@@ -932,13 +933,27 @@ function _setup_saslauthd
     SASLAUTHD_LDAP_TLS_CACERT_DIR="ldap_tls_cacert_dir: ${SASLAUTHD_LDAP_TLS_CACERT_DIR}"
   fi
 
+  if [[ -z ${SASLAUTHD_LDAP_PASSWORD_ATTR} ]]
+  then
+    SASLAUTHD_LDAP_PASSWORD_ATTR=""
+  else
+    SASLAUTHD_LDAP_PASSWORD_ATTR="ldap_password_attr: ${SASLAUTHD_LDAP_PASSWORD_ATTR}"
+  fi
+
+  if [[ -z ${SASLAUTHD_LDAP_MECH} ]]
+  then
+    SASLAUTHD_LDAP_MECH=""
+  else
+    SASLAUTHD_LDAP_MECH="ldap_mech: ${SASLAUTHD_LDAP_MECH}"
+  fi
+
   if [[ ! -f /etc/saslauthd.conf ]]
   then
     _notify 'inf' "Creating /etc/saslauthd.conf"
     cat > /etc/saslauthd.conf << EOF
 ldap_servers: ${SASLAUTHD_LDAP_PROTO}${SASLAUTHD_LDAP_SERVER}
 
-ldap_auth_method: bind
+ldap_auth_method: ${SASLAUTHD_LDAP_AUTH_METHOD}
 ldap_bind_dn: ${SASLAUTHD_LDAP_BIND_DN}
 ldap_bind_pw: ${SASLAUTHD_LDAP_PASSWORD}
 
@@ -950,6 +965,8 @@ ldap_tls_check_peer: ${SASLAUTHD_LDAP_TLS_CHECK_PEER}
 
 ${SASLAUTHD_LDAP_TLS_CACERT_FILE}
 ${SASLAUTHD_LDAP_TLS_CACERT_DIR}
+${SASLAUTHD_LDAP_PASSWORD_ATTR}
+${SASLAUTHD_LDAP_MECH}
 
 ldap_referrals: yes
 log_level: 10

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -918,6 +918,20 @@ function _setup_saslauthd
   [[ -z ${SASLAUTHD_LDAP_START_TLS} ]] && SASLAUTHD_LDAP_START_TLS=no
   [[ -z ${SASLAUTHD_LDAP_TLS_CHECK_PEER} ]] && SASLAUTHD_LDAP_TLS_CHECK_PEER=no
 
+  if [[ -z ${SASLAUTHD_LDAP_TLS_CACERT_FILE} ]]
+  then
+    SASLAUTHD_LDAP_TLS_CACERT_FILE=""
+  else
+    SASLAUTHD_LDAP_TLS_CACERT_FILE="ldap_tls_cacert_file: ${SASLAUTHD_LDAP_TLS_CACERT_FILE}"
+  fi
+
+  if [[ -z ${SASLAUTHD_LDAP_TLS_CACERT_DIR} ]]
+  then
+    SASLAUTHD_LDAP_TLS_CACERT_DIR=""
+  else
+    SASLAUTHD_LDAP_TLS_CACERT_DIR="ldap_tls_cacert_dir: ${SASLAUTHD_LDAP_TLS_CACERT_DIR}"
+  fi
+
   if [[ ! -f /etc/saslauthd.conf ]]
   then
     _notify 'inf' "Creating /etc/saslauthd.conf"
@@ -933,6 +947,9 @@ ldap_filter: ${SASLAUTHD_LDAP_FILTER}
 
 ldap_start_tls: ${SASLAUTHD_LDAP_START_TLS}
 ldap_tls_check_peer: ${SASLAUTHD_LDAP_TLS_CHECK_PEER}
+
+${SASLAUTHD_LDAP_TLS_CACERT_FILE}
+${SASLAUTHD_LDAP_TLS_CACERT_DIR}
 
 ldap_referrals: yes
 log_level: 10


### PR DESCRIPTION
Follow up of: #980
Fixes: #1704

- SASLAUTHD_LDAP_TLS_CACERT_FILE => ldap_tls_cacert_file
- SASLAUTHD_LDAP_TLS_CACERT_DIR => ldap_tls_cacert_dir
- SASLAUTHD_LDAP_PASSWORD_ATTR => ldap_password_attr
- SASLAUTHD_LDAP_AUTH_METHOD => ldap_auth_method
- SASLAUTHD_LDAP_MECH => ldap_mech

Note: actually I have to have 2 values for the `userPassword` attribute in my LDAP because sasl will not authenticate using my ssha256 stored password value, this pull-request is my hope to address my current issue.

Documentations used:
- https://opensource.apple.com/source/passwordserver_sasl/passwordserver_sasl-209/cyrus_sasl/saslauthd/LDAP_SASLAUTHD.auto.html
- https://github.com/winlibs/cyrus-sasl/blob/master/saslauthd/LDAP_SASLAUTHD
- https://blog.sys4.de/cyrus-sasl-saslauthdconf-man-page-en.html
- http://web.mit.edu/ghudson/dev/third/cyrus-sasl/saslauthd/LDAP_SASLAUTHD