### PR TITLE
ci: Require bug reports provide disclosure for AI usage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,6 +15,7 @@ body:
       options:
         - label: I tried searching for an existing issue and followed the [debugging docs](https://docker-mailserver.github.io/docker-mailserver/latest/config/debugging/) advice, but still need assistance.
           required: true
+        - label: I will disclose any AI assistance I have used with the information I provide in my report, so that I do not waste the time of humans trying to help me.
   - type: textarea
     id: what-happened
     attributes:


### PR DESCRIPTION
# Description

User reports are increasingly wasting the time of volunteers to assist them when their configurations have been guided by AI tooling such as LLMs (ChatGPT, Gemini, etc) that instruct the user to deploy configurations in an unsupported/undocumented manner, along with environment variables that aren't part of our project.

Often these reports are due to user error as a result, where when the convenience of AI tooling fails them they delegate troubleshooting to real people, but the lack of disclosure (_especially when a report is vague in details to reproduce_) burdens those that would assist.

Since disclosure often comes after querying questionable configuration or reproduction steps, this change has the intention that users will admit this up front where it was used.

**Recent examples:**
- https://github.com/docker-mailserver/docker-mailserver/issues/4600#issuecomment-3524685732
- https://github.com/docker-mailserver/docker-mailserver/issues/4601#issuecomment-3508232708
- [DMS question at our GH Discussions](https://github.com/orgs/docker-mailserver/discussions/4615#discussioncomment-15154098) (_disclosure was provided, cited for bogus config by AI_)
- https://github.com/EricLBuehler/mistral.rs/pull/1458#discussion_r2139255880 (_CodeRabbit AI reviewer thinking it knows better_)
- https://github.com/lucaslorentz/caddy-docker-proxy/issues/759#issuecomment-3519934220
- https://lobste.rs/s/khca1j/curl_now_requires_disclosing_whether_ai