### PR TITLE
fix(setup.sh): Add legacy config path check

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -12,6 +12,7 @@ DESIRED_CONFIG_PATH=
 DIR="$(pwd)"
 DMS_CONFIG='/tmp/docker-mailserver'
 IMAGE_NAME=
+DEFAULT_IMAGE_NAME='docker.io/mailserver/docker-mailserver:latest'
 INFO=
 PODMAN_ROOTLESS=false
 USE_SELINUX=
@@ -49,7 +50,7 @@ function _show_local_usage
     ${LBLUE}Config path, container or image adjustments${RESET}
         -i IMAGE_NAME
             Provides the name of the 'docker-mailserver' image. The default value is
-            '${WHITE}docker.io/mailserver/docker-mailserver:latest${RESET}'
+            '${WHITE}${DEFAULT_IMAGE_NAME}${RESET}'
 
         -c CONTAINER_NAME
             Provides the name of the running container.
@@ -215,7 +216,7 @@ function _main
   [[ -z ${IMAGE_NAME} ]] && IMAGE_NAME=${INFO%;*}
   if [[ -z ${IMAGE_NAME} ]]
   then
-    IMAGE_NAME=${NAME:-docker.io/mailserver/docker-mailserver:latest}
+    IMAGE_NAME=${NAME:-${DEFAULT_IMAGE_NAME}}
   fi
 
   if test -t 0


### PR DESCRIPTION
# Description

The default `config` path was changed in #2206. This fix takes care of that.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #2247

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
