### PR TITLE
docs: getmail - Update getmail xoauth example links

### DIFF
--- a/docs/content/config/advanced/mail-getmail.md
+++ b/docs/content/config/advanced/mail-getmail.md
@@ -106,8 +106,8 @@ It is possible to utilize the `getmail-gmail-xoauth-tokens` helper to provide au
 
 [getmail-website]: https://www.getmail6.org
 [getmail-docs]: https://getmail6.org/configuration.html
-[getmail-docs-xoauth-12]: https://github.com/getmail6/getmail6/blob/master/docs/getmailrc-examples#L286
-[getmail-docs-xoauth-13]: https://github.com/getmail6/getmail6/blob/master/docs/getmailrc-examples#L351
+[getmail-docs-xoauth-12]: https://github.com/getmail6/getmail6/blob/v6.19.10/docs/getmailrc-examples#L286
+[getmail-docs-xoauth-13]: https://github.com/getmail6/getmail6/blob/v6.19.10/docs/getmailrc-examples#L351
 
 ## Debugging
 


### PR DESCRIPTION
# Description

I noticed the links were outdated and was struggling with the setup until i found https://github.com/getmail6/getmail6/issues/203 and noticed that i was on an outdated documentation page.
