### PR TITLE
chore: update tools we fetch from GitHub

### DIFF
--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -77,7 +77,8 @@ function _install_utils() {
   apt-get "${QUIET}" install --no-install-recommends perl-doc
   local SWAKS_VERSION='20240103.0'
   local SWAKS_RELEASE="swaks-${SWAKS_VERSION}"
-  curl -sSfL "https://github.com/jetmore/swaks/releases/download/v${SWAKS_VERSION}/${SWAKS_RELEASE}.tar.gz" \
+  curl -sSfL \
+    "https://github.com/jetmore/swaks/releases/download/v${SWAKS_VERSION}/${SWAKS_RELEASE}.tar.gz" \
     | tar -xz --directory /usr/local/bin --no-same-owner --strip-components=1 "${SWAKS_RELEASE}/swaks"
 }
 

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -60,8 +60,9 @@ function _install_utils() {
   _log 'debug' 'Installing utils sourced from Github'
 
   _log 'trace' 'Installing jaq'
-  local JAQ_TAG='v2.3.0'
-  curl -sSfL "https://github.com/01mf02/jaq/releases/download/${JAQ_TAG}/jaq-$(uname -m)-unknown-linux-gnu" -o /usr/local/bin/jaq
+  local JAQ_VERSION='v3.0.0'
+  curl -sSfL -o /usr/local/bin/jaq \
+    "https://github.com/01mf02/jaq/releases/download/${JAQ_VERSION}/jaq-${ARCH_A}-unknown-linux-gnu"
   chmod +x /usr/local/bin/jaq
 
   _log 'trace' 'Installing step'

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -66,9 +66,11 @@ function _install_utils() {
   chmod +x /usr/local/bin/jaq
 
   _log 'trace' 'Installing step'
-  local STEP_RELEASE='0.28.7'
-  curl -sSfL "https://github.com/smallstep/cli/releases/download/v${STEP_RELEASE}/step_linux_${STEP_RELEASE}_${ARCH_B}.tar.gz" \
-    | tar -xz --directory /usr/local/bin --no-same-owner --strip-components=2 "step_${STEP_RELEASE}/bin/step"
+  local STEP_CLI_VERSION='0.30.2'
+  curl -sSfL -o /tmp/step-cli.deb \
+    "https://github.com/smallstep/cli/releases/download/v${STEP_CLI_VERSION}/step-cli_${ARCH_B}.deb"
+  dpkg -i /tmp/step-cli.deb
+  rm /tmp/step-cli.deb
 
   _log 'trace' 'Installing swaks'
   # `perl-doc` is required for `swaks --help` to work:


### PR DESCRIPTION
# Description

<!--
  Include a summary of the change.
  Please also include relevant motivation and context.
-->
I updated `jaq` and `step-cli`. `step-cli` is now installed by its `.deb` package instead of using the tarball. I think this is a bit cleaner for Debian.

## Type of change

<!-- Delete options that are not relevant. -->

- [x] Improvement (non-breaking change that does improve existing functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [x] If necessary, I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes