### PR TITLE
fix: remove `expand_keys = true` from Rspamd configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - **Rspamd:**
   - Configuration changes now trigger a service reload instead of a restart ([#4632](https://github.com/docker-mailserver/docker-mailserver/pull/4632))
+  - `expand_keys = true` has been removed from the Redis configuration ([#4689](https://github.com/docker-mailserver/docker-mailserver/pull/4689))
 - **Internal:**
   - `ENABLE_QUOTAS=1` - When an alias has multiple addresses, the first local mailbox address found will be used for the Dovecot dummy account workaround ([#4581](https://github.com/docker-mailserver/docker-mailserver/pull/4581))
   - Change Detection service - Added support for responding to updated DMS config (_Rspamd and TLS certificates_) to `ACCOUNT_PROVISIONER=LDAP` ([#4627](https://github.com/docker-mailserver/docker-mailserver/pull/4627))

--- a/docs/content/config/environment.md
+++ b/docs/content/config/environment.md
@@ -428,7 +428,6 @@ The purpose of this setting is to opt-out of starting an internal Redis instance
 
     ```
     servers = "redis.example.test:6379";
-    expand_keys = true;
     ```
 
 [rspamd-redis-config]: https://rspamd.com/doc/configuration/redis.html

--- a/target/scripts/startup/setup.d/security/rspamd.sh
+++ b/target/scripts/startup/setup.d/security/rspamd.sh
@@ -125,7 +125,6 @@ function __rspamd__setup_redis() {
 # documentation: https://rspamd.com/doc/configuration/redis.html
 
 servers = "127.0.0.1:6379";
-expand_keys = true;
 
 EOF
 

--- a/test/tests/parallel/set1/spam_virus/rspamd_full.bats
+++ b/test/tests/parallel/set1/spam_virus/rspamd_full.bats
@@ -92,7 +92,6 @@ function teardown_file() { _default_teardown ; }
 @test 'Rspamd Redis configuration is correct' {
   _run_in_container rspamadm configdump redis
   assert_success
-  assert_line 'expand_keys = true;'
   assert_line 'servers = "127.0.0.1:6379";'
 
   _run_in_container rspamadm configdump history_redis


### PR DESCRIPTION
# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->
I opted to remove the setting because we do not seem to be using it.

<!-- Link the issue which will be fixed (if any) here: -->
Fixes #4668

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] **I have added information about changes made in this PR to `CHANGELOG.md`**
