### PR TITLE
docs: mention that SPF should be on both EHLO and sender domains

### DIFF
--- a/docs/content/config/best-practices/dkim_dmarc_spf.md
+++ b/docs/content/config/best-practices/dkim_dmarc_spf.md
@@ -321,6 +321,8 @@ The DMARC status may not be displayed instantly due to delays in DNS (caches). D
 
 ### Adding an SPF Record
 
+It is a best practice to have an SPF record for both your EHLO domain and your sender email address domain.
+
 To add a SPF record in your DNS, insert the following line in your DNS zone:
 
 ```txt


### PR DESCRIPTION
# Description

Small documentation update: as far as best practices go, it is currently not mentioned on which domains to put an SPF record.

## Type of change

- [x] Improvement (non-breaking change that does improve existing functionality)
- [x] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
