### PR TITLE
Allow manual domains for dkim generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,20 @@ docker-compose up -d mail
 
 ### Miscellaneous
 
+### DKIM manual domain mode
+
+LDAP setups would need to use this mode because the user accounts are not in `postfix-accounts.cf` or `postfix-virtual.cf`.
+
+``` BASH
+# without SELinux
+docker-compose up -d mail
+./setup.sh config dkim 2048 'domain1.com,domain2.fr'
+
+# with SELinux
+docker-compose up -d mail
+./setup.sh -Z config dkim 2048 'domain1.com,domain2.fr'
+```
+
 #### DNS - DKIM
 
 Now that the keys are generated, you can configure your DNS server by just pasting the content of `config/opendkim/keys/domain.tld/mail.txt` in your `domain.tld.hosts` zone.

--- a/setup.sh
+++ b/setup.sh
@@ -329,13 +329,13 @@ function _main
       shift ; case ${1:-} in
         set      ) shift ; _docker_image setquota "${@}" ;;
         del      ) shift ; _docker_image delquota "${@}" ;;
-        *        )   _usage ;;
+        *        ) _usage ;;
       esac
       ;;
 
     config)
       shift ; case ${1:-} in
-        dkim     ) _docker_image generate-dkim-config "${2:-2048}" ;;
+        dkim     ) _docker_image generate-dkim-config "${2:-2048}" "${3:-}" ;;
         ssl      ) _docker_image generate-ssl-certificate "${2}" ;;
         *        ) _usage ;;
       esac

--- a/target/bin/generate-dkim-config
+++ b/target/bin/generate-dkim-config
@@ -4,29 +4,36 @@ touch /tmp/vhost.tmp
 
 # if no keysize is provided, 2048 is default.
 KEYSIZE=${1:-2048}
+# optional domain names
+DOMAINS="${2:-''}"
 
-# Getting domains FROM mail accounts
-if [[ -f /tmp/docker-mailserver/postfix-accounts.cf ]]
+if [[ -z "${DOMAINS}" ]]
 then
-  # shellcheck disable=SC2034
-  while IFS=$'|' read -r LOGIN PASS
-  do
-    DOMAIN=$(echo "${LOGIN}" | cut -d @ -f2)
-    echo "${DOMAIN}" >>/tmp/vhost.tmp
-  done < <(grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-accounts.cf || true)
-fi
+    # Getting domains FROM mail accounts
+    if [[ -f /tmp/docker-mailserver/postfix-accounts.cf ]]
+    then
+        # shellcheck disable=SC2034
+        while IFS=$'|' read -r LOGIN PASS
+        do
+            DOMAIN=$(echo "${LOGIN}" | cut -d @ -f2)
+            echo "${DOMAIN}" >>/tmp/vhost.tmp
+        done < <(grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-accounts.cf || true)
+    fi
 
-# Getting domains FROM mail aliases
-if [[ -f /tmp/docker-mailserver/postfix-virtual.cf ]]
-then
-  # shellcheck disable=SC2034
-  while read -r FROM TO
-  do
-    UNAME=$(echo "${FROM}" | cut -d @ -f1)
-    DOMAIN=$(echo "${FROM}" | cut -d @ -f2)
+        # Getting domains FROM mail aliases
+    if [[ -f /tmp/docker-mailserver/postfix-virtual.cf ]]
+    then
+        # shellcheck disable=SC2034
+        while read -r FROM TO
+        do
+            UNAME=$(echo "${FROM}" | cut -d @ -f1)
+            DOMAIN=$(echo "${FROM}" | cut -d @ -f2)
 
-    test "${UNAME}" != "${DOMAIN}" && echo "${DOMAIN}" >>/tmp/vhost.tmp
-  done < <(grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-virtual.cf || true)
+            test "${UNAME}" != "${DOMAIN}" && echo "${DOMAIN}" >>/tmp/vhost.tmp
+        done < <(grep -v "^\s*$\|^\s*\#" /tmp/docker-mailserver/postfix-virtual.cf || true)
+    fi
+else
+    tr ',' '\n' <<<"${DOMAINS}" > /tmp/vhost.tmp
 fi
 
 # keeping unique entries


### PR DESCRIPTION
Fix #1735 - The dkim key generator does not work for ldap setups 