### PR TITLE
docs: Add warning about broken apple push notifications support

### DIFF
--- a/docs/content/examples/use-cases/ios-mail-push-support.md
+++ b/docs/content/examples/use-cases/ios-mail-push-support.md
@@ -2,11 +2,14 @@
 title: 'Advanced | iOS Mail Push Support'
 ---
 
-!!! warning "This is broken as of August 2025"
+!!! warning "Status - August 2025"
 
-    Apple has deprecated the API used for certificate renewal as it is currently implemented in dovecot-xaps-daemon for XAPPLEPUSHSERVICE. There is no fix available at the time this is being written; however, [Apple has indicated](https://github.com/stalwartlabs/stalwart/issues/747#issuecomment-3142925679) to some developers that an open IETF standard for push notifications is planned. There is an [open Apple Developer thread](https://developer.apple.com/forums/thread/778671?answerId=850357022#850357022) about this topic as well.
+    Apple has since deprecated their API used for certificate renewal (_see [this Apple Developer thread][apple::dev-push-issue-reference]_) as it is currently implemented in `dovecot-xaps-daemon` for `XAPPLEPUSHSERVICE`. There is no actionable resolution for this issue known at this time.
 
-!!! warning
+    [Apple has communicated plans][apple::push-open-standard] to implement an open IETF standard for push notifications.
+
+[apple::dev-push-issue-reference]: https://developer.apple.com/forums/thread/778671?answerId=850357022#850357022
+[apple::push-open-standard]: https://github.com/stalwartlabs/stalwart/issues/747#issuecomment-3142925679
 
 ## Introduction
 


### PR DESCRIPTION


# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->
Seems like this is planned to be fixed by Apple in the near future, so I don't know if it's worth deleting the whole page. I'm just adding a note in the meantime.

## Type of change

<!-- Delete options that are not relevant. -->

- [X] This change requires a documentation update

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
