### PR TITLE
Get rid of syslogd warnings about kernel logging.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -222,7 +222,7 @@ RUN sed -i -r "/^#?compress/c\compress\ncopytruncate" /etc/logrotate.conf && \
   sed -i -e 's/^\(POLICYHELPER=\).*/\1/' /usr/sbin/invoke-rc.d && \
   # Prevent syslog warning about imklog permissions.
   # We won't want to look at that inside a container anyway.
-  sed -i -e 's/^module\(load="imklog"\)/#module\(load="imklog"\)/' /etc/rsyslog.conf && \
+  sed -i -e 's/^module(load=\"imklog\")/#module(load=\"imklog\")/' /etc/rsyslog.conf && \
   # prevent email when /sbin/init or init system is not existing \
   sed -i -e 's|invoke-rc.d rsyslog rotate > /dev/null|/usr/bin/supervisorctl signal hup rsyslog >/dev/null|g' /usr/lib/rsyslog/rsyslog-rotate
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -220,6 +220,9 @@ RUN sed -i -r "/^#?compress/c\compress\ncopytruncate" /etc/logrotate.conf && \
   # prevent syslog logrotate warnings \
   sed -i -e 's/\(printerror "could not determine current runlevel"\)/#\1/' /usr/sbin/invoke-rc.d && \
   sed -i -e 's/^\(POLICYHELPER=\).*/\1/' /usr/sbin/invoke-rc.d && \
+  # Prevent syslog warning about imklog permissions.
+  # We won't want to look at that inside a container anyway.
+  sed -i -e 's/^module\(load="imklog"\)/#module\(load="imklog"\)/' /etc/rsyslog.conf && \
   # prevent email when /sbin/init or init system is not existing \
   sed -i -e 's|invoke-rc.d rsyslog rotate > /dev/null|/usr/bin/supervisorctl signal hup rsyslog >/dev/null|g' /usr/lib/rsyslog/rsyslog-rotate
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ chmod a+x ./setup.sh
 docker-compose up -d mail
 
 ./setup.sh email add <user@domain> [<password>]
+./setup.sh alias add postmaster@<domain> <user@domain>
 ./setup.sh config dkim
 ```
 
@@ -131,6 +132,7 @@ Edit the files `.env` and `docker-compose.yml`. In `.env` uncomment the variable
 docker-compose up -d mail
 
 ./setup.sh -Z email add <user@domain> [<password>]
+./setup.sh -Z alias add postmaster@<domain> <user@domain>
 ./setup.sh -Z config dkim
 ```
 

--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -10,8 +10,6 @@ readme_directory = no
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
 mydestination = $myhostname, localhost.$mydomain, localhost
-# Uncomment for container accounts to masquerade as the domain instead of the host
-# myorigin = $mydomain
 relayhost =
 mynetworks = 127.0.0.0/8 [::1]/128 [fe80::]/64
 mailbox_size_limit = 0

--- a/target/postfix/main.cf
+++ b/target/postfix/main.cf
@@ -10,6 +10,8 @@ readme_directory = no
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
 mydestination = $myhostname, localhost.$mydomain, localhost
+# Uncomment for container accounts to masquerade as the domain instead of the host
+# myorigin = $mydomain
 relayhost =
 mynetworks = 127.0.0.0/8 [::1]/128 [fe80::]/64
 mailbox_size_limit = 0


### PR DESCRIPTION
- Modify Dockerfile to comment out noisy/errant kernel logging line in /etc/rsyslogd.conf
- Add lines in README.md that prompt users to create an alias that captures messages to postmaster.
- Add commented line in /etc/postfix/main.cf to easily set 'myorigin=$mydomain' if desired.  Then e.g. postmaster emails will be addressed from "postmaster@domain.tld" instead of "postmaster@host.domain.tld".  This may require a regex or an additional or modified virtual alias for postfix to accept mail from such an address.  I have not documented that in these patches.  If people watch mail.log it will be clear.