### PR TITLE
fix: Prevent logs leaking into config files (`FETCHMAIL_PARALLEL=1`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file. The format 
   - Third-party sourced CLI tools updated ([#4557](https://github.com/docker-mailserver/docker-mailserver/pull/4557)):
     - `jaq` from `2.1.0` to [`2.3.0`](https://github.com/01mf02/jaq/releases/tag/v2.3.0)
     - `step` CLI from `0.28.2` to [`0.28.7`](https://github.com/smallstep/cli/releases/tag/v0.28.7))
-  - all logs prints to STDERR (formerly only warning/error) 
+  - DMS logs now all output to STDERR (formerly only warning/error logs) (#[4586](https://github.com/docker-mailserver/docker-mailserver/pull/4586))
 - **Dovecot**
   - Updated the FTS plugin Xapian from `1.9` to [`1.9.1`](https://github.com/grosjo/fts-xapian/releases/tag/1.9.1) which adds Dovecot 2.4 compatibility ([#4557](https://github.com/docker-mailserver/docker-mailserver/pull/4557))
 - **Postfix**

--- a/target/scripts/helpers/log.sh
+++ b/target/scripts/helpers/log.sh
@@ -104,7 +104,9 @@ function _log() {
 
   MESSAGE="$(date --rfc-3339='seconds') ${!LOG_COLOR}${LOG_LEVEL_NAME}${RESET} $(basename "${0}"): ${2}"
 
-  echo -e "${MESSAGE}" >&2  # printing STDOUT would break things :/
+  # All logs should go through to STDERR,
+  # STDOUT is only appropriate for expected program output
+  echo -e "${MESSAGE}" >&2
 }
 
 # Get the value of the environment variable LOG_LEVEL if

--- a/target/scripts/startup/setup.d/fetchmail.sh
+++ b/target/scripts/startup/setup.d/fetchmail.sh
@@ -86,7 +86,7 @@ autorestart=true
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s.log
 user=fetchmail
-command=/usr/bin/fetchmail -f ${RC} -v --nodetach --daemon %(ENV_FETCHMAIL_POLL)s -i /var/lib/fetchmail/.fetchmail-${COUNTER}-UIDL-cache --pidfile /var/run/fetchmail/%(program_name)s.pid
+command=/usr/bin/fetchmail -f ${RC} -v --nodetach --daemon %(ENV_FETCHMAIL_POLL)s -i /var/lib/fetchmail/.fetchmail-UIDL-cache --pidfile /var/run/fetchmail/%(program_name)s.pid
 EOF
       chmod 700 "${RC}"
       chown fetchmail:root "${RC}"

--- a/test/tests/parallel/set1/fetchmail.bats
+++ b/test/tests/parallel/set1/fetchmail.bats
@@ -60,11 +60,11 @@ function teardown_file() {
   _should_not_have_in_config 'pop3.third-party.test. '   /etc/fetchmailrc.d/fetchmail-2.rc
 }
 
-@test "(ENV FETCHMAIL_PARALLEL=1) should detect info line in fetchmail-x.rc" {
+@test "(ENV FETCHMAIL_PARALLEL=1) should not have logs emitted into fetchmail-x.rc" {
   export CONTAINER_NAME=${CONTAINER2_NAME}
 
   _should_not_have_in_config      'INFO'                      /etc/fetchmailrc.d/fetchmail-1.rc
-  _should_note_have_in_config     'INFO'                      /etc/fetchmailrc.d/fetchmail-2.rc
+  _should_not_have_in_config      'INFO'                      /etc/fetchmailrc.d/fetchmail-2.rc
 }
 
 function _should_have_in_config() {


### PR DESCRIPTION
# Description

fixes fetchmail in parallel mode, when logging is added as first line

```
root@mail:/etc/fetchmailrc.d# head fetchmail-1.rc 
2025-10-05 15:16:55+02:00 INFO  start-mailserver.sh: File '/etc/fetchmailrc' was missing a final newline - this has been fixed
set daemon 300
set syslog
poll posteo.de with proto IMAP
...
```
results in 

```
mailserver_1  | 2025-10-05 15:16:55+02:00 INFO  start-mailserver.sh: Starting daemons
mailserver_1  | 2025-10-05 15:16:56,859 WARN exited: fetchmail-1 (exit status 5; not expected)
mailserver_1  | 2025-10-05 15:16:57,066 WARN exited: fetchmail-2 (exit status 5; not expected)
mailserver_1  | 2025-10-05 15:16:57+02:00 INFO  start-mailserver.sh: mail.example.com is up and running
```

# explanation:

this reads from STDOUT and adds the log as well to the rc file 

`target/scripts/startup/setup.d/fetchmail.sh` (line >54)
```bash
   while read -r LINE; do
        if [[ ${LINE} =~ poll ]]; then
         ...
          # Just the server settings that need to be added to the specific rc.d file
          echo "${LINE}" >>"${FETCHMAILRCD}/fetchmail-${COUNTER}.rc"
        fi
      done < <(_get_valid_lines_from_file "${FETCHMAILRC}")
```

`target/scripts/helpers/utils.sh`
```bash
# Returns input after filtering out lines that are:
# empty, white-space, comments (`#` as the first non-whitespace character)
function _get_valid_lines_from_file() {
  _convert_crlf_to_lf_if_necessary "${1}"
  _append_final_newline_if_missing "${1}"

  grep --extended-regexp --invert-match "^\s*$|^\s*#" "${1}" || true
}
```

below

```bash
# This is to sanitize configs from users that unknowingly removed the end-of-file LF:
function _append_final_newline_if_missing() {
   ....
      _log 'info' "File '${1}' was missing a final newline - this has been fixed"
  ....

}
```

because of

`target/scripts/helpers/logs.sh`
```bash
function _log() {
  ...
  if [[ ${1} =~ ^(warn|error)$ ]]; then
    echo -e "${MESSAGE}" >&2
  else
    echo -e "${MESSAGE}"  # <----- 
  fi
}
```


## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
