### PR TITLE
tests: Temoporary fix for LDAP via Bitnami Legacy

### DIFF
--- a/test/tests/serial/mail_with_ldap.bats
+++ b/test/tests/serial/mail_with_ldap.bats
@@ -21,6 +21,7 @@ function setup_file() {
   docker network create "${DMS_TEST_NETWORK}"
 
   # Setup local openldap service:
+  # TODO: Migrate away from `bitnamilegacy/openldap`: https://github.com/docker-mailserver/docker-mailserver/issues/4582
   docker run --rm -d --name "${CONTAINER2_NAME}" \
     --env LDAP_ADMIN_PASSWORD=admin \
     --env LDAP_ROOT='dc=example,dc=test' \
@@ -30,7 +31,7 @@ function setup_file() {
     --volume "${REPOSITORY_ROOT}/test/config/ldap/openldap/schemas/:/schemas/:ro" \
     --hostname "${FQDN_LDAP}" \
     --network "${DMS_TEST_NETWORK}" \
-    bitnami/openldap:latest
+    bitnamilegacy/openldap:latest
 
   _run_until_success_or_timeout 20 sh -c "docker logs ${CONTAINER2_NAME} 2>&1 | grep 'LDAP setup finished'"
 


### PR DESCRIPTION
# Description

This will allow our test suite to pass, but only for as long as the `bitnamilegacy` image repo remains available publicly. An alternative image (_and potentially larger refactor to support it_) will need to be found/configured at some point or we'll run into the same problem eventually 😓 

Fixes #4582

---

For context, the `bitnami/openldap` image was originally introduced in Aug 2023 here: https://github.com/docker-mailserver/docker-mailserver/pull/3494
