### PR TITLE
Add sieve-execute

### DIFF
--- a/target/dovecot/90-sieve.conf
+++ b/target/dovecot/90-sieve.conf
@@ -51,7 +51,7 @@ plugin {
   # deprecated imapflags extension in addition to all extensions were already
   # enabled by default.
   #sieve_extensions = +notify +imapflags
-  sieve_extensions = +notify +imapflags +vnd.dovecot.pipe +vnd.dovecot.filter
+  sieve_extensions = +notify +imapflags +vnd.dovecot.pipe +vnd.dovecot.filter +vnd.dovecot.execute
 
   # Which Sieve language extensions are ONLY available in global scripts. This
   # can be used to restrict the use of certain Sieve extensions to administrator
@@ -108,4 +108,5 @@ plugin {
   # Locations of programs that can be called by the sieve_extprograms plugin
   sieve_pipe_bin_dir = /usr/lib/dovecot/sieve-pipe
   sieve_filter_bin_dir = /usr/lib/dovecot/sieve-filter
+  sieve_execute_bin_dir = /usr/lib/dovecot/sieve-execute
 }


### PR DESCRIPTION
Modified Sieve configuration to include the `vnd.dovecot.execute` extension, and added `sieve_execute_bin_dir` (similar to `sieve_pipe_bin_dir`)

What's left is to copy files from `config/sieve-execute` to `/usr/lib/dovecot/sieve-execute`. I'll push commits for this in the next few days.

See: https://wiki2.dovecot.org/Pigeonhole/Sieve/Plugins/Extprograms